### PR TITLE
Make portable.ini unnecessary

### DIFF
--- a/Manual/index.html
+++ b/Manual/index.html
@@ -80,8 +80,7 @@ Just in case you're reading this without having installed it yourself, however,
 here are the installation instructions for various operating systems.</p>
 
 <h4>Windows</h4>
-<p>The Windows version is available as an .exe installer. You can convert the game
-to Portable mode by placing a blank Portable.ini inside of the StepMania install directory.</p>
+<p>The Windows version is available as an .exe installer.</p>
 
 <h4>Mac OS X</h4>
 <p>The Mac version is distributed as a .dmg file; Mount it, make a StepMania folder

--- a/src/RageFileManager.cpp
+++ b/src/RageFileManager.cpp
@@ -331,11 +331,6 @@ void RageFileManager::MountInitialFilesystems()
 	HOOKS->MountInitialFilesystems( RageFileManagerUtil::sDirOfExecutable );
 }
 
-void RageFileManager::MountUserFilesystems()
-{
-	HOOKS->MountUserFilesystems( RageFileManagerUtil::sDirOfExecutable );
-}
-
 RageFileManager::~RageFileManager()
 {
 	// Unregister with Lua.

--- a/src/RageFileManager.h
+++ b/src/RageFileManager.h
@@ -21,7 +21,6 @@ public:
 	RageFileManager( const RString &argv0 );
 	~RageFileManager();
 	void MountInitialFilesystems();
-	void MountUserFilesystems();
 
 	void GetDirListing( const RString &sPath, vector<RString> &AddTo, bool bOnlyDirs, bool bReturnPathToo );
 	void GetDirListingWithMultipleExtensions(const RString &sPath,

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -996,9 +996,9 @@ int sm_main(int argc, char* argv[])
 	FILEMAN = new RageFileManager( argv[0] );
 	FILEMAN->MountInitialFilesystems();
 
-	bool bPortable = DoesFileExist("Portable.ini");
-	if( !bPortable )
-		FILEMAN->MountUserFilesystems();
+	//bool bPortable = DoesFileExist("Portable.ini");
+	//if( !bPortable )
+	//	FILEMAN->MountUserFilesystems();
 
 	// Set this up next. Do this early, since it's needed for RageException::Throw.
 	LOG		= new RageLog;

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -996,10 +996,6 @@ int sm_main(int argc, char* argv[])
 	FILEMAN = new RageFileManager( argv[0] );
 	FILEMAN->MountInitialFilesystems();
 
-	//bool bPortable = DoesFileExist("Portable.ini");
-	//if( !bPortable )
-	//	FILEMAN->MountUserFilesystems();
-
 	// Set this up next. Do this early, since it's needed for RageException::Throw.
 	LOG		= new RageLog;
 

--- a/src/arch/ArchHooks/ArchHooks.h
+++ b/src/arch/ArchHooks/ArchHooks.h
@@ -91,11 +91,6 @@ public:
 	 */
 	static void MountInitialFilesystems( const RString &sDirOfExecutable );
 
-	/* 
-	 * Add file search paths for user-writable directories. 
-	 */
-	static void MountUserFilesystems( const RString &sDirOfExecutable );
-
 	/*
 	 * Platform-specific code calls this to indicate focus changes.
 	 */

--- a/src/arch/ArchHooks/ArchHooks_MacOSX.mm
+++ b/src/arch/ArchHooks/ArchHooks_MacOSX.mm
@@ -326,46 +326,6 @@ void ArchHooks::MountInitialFilesystems( const RString &sDirOfExecutable )
 	}
 }
 
-void ArchHooks::MountUserFilesystems( const RString &sDirOfExecutable )
-{
-	char dir[PATH_MAX];
-
-	// /Save -> ~/Library/Preferences/PRODUCT_ID
-	PathForFolderType( dir, kPreferencesFolderType );
-	FILEMAN->Mount( "dir", ssprintf("%s/" PRODUCT_ID, dir), "/Save" );
-
-	// Other stuff -> ~/Library/Application Support/PRODUCT_ID/*
-	PathForFolderType( dir, kApplicationSupportFolderType );
-	FILEMAN->Mount( "dir", ssprintf("%s/" PRODUCT_ID "/Announcers", dir), "/Announcers" );
-	FILEMAN->Mount( "dir", ssprintf("%s/" PRODUCT_ID "/BGAnimations", dir), "/BGAnimations" );
-	FILEMAN->Mount( "dir", ssprintf("%s/" PRODUCT_ID "/BackgroundEffects", dir), "/BackgroundEffects" );
-	FILEMAN->Mount( "dir", ssprintf("%s/" PRODUCT_ID "/BackgroundTransitions", dir), "/BackgroundTransitions" );
-	FILEMAN->Mount( "dir", ssprintf("%s/" PRODUCT_ID "/CDTitles", dir), "/CDTitles" );
-	FILEMAN->Mount( "dir", ssprintf("%s/" PRODUCT_ID "/Characters", dir), "/Characters" );
-	FILEMAN->Mount( "dir", ssprintf("%s/" PRODUCT_ID "/Courses", dir), "/Courses" );
-	FILEMAN->Mount( "dir", ssprintf("%s/" PRODUCT_ID "/NoteSkins", dir), "/NoteSkins" );
-	FILEMAN->Mount( "dir", ssprintf("%s/" PRODUCT_ID "/Packages", dir), "/" + SpecialFiles::USER_PACKAGES_DIR );
-	FILEMAN->Mount( "dir", ssprintf("%s/" PRODUCT_ID "/Songs", dir), "/Songs" );
-	FILEMAN->Mount( "dir", ssprintf("%s/" PRODUCT_ID "/RandomMovies", dir), "/RandomMovies" );
-	FILEMAN->Mount( "dir", ssprintf("%s/" PRODUCT_ID "/Themes", dir), "/Themes" );
-
-	// /Screenshots -> ~/Pictures/PRODUCT_ID Screenshots
-	PathForFolderType( dir, kPictureDocumentsFolderType );
-	FILEMAN->Mount( "dir", ssprintf("%s/" PRODUCT_ID " Screenshots", dir), "/Screenshots" );
-
-	// /Cache -> ~/Library/Caches/PRODUCT_ID
-	PathForFolderType( dir, kCachedDataFolderType );
-	FILEMAN->Mount( "dir", ssprintf("%s/" PRODUCT_ID, dir), "/Cache" );
-
-	// /Logs -> ~/Library/Logs/PRODUCT_ID
-	PathForFolderType( dir, kDomainLibraryFolderType );
-	FILEMAN->Mount( "dir", ssprintf("%s/Logs/" PRODUCT_ID, dir), "/Logs" );
-
-	// /Desktop -> /Users/<user>/Desktop/PRODUCT_ID
-	// PathForFolderType( dir, kDesktopFolderType );
-	// FILEMAN->Mount( "dir", ssprintf("%s/" PRODUCT_ID, dir), "/Desktop" );
-}
-
 static inline int GetIntValue( CFTypeRef r )
 {
 	int ret;

--- a/src/arch/ArchHooks/ArchHooks_Unix.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Unix.cpp
@@ -394,31 +394,6 @@ void ArchHooks::MountInitialFilesystems( const RString &sDirOfExecutable )
 	FILEMAN->Mount( "dir", Root, "/" );
 }
 
-void ArchHooks::MountUserFilesystems( const RString &sDirOfExecutable )
-{
-	/* Path to write general mutable user data when not Portable
-	 * Lowercase the PRODUCT_ID; dotfiles and directories are almost always lowercase.
-	 */
-	const char *szHome = getenv( "HOME" );
-	RString sUserDataPath = ssprintf( "%s/.%s", szHome? szHome:".", "stepmania-5.0" ); //call an ambulance!
-	FILEMAN->Mount( "dir", sUserDataPath + "/Announcers", "/Announcers" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/BGAnimations", "/BGAnimations" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/BackgroundEffects", "/BackgroundEffects" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/BackgroundTransitions", "/BackgroundTransitions" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/Cache", "/Cache" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/CDTitles", "/CDTitles" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/Characters", "/Characters" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/Courses", "/Courses" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/Logs", "/Logs" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/NoteSkins", "/NoteSkins" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/Packages", "/" + SpecialFiles::USER_PACKAGES_DIR );
-	FILEMAN->Mount( "dir", sUserDataPath + "/Save", "/Save" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/Screenshots", "/Screenshots" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/Songs", "/Songs" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/RandomMovies", "/RandomMovies" );
-	FILEMAN->Mount( "dir", sUserDataPath + "/Themes", "/Themes" );
-}
-
 /*
  * (c) 2003-2004 Glenn Maynard
  * All rights reserved.

--- a/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
@@ -59,38 +59,6 @@ void ArchHooks::MountInitialFilesystems( const RString &sDirOfExecutable )
 	FILEMAN->Mount( "dir", sDir, "/" );
 }
 
-void ArchHooks::MountUserFilesystems( const RString &sDirOfExecutable )
-{
-	/*
-	 * Look, I know what you're thinking: "Hey, let's put all this stuff into
-	 * their respective 'proper' places on the filesystem!" Stop. Now.
-	 * This was done before and it was the most ungodly confusing thing to ever
-	 * happen. Just don't do it, seriously. Keep them in one place.
-	 * - Colby
-	 */
-	RString sAppDataDir = SpecialDirs::GetAppDataDir() + PRODUCT_ID;
-	//RString sCommonAppDataDir = SpecialDirs::GetCommonAppDataDir() + PRODUCT_ID;
-	//RString sLocalAppDataDir = SpecialDirs::GetLocalAppDataDir() + PRODUCT_ID;
-	//RString sPicturesDir = SpecialDirs::GetPicturesDir() + PRODUCT_ID;
-
-	FILEMAN->Mount( "dir", sAppDataDir + "/Announcers", "/Announcers" );
-	FILEMAN->Mount( "dir", sAppDataDir + "/BGAnimations", "/BGAnimations" );
-	FILEMAN->Mount( "dir", sAppDataDir + "/BackgroundEffects", "/BackgroundEffects" );
-	FILEMAN->Mount( "dir", sAppDataDir + "/BackgroundTransitions", "/BackgroundTransitions" );
-	FILEMAN->Mount( "dir", sAppDataDir + "/Cache", "/Cache" );
-	FILEMAN->Mount( "dir", sAppDataDir + "/CDTitles", "/CDTitles" );
-	FILEMAN->Mount( "dir", sAppDataDir + "/Characters", "/Characters" );
-	FILEMAN->Mount( "dir", sAppDataDir + "/Courses", "/Courses" );
-	FILEMAN->Mount( "dir", sAppDataDir + "/Logs", "/Logs" );
-	FILEMAN->Mount( "dir", sAppDataDir + "/NoteSkins", "/NoteSkins" );
-	FILEMAN->Mount( "dir", sAppDataDir + "/Packages", "/" + SpecialFiles::USER_PACKAGES_DIR );
-	FILEMAN->Mount( "dir", sAppDataDir + "/Save", "/Save" );
-	FILEMAN->Mount( "dir", sAppDataDir + "/Screenshots", "/Screenshots" );
-	FILEMAN->Mount( "dir", sAppDataDir + "/Songs", "/Songs" );
-	FILEMAN->Mount( "dir", sAppDataDir + "/RandomMovies", "/RandomMovies" );
-	FILEMAN->Mount( "dir", sAppDataDir + "/Themes", "/Themes" );
-}
-
 static RString LangIdToString( LANGID l )
 {
 	switch( PRIMARYLANGID(l) )

--- a/src/archutils/Win32/CrashHandlerChild.cpp
+++ b/src/archutils/Win32/CrashHandlerChild.cpp
@@ -732,16 +732,8 @@ BOOL CrashDialog::HandleMessage( UINT msg, WPARAM wParam, LPARAM lParam )
 			return TRUE;
 		case IDC_VIEW_LOG:
 			{
-				RString sLogPath;
-				FILE *pFile = fopen( SpliceProgramPath("../Portable.ini"), "r" );
-				if(pFile != NULL)
-				{
-					sLogPath = SpliceProgramPath("../Logs/log.txt");
-					fclose( pFile );
-				}
-				else
-					sLogPath = SpecialDirs::GetAppDataDir() + PRODUCT_ID +"/Logs/log.txt";
-
+				RString sLogPath = SpliceProgramPath("../Logs/log.txt");
+				
 				ShellExecute( NULL, "open", sLogPath, "", "", SW_SHOWNORMAL );
 			}
 			break;

--- a/stepmania.nsi
+++ b/stepmania.nsi
@@ -251,7 +251,6 @@ Section "Main Section" SecMain
 !endif
 
 !ifdef INSTALL_NON_PCK_FILES
-	File "portable.ini"
 	
 	CreateDirectory "$INSTDIR\Announcers"
 	SetOutPath "$INSTDIR\Announcers"
@@ -765,7 +764,6 @@ Section "Uninstall"
 !endif
 
 !ifdef INSTALL_NON_PCK_FILES
-	Delete "$INSTDIR\portable.ini"
 	
 	Delete "$INSTDIR\Announcers\instructions.txt"
 	RMDir "$INSTDIR\Announcers"


### PR DESCRIPTION
Functions that make folders created by the Etterna program such as Cache and Save be in local user directories have been removed as well.