### PR TITLE
Fixed noteskins for Solo gameplay

### DIFF
--- a/NoteSkins/dance/DivideByZero/NoteSkin.lua
+++ b/NoteSkins/dance/DivideByZero/NoteSkin.lua
@@ -21,6 +21,8 @@ USWN.ButtonRedir =
 	Down = "Down",
 	Left = "Down",
 	Right = "Down",
+	UpLeft = "Down",
+	UpRight = "Down",
 };
 
 -- Defined the parts to be rotated at which degree
@@ -30,6 +32,8 @@ USWN.Rotate =
 	Down = 0,
 	Left = 90,
 	Right = -90,
+	UpLeft = 135,
+	UpRight = 225,
 };
 
 

--- a/NoteSkins/dance/SubtractByZero/NoteSkin.lua
+++ b/NoteSkins/dance/SubtractByZero/NoteSkin.lua
@@ -21,6 +21,8 @@ USWN.ButtonRedir =
 	Down = "Down",
 	Left = "Down",
 	Right = "Down",
+	UpLeft = "Down",
+	UpRight = "Down",
 };
 
 -- Defined the parts to be rotated at which degree
@@ -30,6 +32,8 @@ USWN.Rotate =
 	Down = 0,
 	Left = 0,
 	Right = 0,
+	UpLeft = 0,
+	UpRight = 0,
 };
 
 


### PR DESCRIPTION
The noteskins are missing definitions for the UpLeft and UpRight notes. With this, the notes display properly in-game instead of showing crosses in the extra lanes.