### PR TITLE
Init MESSAGEMAN earlier

### DIFF
--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -987,6 +987,8 @@ int sm_main(int argc, char* argv[])
 
 	LUA		= new LuaManager;
 	HOOKS->RegisterWithLua();
+	
+	MESSAGEMAN	= new MessageManager;
 
 	// Initialize the file extension type lists so everything can ask ActorUtil
 	// what the type of a file is.
@@ -1164,7 +1166,6 @@ int sm_main(int argc, char* argv[])
 	SONGMAN->UpdatePopular();
 	SONGMAN->UpdatePreferredSort();
 	NSMAN 		= new NetworkSyncManager( NULL );
-	MESSAGEMAN	= new MessageManager;
 	STATSMAN	= new StatsManager;
 
 	FILTERMAN = new FilterManager;


### PR DESCRIPTION
It is undefined behaviour to call MESSAGEMAN->Broadcast before initialization (compilers are free to compile away the null check on MessageMan.cpp:209, and in fact g++ does, leading to a SIGSEGV on startup).