### PR TITLE
Added a global StringConvert function

### DIFF
--- a/src/global.cpp
+++ b/src/global.cpp
@@ -55,6 +55,18 @@ void NORETURN sm_crash( const char *reason )
 #endif
 }
 
+std::string StringConvert(RString String)
+{
+	std::string rString = String;
+	return rString;	
+}
+
+RString StringConvert(std::string String)
+{
+	RString rString = String;
+	return rString;
+}
+
 /*
  * (c) 2004 Glenn Maynard
  * All rights reserved.

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -55,16 +55,14 @@ void NORETURN sm_crash( const char *reason )
 #endif
 }
 
-std::string StringConvert(RString String)
+inline std::string StringConvert(RString String)
 {
-	std::string rString = String;
-	return rString;	
+	return std::string(String);	
 }
 
-RString StringConvert(std::string String)
+inline RString StringConvert(std::string String)
 {
-	RString rString = String;
-	return rString;
+	return RString(String);
 }
 
 /*

--- a/src/global.h
+++ b/src/global.h
@@ -147,6 +147,9 @@ template<int> struct CompileAssertDecl { };
 /** @brief Use RStrings throughout the program. */
 using RString = StdString::CStdStringA;
 
+std::string StringConvert(RString String);
+RString StringConvert(std::string String);
+
 #include "RageException.h"
 
 /* Define a few functions if necessary */


### PR DESCRIPTION
Seeing that RString is a mess and we want future commits to use std::string, some older code depends on RString, we fix that by using this convert.