### PR TITLE
Add custom timing windows eval screen rescoring

### DIFF
--- a/Themes/Til Death/BGAnimations/ScreenEvaluation decorations/default.lua
+++ b/Themes/Til Death/BGAnimations/ScreenEvaluation decorations/default.lua
@@ -1,6 +1,9 @@
 local t = Def.ActorFrame{}
 
+local enabledCustomWindows = playerConfig:get_data(pn_to_profile_slot(PLAYER_1)).CustomEvaluationWindowTimings
 PROFILEMAN:SaveProfile(PLAYER_1)
+
+local customWindows = timingWindowConfig:get_data().customWindows
 
 local scoreType = themeConfig:get_data().global.DefaultScoreType
 
@@ -95,9 +98,12 @@ function scoreBoard(pn,position)
 		end
 	}
 	
-	local judge = GetTimingDifficulty()
+	local customWindow
+	local judge = enabledCustomWindows and 0 or GetTimingDifficulty()
 	local pss = STATSMAN:GetCurStageStats():GetPlayerStageStats(pn)
 	local score = SCOREMAN:GetMostRecentScore()
+	local dvt = pss:GetOffsetVector()
+	local totalTaps = pss:GetTotalTaps()
 	
 	t[#t+1] = Def.Quad{
 		InitCommand=function(self)
@@ -169,7 +175,25 @@ function scoreBoard(pn,position)
 			self:settextf("%05.2f%% (%s)",notShit.floor(pss:GetWifeScore()*10000)/100, "Wife")
 		end,
 		CodeMessageCommand=function(self,params)
-			if params.Name == "PrevJudge" and judge > 1 then
+			if enabledCustomWindows then
+				if params.Name == "PrevJudge" then
+					judge = judge < 2 and #customWindows or judge - 1
+					customWindow = timingWindowConfig:get_data()[customWindows[judge]]
+					local totalHolds = pss:GetRadarPossible():GetValue("RadarCategory_Holds") + pss:GetRadarPossible():GetValue("RadarCategory_Rolls")
+					local holdsHit = pss:GetRadarActual():GetValue("RadarCategory_Holds") + pss:GetRadarActual():GetValue("RadarCategory_Rolls")
+					local minesHit = pss:GetRadarPossible():GetValue("RadarCategory_Mines") -  pss:GetRadarActual():GetValue("RadarCategory_Mines")
+					local perc = getRescoredCustomPercentage(dvt, customWindow, totalHolds, holdsHit, minesHit, totalTaps)
+					self:settextf("%05.2f%% (%s)", perc, customWindow.name)
+				elseif params.Name == "NextJudge" then
+					judge = judge == #customWindows and 1 or judge + 1
+					customWindow = timingWindowConfig:get_data()[customWindows[judge]]
+					local totalHolds = pss:GetRadarPossible():GetValue("RadarCategory_Holds") + pss:GetRadarPossible():GetValue("RadarCategory_Rolls")
+					local holdsHit = pss:GetRadarActual():GetValue("RadarCategory_Holds") + pss:GetRadarActual():GetValue("RadarCategory_Rolls")
+					local minesHit = pss:GetRadarPossible():GetValue("RadarCategory_Mines") -  pss:GetRadarActual():GetValue("RadarCategory_Mines")
+					local perc = getRescoredCustomPercentage(dvt, customWindow, totalHolds, holdsHit, minesHit, totalTaps)
+					self:settextf("%05.2f%% (%s)", perc, customWindow.name)
+				end
+			elseif params.Name == "PrevJudge" and judge > 1 then
 				judge = judge - 1
 				self:settextf("%05.2f%% (%s)", notShit.floor(score:RescoreToWifeJudge(judge)*10000)/100, "Wife J"..judge)
 			elseif params.Name == "NextJudge" and judge < 9 then
@@ -177,9 +201,12 @@ function scoreBoard(pn,position)
 				if judge == 9 then
 					self:settextf("%05.2f%% (%s)", notShit.floor(score:RescoreToWifeJudge(judge)*10000)/100, "Wife Justice")
 				else
-					self:settextf("%05.2f%% (%s)", notShit.floor(score:RescoreToWifeJudge(judge)*10000)/100, "Wife J"..judge)	
+					self:settextf("%05.2f%% (%s)", notShit.floor(score:RescoreToWifeJudge(judge)*10000)/100, "Wife J"..judge)
 				end
-				
+			end
+			if params.Name == "ResetJudge" then
+				judge = enabledCustomWindows and 0 or GetTimingDifficulty()
+				self:playcommand("Set")
 			end
 		end,
 	};
@@ -211,8 +238,15 @@ function scoreBoard(pn,position)
 			end,
 			CodeMessageCommand=function(self,params)
 				if params.Name == "PrevJudge" or params.Name == "NextJudge" then
-					local rescoreJudges = score:RescoreJudges(judge)
-					self:zoomx(frameWidth*rescoreJudges[k]/pss:GetTotalTaps())
+					if enabledCustomWindows then
+						self:finishtweening():decelerate(2):zoomx(frameWidth*getRescoredCustomJudge(dvt, customWindow.judgeWindows, k)/totalTaps)
+					else
+						local rescoreJudges = getRescoredJudge(dvt, judge, k)
+						self:finishtweening():decelerate(2):zoomx(frameWidth*rescoreJudges/totalTaps)
+					end
+				end
+				if params.Name == "ResetJudge" then
+					self:finishtweening():decelerate(2):zoomx(frameWidth*pss:GetPercentageOfTaps(v))
 				end
 			end,
 		};
@@ -225,7 +259,15 @@ function scoreBoard(pn,position)
 			end,
 			SetCommand=function(self) 
 				self:settext(getJudgeStrings(v))
-			end
+			end,
+			CodeMessageCommand=function(self,params)
+				if enabledCustomWindows and (params.Name == "PrevJudge" or params.Name == "NextJudge") then
+					self:settext(getCustomJudgeString(customWindow.judgeNames, k))
+				end
+				if params.Name == "ResetJudge" then
+					self:playcommand("Set")
+				end
+			end,
 		};
 		t[#t+1] = LoadFont("Common Large")..{
 			InitCommand=function(self)
@@ -239,8 +281,14 @@ function scoreBoard(pn,position)
 			end,
 			CodeMessageCommand=function(self,params)
 				if params.Name == "PrevJudge" or params.Name == "NextJudge" then
-					local rescoreJudges = score:RescoreJudges(judge)
-					self:settext(rescoreJudges[k])
+					if enabledCustomWindows then
+						self:settext(getRescoredCustomJudge(dvt, customWindow.judgeWindows, k))
+					else
+						self:settext(getRescoredJudge(dvt, judge, k))
+					end
+				end
+				if params.Name == "ResetJudge" then
+					self:playcommand("Set")
 				end
 			end,
 		};
@@ -256,8 +304,16 @@ function scoreBoard(pn,position)
 			end,
 			CodeMessageCommand=function(self,params)
 				if params.Name == "PrevJudge" or params.Name == "NextJudge" then
-					local rescoreJudges = score:RescoreJudges(judge)
-					self:settextf("(%03.2f%%)",rescoreJudges[k]/pss:GetTotalTaps()*100)
+					local rescoredJudge
+					if enabledCustomWindows then
+						rescoredJudge = getRescoredCustomJudge(dvt, customWindow.judgeWindows, k)
+					else
+						rescoredJudge = getRescoredJudge(dvt, judge, k)
+					end
+					self:settextf("(%03.2f%%)", rescoredJudge/totalTaps * 100)
+				end
+				if params.Name == "ResetJudge" then
+					self:playcommand("Set")
 				end
 			end,
 		};

--- a/Themes/Til Death/BGAnimations/ScreenEvaluation decorations/default.lua
+++ b/Themes/Til Death/BGAnimations/ScreenEvaluation decorations/default.lua
@@ -175,33 +175,28 @@ function scoreBoard(pn,position)
 			self:settextf("%05.2f%% (%s)",notShit.floor(pss:GetWifeScore()*10000)/100, "Wife")
 		end,
 		CodeMessageCommand=function(self,params)
+			local totalHolds = pss:GetRadarPossible():GetValue("RadarCategory_Holds") + pss:GetRadarPossible():GetValue("RadarCategory_Rolls")
+			local holdsHit = pss:GetRadarActual():GetValue("RadarCategory_Holds") + pss:GetRadarActual():GetValue("RadarCategory_Rolls")
+			local minesHit = pss:GetRadarPossible():GetValue("RadarCategory_Mines") -  pss:GetRadarActual():GetValue("RadarCategory_Mines")
 			if enabledCustomWindows then
 				if params.Name == "PrevJudge" then
 					judge = judge < 2 and #customWindows or judge - 1
 					customWindow = timingWindowConfig:get_data()[customWindows[judge]]
-					local totalHolds = pss:GetRadarPossible():GetValue("RadarCategory_Holds") + pss:GetRadarPossible():GetValue("RadarCategory_Rolls")
-					local holdsHit = pss:GetRadarActual():GetValue("RadarCategory_Holds") + pss:GetRadarActual():GetValue("RadarCategory_Rolls")
-					local minesHit = pss:GetRadarPossible():GetValue("RadarCategory_Mines") -  pss:GetRadarActual():GetValue("RadarCategory_Mines")
-					local perc = getRescoredCustomPercentage(dvt, customWindow, totalHolds, holdsHit, minesHit, totalTaps)
-					self:settextf("%05.2f%% (%s)", perc, customWindow.name)
+					self:settextf("%05.2f%% (%s)", getRescoredCustomPercentage(dvt, customWindow, totalHolds, holdsHit, minesHit, totalTaps), customWindow.name)
 				elseif params.Name == "NextJudge" then
 					judge = judge == #customWindows and 1 or judge + 1
 					customWindow = timingWindowConfig:get_data()[customWindows[judge]]
-					local totalHolds = pss:GetRadarPossible():GetValue("RadarCategory_Holds") + pss:GetRadarPossible():GetValue("RadarCategory_Rolls")
-					local holdsHit = pss:GetRadarActual():GetValue("RadarCategory_Holds") + pss:GetRadarActual():GetValue("RadarCategory_Rolls")
-					local minesHit = pss:GetRadarPossible():GetValue("RadarCategory_Mines") -  pss:GetRadarActual():GetValue("RadarCategory_Mines")
-					local perc = getRescoredCustomPercentage(dvt, customWindow, totalHolds, holdsHit, minesHit, totalTaps)
-					self:settextf("%05.2f%% (%s)", perc, customWindow.name)
+					self:settextf("%05.2f%% (%s)", getRescoredCustomPercentage(dvt, customWindow, totalHolds, holdsHit, minesHit, totalTaps), customWindow.name)
 				end
 			elseif params.Name == "PrevJudge" and judge > 1 then
 				judge = judge - 1
-				self:settextf("%05.2f%% (%s)", notShit.floor(score:RescoreToWifeJudge(judge)*10000)/100, "Wife J"..judge)
+				self:settextf("%05.2f%% (%s)", getRescoredWifeJudge(dvt, judge, totalHolds - holdsHit, minesHit, totalTaps), "Wife J"..judge)
 			elseif params.Name == "NextJudge" and judge < 9 then
 				judge = judge + 1
 				if judge == 9 then
-					self:settextf("%05.2f%% (%s)", notShit.floor(score:RescoreToWifeJudge(judge)*10000)/100, "Wife Justice")
+					self:settextf("%05.2f%% (%s)", getRescoredWifeJudge(dvt, judge, (totalHolds - holdsHit), minesHit, totalTaps), "Wife Justice")
 				else
-					self:settextf("%05.2f%% (%s)", notShit.floor(score:RescoreToWifeJudge(judge)*10000)/100, "Wife J"..judge)
+					self:settextf("%05.2f%% (%s)", getRescoredWifeJudge(dvt, judge, (totalHolds - holdsHit), minesHit, totalTaps), "Wife J"..judge)
 				end
 			end
 			if params.Name == "ResetJudge" then

--- a/Themes/Til Death/Languages/en.ini
+++ b/Themes/Til Death/Languages/en.ini
@@ -98,6 +98,7 @@ AvgScoreType = Avg. Scoretype
 GhostScoreType=Ghost Scoretype
 GhostTarget=Ghost Target
 CustomizeGameplay= Customize Gameplay
+CustomEvalWindows= Custom Evaluation Windows
 
 PaceMaker=Pacemaker Graph
 LaneCover=Lane Cover
@@ -141,6 +142,7 @@ LaneCover=Enable lane cover which will cover a portion of the notefield. The hei
 CBHighlight=Highlights the lane where a combo breaking judgment has occured.
 NPSDisplay=Toggle whether to display a flying average NPS display. The time window can be set at Theme Options.
 CustomizeGameplay= While active, allows you to reposition and resize elements on the gameplay screen to your liking. Any changes will persist through version updates.
+CustomEvalWindows= When active, allows you to translate scores at eval screen to custom timing windows/weights.
 
 Avatars=Set Avatars. This is temporary.
 

--- a/Themes/Til Death/Scripts/01 color_config.lua
+++ b/Themes/Til Death/Scripts/01 color_config.lua
@@ -154,6 +154,23 @@ function offsetToJudgeColor(offset,scale)
 	end
 end
 
+function customOffsetToJudgeColor(offset, windows)
+	local offset = math.abs(offset)
+	if offset <= windows.marv then
+		return color(colorConfig:get_data().judgment["TapNoteScore_W1"])
+	elseif offset <= windows.perf then
+		return color(colorConfig:get_data().judgment["TapNoteScore_W2"])
+	elseif offset <= windows.great then
+		return color(colorConfig:get_data().judgment["TapNoteScore_W3"])
+	elseif offset <= windows.good then
+		return color(colorConfig:get_data().judgment["TapNoteScore_W4"])
+	elseif offset <= windows.boo then
+		return color(colorConfig:get_data().judgment["TapNoteScore_W5"])
+	else
+		return color(colorConfig:get_data().judgment["TapNoteScore_Miss"])
+	end
+end
+
 function byJudgment(judge)
 	return color(colorConfig:get_data().judgment[judge])
 end

--- a/Themes/Til Death/Scripts/01 player_config.lua
+++ b/Themes/Til Death/Scripts/01 player_config.lua
@@ -23,6 +23,7 @@ local defaultConfig = {
 	BackgroundType = 1,
 	ProgressBarPos = 1, --moved from theme options into here, 1 = top; 0 = bottom
 	CustomizeGameplay = false,
+	CustomEvaluationWindowTimings = false,
 	GameplayXYCoordinates = {
 		JudgeX = 0,
 		JudgeY = 40,

--- a/Themes/Til Death/Scripts/01 timing_windows_config.lua
+++ b/Themes/Til Death/Scripts/01 timing_windows_config.lua
@@ -1,0 +1,59 @@
+local defaultConfig = {
+	-- put here the added custom windows in the desired order(if you dont they wont rotate in the eval screen)
+	customWindows = { "dpJ4", "osuManiaOD10"},
+	dpJ4 = {
+		name = "DP Judge 4",
+		-- if you dont set judgeNames, defaults will be used, see next example for names
+		judgeWindows = {
+			marv = 22.5,
+			perf = 45.0,
+			great = 90.0,
+			good = 135.0,
+			boo = 180.0
+		},
+		judgeWeights = {
+			marv = 2,
+			perf = 2,
+			great = 1,
+			good = 0,
+			boo = -4,
+			miss = -8,
+			holdHit = 6,
+			holdMiss = -6,
+			mineHit = -8
+		},
+	},
+	-- this is a mere example, dont take it too seriously
+	osuManiaOD10 = {
+		name = "osu!mania OD10",
+		judgeNames = {
+			marv = "300g",
+			perf = "300",
+			great = "200",
+			good = "100",
+			boo = "50",
+			miss = "Miss"
+		},
+		judgeWindows = {
+			marv = 16.0,
+			perf = 34.0,
+			great = 67.0,
+			good = 97.0,
+			boo = 121.0
+		},
+		judgeWeights = {
+			marv = 3.2,
+			perf = 3,
+			great = 2,
+			good = 1,
+			boo = 0.5,
+			miss = 0,
+			holdHit = 0.5,
+			holdMiss = -3,
+			mineHit = 0
+		},
+	},
+}
+
+timingWindowConfig = create_setting("timingWindowConfig", "timingWindowConfig.lua", defaultConfig, -1)
+timingWindowConfig:load()

--- a/Themes/Til Death/Scripts/02 ThemePrefs.lua
+++ b/Themes/Til Death/Scripts/02 ThemePrefs.lua
@@ -313,6 +313,34 @@ function CustomizeGameplay()
 	return t
 end
 
+function CustomEvalWindows()
+	local t = {
+		Name = "CustomEvalWindows",
+		LayoutType = "ShowAllInRow",
+		SelectType = "SelectOne",
+		OneChoiceForAllPlayers = false,
+		ExportOnChange = true,
+		Choices = { THEME:GetString('OptionNames','Off'),'On'},
+		LoadSelections = function(self, list, pn)
+			local pref = playerConfig:get_data(pn_to_profile_slot(pn)).CustomEvaluationWindowTimings
+			if pref then
+				list[2] = true
+			else
+				list[1] = true
+			end
+		end,
+		SaveSelections = function(self, list, pn)
+			local value
+			value = list[2]
+			playerConfig:get_data(pn_to_profile_slot(pn)).CustomEvaluationWindowTimings = value
+			playerConfig:set_dirty(pn_to_profile_slot(pn))
+			playerConfig:save(pn_to_profile_slot(pn))
+		end,
+	}
+	setmetatable( t, t )
+	return t
+end
+
 function ErrorBar()
 	local t = {
 		Name = "ErrorBar",

--- a/Themes/Til Death/Scripts/Texts.lua
+++ b/Themes/Til Death/Scripts/Texts.lua
@@ -1,3 +1,6 @@
+local judges = { "marv", "perf", "great", "good", "boo", "miss" }
+local defaultJudges = {'TapNoteScore_W1','TapNoteScore_W2','TapNoteScore_W3','TapNoteScore_W4','TapNoteScore_W5','TapNoteScore_Miss'}
+
 local shortDiffName = {
 	Difficulty_Beginner	= 'BG',
 	Difficulty_Easy		= 'EZ',
@@ -99,10 +102,15 @@ function getJudgeStrings(judge)
 	end
 end;
 
-
 function getShortJudgeStrings(judge)
 	if judge ~= nil then
 		return shortJudgeString[judge] or judge
+	end
+end;
+
+function getCustomJudgeString(customNames, judge)
+	if judge ~= nil then
+		return customNames and customNames[judges[judge]] or getJudgeStrings(defaultJudges[judge])
 	end
 end;
 

--- a/Themes/Til Death/metrics.ini
+++ b/Themes/Til Death/metrics.ini
@@ -240,14 +240,15 @@ Class="ScreenWithMenuElements"
 Fallback="ScreenWithMenuElements"
 PrevScreen="ScreenSelectMusic"
 
-CodeNames="PlotCancel,PlotExit,PrevJudge,NextJudge,PlotThickens,PlotTwist,StarPlot64,SheriffOfPlottingham"
+CodeNames="PlotCancel,PlotExit,ResetJudge,PrevJudge,NextJudge,PlotThickens,PlotTwist,StarPlot64,SheriffOfPlottingham"
 CodePlotCancel="Start","Left"
 CodePlotExit="Back"
+CodeResetJudge="MenuUp"
 CodeNextJudge="EffectUp"
 CodePrevJudge="EffectDown"
 CodePlotThickens="MenuLeft"
 CodePlotTwist="MenuRight"
-CodeStarPlot64="MenuUp"
+#CodeStarPlot64="MenuUp"
 CodeSheriffOfPlottingham="MenuDown"
 
 [ScreenColorChange]
@@ -387,7 +388,7 @@ StepsTypeSetCommand=%function(self,param) \
 end; \
 
 [ScreenPlayerOptions]
-LineNames="1,Rate,8,4,CG,RS,14,5,7,10,13,JT,DP,TT,TG,TTM,JC,EB,PI,FBP,FB,MB,SF,LC,NPS,16,BG,Life,Judge,Background,Fail,Center,Score"
+LineNames="1,Rate,8,4,CG,RS,14,5,7,10,13,JT,DP,TT,TG,TTM,JC,EB,PI,FBP,FB,MB,SF,LC,NPS,16,BG,Life,Judge,CW,Background,Fail,Center,Score"
 LineCenter="conf,Center1Player"
 LineCG="lua,CustomizeGameplay()"
 LineRS="lua,ReceptorSize()"
@@ -411,6 +412,7 @@ LineFail="list,Fail"
 LineScore="list,SaveScores"
 LineLife="conf,LifeDifficulty"
 LineJudge="conf,TimingWindowScale"
+LineCW="lua,CustomEvalWindows()"
 LineBackground="conf,BGBrightness"
 
 NextScreen="ScreenGameplay"
@@ -461,7 +463,8 @@ Appearance,6="mod,blink;name,Blink"
 
 [ScreenEvaluation]
 # judge changer listener i guess
-CodeNames="PrevJudge,NextJudge"
+CodeNames="ResetJudge,PrevJudge,NextJudge"
+CodeResetJudge="MenuUp"
 CodeNextJudge="EffectUp"
 CodePrevJudge="EffectDown"
 


### PR DESCRIPTION
These should be added to the Scripts/01 timing_windows_config.lua file in order to work(there are a few examples there too). The previous judge rescorer at eval screen has also been moved to lua(so it's not disabled anymore) and a menu option for using the custom timing windows has been added into the player options menu.
Also added a command to reset the current displayed score to the original one, currently bound to MenuUp.