### PR TITLE
Changed location of logged in text

### DIFF
--- a/Themes/Til Death/BGAnimations/_PlayerInfo.lua
+++ b/Themes/Til Death/BGAnimations/_PlayerInfo.lua
@@ -109,6 +109,7 @@ t[#t+1] = Def.ActorFrame{
 		end,
 		LoginMessageCommand=function(self)
 			self:settextf("Logged in as %s (%5.2f: #%i)",DLMAN:GetUsername(),DLMAN:GetSkillsetRating("Overall"),DLMAN:GetSkillsetRank(ms.SkillSets[1]))
+			self:xy(SCREEN_CENTER_X-75,AvatarY+25)
 		end,
 		OnlineUpdateMessageCommand=function(self)
 			self:queuecommand("Set")


### PR DESCRIPTION
changed the location of the logged in text at the bottom of the screen to above the session timer rather than to the right of it so it won't overlap