### PR TITLE
MP3 FFMPEG 

### DIFF
--- a/CMake/SetupFfmpeg.cmake
+++ b/CMake/SetupFfmpeg.cmake
@@ -1,4 +1,4 @@
-set(SM_FFMPEG_VERSION "2.1.3")
+set(SM_FFMPEG_VERSION "3.3.3")
 set(SM_FFMPEG_SRC_LIST "${SM_EXTERN_DIR}" "/ffmpeg-linux-" "${SM_FFMPEG_VERSION}")
 sm_join("${SM_FFMPEG_SRC_LIST}" "" SM_FFMPEG_SRC_DIR)
 set(SM_FFMPEG_CONFIGURE_EXE "${SM_FFMPEG_SRC_DIR}/configure")
@@ -12,13 +12,8 @@ if (MINGW)
 endif()
 list(APPEND FFMPEG_CONFIGURE
   "${SM_FFMPEG_CONFIGURE_EXE}"
-  "--disable-programs"
-  "--disable-doc"
-  "--disable-avdevice"
-  "--disable-swresample"
-  "--disable-postproc"
-  "--disable-avfilter"
-  "--disable-shared"
+  "--disable-muxers"
+  "--disable-encoders"
   "--enable-static"
 )
 


### PR DESCRIPTION
Remov the formatprobe(It was crashing randomly. Seems to work fine without it. It's commented)
Change the FFMPEG version of the submodule(Built on linux)
Change the remaining deprecated FFMPEG calls to supported ones(Specifically stream[i]->codec to get the codec context is now obtained from the codecparameters(stream[i]->codecpar) and allocated using the codec, which is loaded before the context(It used to need the context to load) also using codecparameters and decode_audio4 replaced with 2 functions)
Make the Seek and Read functions used by the format context defined by us that make the api use ragefile use a hiddenptr instead of a pointer to the ragefile(Since the RageReader stores a hiddenptr and not a pointer this makes more sense)