### PR TITLE
pump holds appear to be working again

### DIFF
--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -858,7 +858,7 @@ static const Game g_Game_Pump =
 	"pump",						// m_szName
 	g_apGame_Pump_Styles,				// m_apStyles
 	false,						// m_bCountNotesSeparately
-	false, // m_bTickHolds
+	true, // m_bTickHolds
 	false, // m_PlayersHaveSeparateStyles
 	{						// m_InputScheme
 		"pump",					// m_szName


### PR DESCRIPTION
via Nico's fix in 74516bb - tested that holds increase combo on Pump gametype and do not crash the client. Tested 5 different songs at various BPMs with successful results.