### PR TITLE
Downloadies

### DIFF
--- a/src/DownloadManager.h
+++ b/src/DownloadManager.h
@@ -1,4 +1,4 @@
-
+#pragma once
 #ifndef SM_DOWNMANAGER
 
 #define SM_DOWNMANAGER
@@ -81,6 +81,7 @@ public:
 	DownloadManager();
 	~DownloadManager();
 	map<string, Download*> downloads;
+	map<string, Download*> finishedDownloads;
 	CURLM* mHandle{nullptr};
 	CURLMcode ret;
 	int running{0};


### PR DESCRIPTION
Dont download packs already loaded (Check by name) and fix a crash for null download calls from lua (Store finished downloads in a new map)

Also add an ifndef to downloadmanager.cpp that makes VS not give random errors sometimes