### PR TITLE
Dont show song info if steps change right before moving into a pack

### DIFF
--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/wifeTwirl.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/wifeTwirl.lua
@@ -69,7 +69,6 @@ t[#t+1] = Def.Actor{
 	CurrentStepsP1ChangedMessageCommand=function(self)	
 		song = GAMESTATE:GetCurrentSong()			
 		MESSAGEMAN:Broadcast("UpdateChart")
-		alreadybroadcasted = true
 	end,
 	CurrentSongChangedMessageCommand=function(self)
 		-- This will disable mirror when switching songs if OneShotMirror is enabled or if permamirror is flagged on the chart (it is enabled if so in screengameplayunderlay/default)


### PR DESCRIPTION
Fixes https://github.com/etternagame/etterna/issues/77
Havent tested very thoroughly (Only checked that exiting a pack doesnt show song info, changing steps on a song changes the info properly in the firt two tabs and same goes for changing song)