### PR TITLE
Rename Stepmania to Etterna in project name, exe files and installer

### DIFF
--- a/CMake/DefineOptions.cmake
+++ b/CMake/DefineOptions.cmake
@@ -47,7 +47,7 @@ else()
   # Turn this option on to enable using the Texture Font Generator.
   option(WITH_TEXTURE_GENERATOR "Build with the Texture Font Generator. Ensure the MFC library is installed." OFF)
   # Turn this option off to use dynamic linking instead of static linking.
-  option(WITH_STATIC_LINKING "Build StepMania with static linking." ON)
+  option(WITH_STATIC_LINKING "Build Etterna with static linking." ON)
 endif()
 
 if(WIN32)

--- a/StepmaniaCore.cmake
+++ b/StepmaniaCore.cmake
@@ -14,7 +14,7 @@ set(SM_DOC_DIR "${CMAKE_CURRENT_LIST_DIR}/Docs")
 set(SM_ROOT_DIR "${CMAKE_CURRENT_LIST_DIR}")
 
 # TODO: Reconsile the OS dependent naming scheme.
-set(SM_EXE_NAME "StepMania")
+set(SM_EXE_NAME "Etterna")
 
 # Some OS specific helpers.
 if (CMAKE_SYSTEM_NAME MATCHES "Linux")
@@ -456,12 +456,12 @@ elseif(LINUX)
   
   find_package(OpenGL REQUIRED)
   if (NOT ${OPENGL_FOUND})
-    message(FATAL_ERROR "OpenGL required to compile StepMania.")
+    message(FATAL_ERROR "OpenGL required to compile Etterna.")
   endif()
 
   find_package(GLEW REQUIRED)
   if (NOT ${GLEW_FOUND})
-    message(FATAL_ERROR "GLEW required to compile StepMania.")
+    message(FATAL_ERROR "GLEW required to compile Etterna.")
   endif()
 
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,19 +56,19 @@ if(NOT APPLE)
 endif()
 
 if(MSVC OR APPLE)
-  set(SM_NAME_RELEASE "StepMania")
-  set(SM_NAME_DEBUG "StepMania-debug")
-  set(SM_NAME_MINSIZEREL "StepMania-min-size")
-  set(SM_NAME_RELWITHDEBINFO "StepMania-release-symbols")
+  set(SM_NAME_RELEASE "Etterna")
+  set(SM_NAME_DEBUG "Etterna-debug")
+  set(SM_NAME_MINSIZEREL "Etterna-min-size")
+  set(SM_NAME_RELWITHDEBINFO "Etterna-release-symbols")
 else()
-  set(SM_NAME_RELEASE "stepmania")
-  set(SM_NAME_DEBUG "stepmania-debug")
-  set(SM_NAME_MINSIZEREL "stepmania-min-size")
-  set(SM_NAME_RELWITHDEBINFO "stepmania-release-symbols")
+  set(SM_NAME_RELEASE "etterna")
+  set(SM_NAME_DEBUG "etterna-debug")
+  set(SM_NAME_MINSIZEREL "etterna-min-size")
+  set(SM_NAME_RELWITHDEBINFO "etterna-release-symbols")
 endif()
 
 # Configure generated files here.
-configure_file("${SM_XCODE_DIR}/Info.plist.in.xml" "${SM_XCODE_DIR}/Info.StepMania.plist")
+configure_file("${SM_XCODE_DIR}/Info.plist.in.xml" "${SM_XCODE_DIR}/Info.Etterna.plist")
 configure_file("${SM_XCODE_DIR}/plistHelper.in.hpp" "${SM_XCODE_DIR}/plistHelper.hpp")
 
 # TODO: Make this actually be data and not an executable.
@@ -190,15 +190,15 @@ elseif(APPLE)
     RUNTIME_OUTPUT_DIRECTORY_DEBUG "${SM_ROOT_DIR}"
     RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL "${SM_ROOT_DIR}"
     RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${SM_ROOT_DIR}"
-    MACOSX_BUNDLE_INFO_PLIST "${SM_XCODE_DIR}/Info.StepMania.plist"
-    XCODE_ATTRIBUTE_INFOPLIST_FILE "${SM_XCODE_DIR}/Info.StepMania.plist"
+    MACOSX_BUNDLE_INFO_PLIST "${SM_XCODE_DIR}/Info.Etterna.plist"
+    XCODE_ATTRIBUTE_INFOPLIST_FILE "${SM_XCODE_DIR}/Info.Etterna.plist"
     XCODE_ATTRIBUTE_INFOPLIST_PREPROCESS "YES"
     XCODE_ATTRIBUTE_INFOPLIST_PREPROCESSOR_DEFINITIONS[variant=Release] "RELEASE"
     XCODE_ATTRIBUTE_INFOPLIST_PREPROCESSOR_DEFINITIONS[variant=Debug] "DEBUG"
     XCODE_ATTRIBUTE_INFOPLIST_PREPROCESSOR_DEFINITIONS[variant=MinSizeRel] "MINSIZEREL"
     XCODE_ATTRIBUTE_INFOPLIST_PREPROCESSOR_DEFINITIONS[variant=RelWithDebInfo] "RELWITHDEBINFO"
     XCODE_ATTRIBUTE_INFOPLIST_PREFIX_HEADER "${SM_XCODE_DIR}/plistHelper.hpp"
-    XCODE_ATTRIBUTE_GCC_PREFIX_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/archutils/Darwin/StepMania.pch"
+    XCODE_ATTRIBUTE_GCC_PREFIX_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/archutils/Darwin/Etterna.pch"
     XCODE_ATTRIBUTE_LIBRARY_SEARCH_PATHS "${SM_XCODE_DIR}/Libraries"
   )
 
@@ -250,7 +250,7 @@ elseif(APPLE)
       cp -r "${SM_ROOT_DIR}/${SM_APP_RELEASE_NAME}.app" .\;
       cd ${SM_ROOT_DIR}\;
       hdiutil create "${SM_DMG_RELEASE_NAME}"
-        -volname "StepMania ${SM_DMG_VERSION}"
+        -volname "Etterna ${SM_DMG_VERSION}"
         -srcfolder "dmgtmpdir/${SM_NAME_VERSION}/"
         -ov\;
       rm -rf dmgtmpdir\;
@@ -260,9 +260,9 @@ elseif(APPLE)
   # Add the ability to copy the resource file.
   add_custom_command(TARGET "${SM_EXE_NAME}"
     POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:StepMania>/../Resources"
-    COMMAND ${CMAKE_COMMAND} -E copy "${SM_XCODE_DIR}/smicon.icns" "$<TARGET_FILE_DIR:StepMania>/../Resources/"
-    COMMAND ${CMAKE_COMMAND} -E copy "${SM_XCODE_DIR}/Hardware.plist" "$<TARGET_FILE_DIR:StepMania>/../Resources/"
+    COMMAND ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:Etterna>/../Resources"
+    COMMAND ${CMAKE_COMMAND} -E copy "${SM_XCODE_DIR}/smicon.icns" "$<TARGET_FILE_DIR:Etterna>/../Resources/"
+    COMMAND ${CMAKE_COMMAND} -E copy "${SM_XCODE_DIR}/Hardware.plist" "$<TARGET_FILE_DIR:Etterna>/../Resources/"
   )
 else() # Linux
   set_target_properties("${SM_EXE_NAME}" PROPERTIES
@@ -493,7 +493,7 @@ else() # Unix / Linux
     list(APPEND SMDATA_LINK_LIB ${PULSEAUDIO_LIBRARY})
     # PACKAGE_NAME and PACKAGE_VERSION are only used in this scenario. Why is not clear.
     # TODO: Remove this silliness.
-    sm_add_compile_definition("${SM_EXE_NAME}" PACKAGE_NAME="StepMania")
+    sm_add_compile_definition("${SM_EXE_NAME}" PACKAGE_NAME="Etterna")
     set(PACKAGE_VERSION "${SM_VERSION_MAJOR}.${SM_VERSION_MINOR}")
     sm_add_compile_definition("${SM_EXE_NAME}" PACKAGE_VERSION="${PACKAGE_VERSION}")
   endif()
@@ -612,7 +612,7 @@ target_include_directories("${SM_EXE_NAME}" PUBLIC ${SM_INCLUDE_DIRS})
 if(WIN32)
   set(SM_INSTALL_DESTINATION ".")
 else()
-  set(SM_INSTALL_DESTINATION "stepmania-5.0")
+  set(SM_INSTALL_DESTINATION "Etterna")
 endif()
 
 if(NOT APPLE)
@@ -630,7 +630,7 @@ if(NOT APPLE)
     install(FILES "${SM_PROGRAM_DIR}/parallel_lights_io.dll" DESTINATION "${SM_FULL_INSTALLATION_PATH}")
 	install(FILES "${SM_PROGRAM_DIR}/swresample-2.dll" DESTINATION "${SM_FULL_INSTALLATION_PATH}")
     install(FILES "${SM_PROGRAM_DIR}/swscale-4.dll" DESTINATION "${SM_FULL_INSTALLATION_PATH}")
-    install(FILES "${SM_PROGRAM_DIR}/StepMania.vdi" DESTINATION "${SM_FULL_INSTALLATION_PATH}")
+    install(FILES "${SM_PROGRAM_DIR}/Etterna.vdi" DESTINATION "${SM_FULL_INSTALLATION_PATH}")
 
     # foreach(SM_WINDOW_DLL "${SM_WINDOWS_PROGRAM_DLLS}")
     #   install(FILES "${SM_WINDOW_DLL}" DESTINATION "${SM_INSTALL_DESTINATION}")

--- a/stepmania.nsi
+++ b/stepmania.nsi
@@ -100,7 +100,7 @@
 		# These indented statements modify settings for MUI_PAGE_FINISH
 		!define MUI_FINISHPAGE_NOAUTOCLOSE
 
-		!define MUI_FINISHPAGE_RUN "$INSTDIR\Program\StepMania.exe"
+		!define MUI_FINISHPAGE_RUN "$INSTDIR\Program\Etterna.exe"
 		!define MUI_FINISHPAGE_RUN_NOTCHECKED
 		!define MUI_FINISHPAGE_RUN_TEXT "$(TEXT_IO_LAUNCH_THE_GAME)"
 
@@ -170,7 +170,7 @@
 	; generate, then include installer strings
 	;!delfile "nsis_strings_temp.inc"
 
-	!system '"Program\StepMania.exe" --ExportNsisStrings'
+	!system '"Program\Etterna.exe" --ExportNsisStrings'
 	!include "nsis_strings_temp.inc"
 
 ;-------------------------------------------------------------------------------
@@ -217,10 +217,10 @@ Section "Main Section" SecMain
 	WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\${PRODUCT_ID}" "" "$INSTDIR"
 	WriteRegStr HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_ID}" "DisplayName" "$(TEXT_IO_REMOVE_ONLY)"
 	WriteRegStr HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_ID}" "DisplayVersion" "$(PRODUCT_VER)"
-	WriteRegStr HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_ID}" "Comments" "StepMania 5 is a rhythm game simulator."
-	WriteRegStr HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_ID}" "Publisher" "StepMania Team"
-	WriteRegStr HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_ID}" "URLInfoAbout" "http://www.stepmania.com/"
-	WriteRegStr HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_ID}" "URLUpdateInfo" "http://code.google.com/p/stepmania/"
+	WriteRegStr HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_ID}" "Comments" "Etterna is a rhythm game"
+	WriteRegStr HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_ID}" "Publisher" "Etterna Team"
+	WriteRegStr HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_ID}" "URLInfoAbout" "https://etternaonline.com/"
+	WriteRegStr HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_ID}" "URLUpdateInfo" "https://etternaonline.com/"
 	WriteRegStr HKEY_LOCAL_MACHINE "Software\Microsoft\Windows\CurrentVersion\Uninstall\${PRODUCT_ID}" "UninstallString" '"$INSTDIR\uninstall.exe"'
 !endif
 
@@ -238,16 +238,16 @@ Section "Main Section" SecMain
 
 !ifdef ASSOCIATE_SMZIP
 	WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\Classes\smzipfile" "" "$(TEXT_IO_SMZIP_PACKAGE)"
-	WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\Classes\smzipfile\DefaultIcon" "" "$INSTDIR\Program\StepMania.exe,1"
-	WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\Classes\smzipfile\shell\open\command" "" '"$INSTDIR\Program\StepMania.exe" "%1"'
+	WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\Classes\smzipfile\DefaultIcon" "" "$INSTDIR\Program\Etterna.exe,1"
+	WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\Classes\smzipfile\shell\open\command" "" '"$INSTDIR\Program\Etterna.exe" "%1"'
 	WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\Classes\.smzip" "" "smzipfile"
 !endif
 
 !ifdef ASSOCIATE_SMURL
-	WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\Classes\stepmania" "" "StepMania protocol handler"
+	WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\Classes\stepmania" "" "Etterna protocol handler"
 	WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\Classes\stepmania" "URL Protocol" ""
-	WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\Classes\stepmania\DefaultIcon" "" "$INSTDIR\Program\StepMania.exe"
-	WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\Classes\stepmania\shell\open\command" "" '"$INSTDIR\Program\StepMania.exe" "%1"'
+	WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\Classes\stepmania\DefaultIcon" "" "$INSTDIR\Program\Etterna.exe"
+	WriteRegStr HKEY_LOCAL_MACHINE "SOFTWARE\Classes\stepmania\shell\open\command" "" '"$INSTDIR\Program\Etterna.exe" "%1"'
 !endif
 
 !ifdef INSTALL_NON_PCK_FILES
@@ -445,8 +445,8 @@ Section "Main Section" SecMain
 	SetOutPath "$INSTDIR\Program"
 !ifdef INSTALL_EXECUTABLES
 	; normal exec
-	File "Program\StepMania.exe"
-	File "Program\StepMania.vdi"
+	File "Program\Etterna.exe"
+	File "Program\Etterna.vdi"
 	; other programs
 	;File "Program\Texture Font Generator.exe"
 	; AJ can never get this built properly:
@@ -471,7 +471,7 @@ Section "Main Section" SecMain
 		ExecWait 'Prerequisites\vc_redist.x86.exe' $0
 		
 		${If} $0 != 0
-		MessageBox MB_OK "Stepmania 5 requires visual studio 2015 x86 C++ runtimes to run."
+		MessageBox MB_OK "Etterna requires visual studio 2015 x86 C++ runtimes to run."
 		${EndIf}
 		
 		; Clear nsis errors as we already delt with it
@@ -519,10 +519,10 @@ Section "Main Section" SecMain
 	CreateDirectory "$SMPROGRAMS\${PRODUCT_ID}\"
 	; todo: make desktop shortcut an option
 	!ifdef MAKE_DESKTOP_SHORTCUT
-		CreateShortCut "$DESKTOP\$(TEXT_IO_RUN).lnk" "$INSTDIR\Program\StepMania.exe"
+		CreateShortCut "$DESKTOP\$(TEXT_IO_RUN).lnk" "$INSTDIR\Program\Etterna.exe"
 	!endif
 
-	CreateShortCut "$SMPROGRAMS\${PRODUCT_ID}\$(TEXT_IO_RUN).lnk" "$INSTDIR\Program\StepMania.exe"
+	CreateShortCut "$SMPROGRAMS\${PRODUCT_ID}\$(TEXT_IO_RUN).lnk" "$INSTDIR\Program\Etterna.exe"
 
 	!ifdef MAKE_OPEN_PROGRAM_FOLDER_SHORTCUT
 		CreateShortCut "$SMPROGRAMS\${PRODUCT_ID}\$(TEXT_IO_OPEN_PROGRAM_FOLDER).lnk" "$WINDIR\explorer.exe" "$INSTDIR\"
@@ -540,7 +540,7 @@ Section "Main Section" SecMain
 	!ifdef MAKE_UPDATES_SHORTCUT
 		CreateShortCut "$SMPROGRAMS\${PRODUCT_ID}\$(TEXT_IO_CHECK_FOR_UPDATES).lnk" "${UPDATES_URL}"
 	!endif
-	CreateShortCut "$INSTDIR\${PRODUCT_ID}.lnk" "$INSTDIR\Program\StepMania.exe"
+	CreateShortCut "$INSTDIR\${PRODUCT_ID}.lnk" "$INSTDIR\Program\Etterna.exe"
 !endif
 
 	IfErrors do_error do_no_error
@@ -615,7 +615,7 @@ Function LeaveAutorun
 	GoTo proceed
 
 	play:
-	Exec "$INSTDIR\Program\StepMania.exe"
+	Exec "$INSTDIR\Program\Etterna.exe"
 	IfErrors play_error
 	quit
 
@@ -687,7 +687,7 @@ Function PreInstall
 			ExecWait "Prerequisites\dxwebsetup.exe" $0
 		
 			${If} $0 != 0
-				MessageBox MB_OK "Stepmania 5 requires directX runtimes."
+				MessageBox MB_OK "Etterna requires directX runtimes."
 			${EndIf}
 			
 			; Clear nsis errors as we already delt with it
@@ -697,7 +697,7 @@ Function PreInstall
 		continue:
 !else
 		; Check that full version is installed.
-		IfFileExists "$INSTDIR\Program\StepMania.exe" proceed_with_patch
+		IfFileExists "$INSTDIR\Program\Etterna.exe" proceed_with_patch
 		MessageBox MB_YESNO|MB_ICONINFORMATION "$(TEXT_IO_FULL_INSTALL_NOT_FOUND)" IDYES proceed_with_patch
 		Abort
 		proceed_with_patch:
@@ -744,7 +744,7 @@ FunctionEnd
 ; The file deletions bellow don't simply recursively delete things because some
 ; people might decide it's a good idea to use a folder like Program Files as
 ; the folder for installation, and we don't want to delete everything in there.
-; ex. C:\Program Files\Program\Stepmania.exe
+; ex. C:\Program Files\Program\Etterna.exe
 
 Section "Uninstall"
 
@@ -885,6 +885,10 @@ Section "Uninstall"
 	Delete "$INSTDIR\Program\StepMania.vdi"
 	Delete "$INSTDIR\Program\StepMania-SSE2.exe"
 	Delete "$INSTDIR\Program\StepMania-SSE2.vdi"
+	Delete "$INSTDIR\Program\Etterna.exe"
+	Delete "$INSTDIR\Program\Etterna.vdi"
+	Delete "$INSTDIR\Program\Etterna-SSE2.exe"
+	Delete "$INSTDIR\Program\Etterna-SSE2.vdi"
 	Delete "$INSTDIR\Program\tools.exe"
 	Delete "$INSTDIR\Program\Texture Font Generator.exe"
 !endif


### PR DESCRIPTION
The exe should now be called Etterna.exe and the project in VS Etterna instead of Stepmania
Only tested on windows