### PR TITLE
Fix net eval ssr (1 => "Overall")

### DIFF
--- a/Themes/Til Death/BGAnimations/ScreenNetEvaluation decorations.lua
+++ b/Themes/Til Death/BGAnimations/ScreenNetEvaluation decorations.lua
@@ -258,7 +258,7 @@ function scoreBoard(pn,position)
 			self:queuecommand("Set")
 		end,
 		SetCommand=function(self)
-			local meter = score:GetSkillsetSSR(1)
+			local meter = score:GetSkillsetSSR("Overall")
 			self:settextf("%5.2f", meter)
 			self:diffuse(ByMSD(meter))
 		end,


### PR DESCRIPTION
Net evaluation screen SSRs are broken (GetSkillsetSSR used to take a number and now takes a string so it doesnt work atm online)