### PR TITLE
Removed 3:4 and 1:1 Aspect Ratios

### DIFF
--- a/Themes/Til Death/BGAnimations/ScreenGameplay overlay/WifeJudgmentSpotting.lua
+++ b/Themes/Til Death/BGAnimations/ScreenGameplay overlay/WifeJudgmentSpotting.lua
@@ -126,13 +126,20 @@ local enabledTargetTracker = playerConfig:get_data(pn_to_profile_slot(PLAYER_1))
 local enabledDisplayPercent = playerConfig:get_data(pn_to_profile_slot(PLAYER_1)).DisplayPercent
 local enabledJudgeCounter = playerConfig:get_data(pn_to_profile_slot(PLAYER_1)).JudgeCounter
 
--- restart button
+--lifebar stuff
+local lifeBarX = playerConfig:get_data(pn_to_profile_slot(PLAYER_1)).GameplayXYCoordinates.LifeBarX
+local lifeBarY = playerConfig:get_data(pn_to_profile_slot(PLAYER_1)).GameplayXYCoordinates.LifeBarY
+local lifeBarWidth = playerConfig:get_data(pn_to_profile_slot(PLAYER_1)).GameplaySizes.LifeBarWidth
+local lifeBarHeight = playerConfig:get_data(pn_to_profile_slot(PLAYER_1)).GameplaySizes.LifeBarHeight
+
+-- restart button (MOVED OUT OF THEME IN FAVOR OF REMAPPING)
+--[[
 local function froot(loop)
 	if loop.DeviceInput.button == "DeviceButton_`" then
 		SCREENMAN:GetTopScreen():SetPrevScreenName("ScreenStageInformation"):begin_backing_out()
 	end
 end
-
+]]
 --[[~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 												**Main listener that moves and resizes things**
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Themes/_fallback/Languages/de.ini
+++ b/Themes/_fallback/Languages/de.ini
@@ -1,4 +1,4 @@
-[Common]
+﻿[Common]
 WindowTitle=Etterna
 Etterna=Etterna
 
@@ -130,6 +130,7 @@ MenuUp=MenuHoch
 Operator=Operator
 EffectUp=EffektHoch
 EffectDown=EffektRunter
+RestartGameplay=NeustartGameplay
 Right=Rechts
 Select=Auswählen
 Start=Start

--- a/Themes/_fallback/Languages/en.ini
+++ b/Themes/_fallback/Languages/en.ini
@@ -129,6 +129,7 @@ MenuUp=MenuUp
 Operator=Operator
 EffectUp=EffectUp
 EffectDown=EffectDown
+RestartGameplay=RestartGameplay
 Right=Right
 Select=Select
 Start=Start

--- a/Themes/_fallback/Languages/es.ini
+++ b/Themes/_fallback/Languages/es.ini
@@ -128,6 +128,7 @@ MenuUp=MenúArriba
 Operator=Operador
 EffectUp=EfectoPositivo
 EffectDown=EfectoNegativo
+RestartGameplay=ReiniciarJuego
 Right=Derecha
 Select=Select
 Start=Start

--- a/Themes/_fallback/Languages/fr.ini
+++ b/Themes/_fallback/Languages/fr.ini
@@ -129,6 +129,7 @@ MenuUp=MenuHaut
 Operator=Opérateur
 EffectUp=EffectUp
 EffectDown=EffectDown
+RestartGameplay=RedémarrerGameplay
 Right=Droite
 Select=Select
 Start=Start

--- a/Themes/_fallback/Languages/ja.ini
+++ b/Themes/_fallback/Languages/ja.ini
@@ -1,4 +1,4 @@
-// Stepmania用日本語言語パック(fallback用) Ver.2-20150411
+﻿// Stepmania用日本語言語パック(fallback用) Ver.2-20150411
 
 // 翻訳終わった部分には済マーク入れます
 // 5.0.7の追加オプションの説明を追加
@@ -152,6 +152,7 @@ MenuUp=MenuUp
 Operator=Operator
 EffectUp=EffectUp
 EffectDown=EffectDown
+RestartGameplay=RestartGameplay
 Right=Right
 Select=Select
 Start=Start

--- a/Themes/_fallback/Languages/nl.ini
+++ b/Themes/_fallback/Languages/nl.ini
@@ -129,6 +129,7 @@ MenuUp=MenuOmhoog
 Operator=Operator
 EffectUp=EffectOmhoog
 EffectDown=EffectOmlaag
+RestartGamepaly=HerstartGameplay
 Right=Rechts
 Select=Selecteer
 Start=Start

--- a/Themes/_fallback/Languages/pl.ini
+++ b/Themes/_fallback/Languages/pl.ini
@@ -1,4 +1,4 @@
-[Common]
+﻿[Common]
 WindowTitle=Etterna
 Etterna=Etterna PL
 
@@ -129,6 +129,7 @@ MenuUp=MenuGóra
 Operator=Operator
 EffectUp=EffectGóra
 EffectDown=EffectDół
+RestartGameplay=WznowićRozgrywkę
 Right=Prawo
 Select=Wybierz
 Start=Start

--- a/Themes/_fallback/Languages/zh.ini
+++ b/Themes/_fallback/Languages/zh.ini
@@ -132,6 +132,7 @@ MenuUp=選單上
 Operator=系統設定
 EffectUp=效果上
 EffectDown=效果下
+RestartGameplay=重启游戏
 Right=右
 Select=選擇
 Start=開始

--- a/Themes/_fallback/Scripts/02 Utilities.lua
+++ b/Themes/_fallback/Scripts/02 Utilities.lua
@@ -323,8 +323,8 @@ end
 
 -- supported aspect ratios
 AspectRatios = {
-	ThreeFour   = 0.75,		-- (576x760 at 1024x768; meant for rotated monitors?)
-	OneOne      = 1.0,		-- 480x480  (uses Y value of specified resolution)
+	--ThreeFour   = 0.75,		-- (576x760 at 1024x768; meant for rotated monitors?)
+	--OneOne      = 1.0,		-- 480x480  (uses Y value of specified resolution)
 	FiveFour    = 1.25,		-- 600x480 (1280x1024 is a real use case)
 	FourThree   = 1.33333,	-- 640x480 (common)
 	SixteenTen  = 1.6,		-- 720x480 (common)

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -1,4 +1,4 @@
-﻿#include "global.h"
+#include "global.h"
 #include "Game.h"
 
 TapNoteScore Game::MapTapNoteScore( TapNoteScore tns ) const
@@ -27,6 +27,7 @@ static const Game::PerButtonInfo g_CommonButtonInfo[] =
 	{ GameButtonType_Menu }, // GAME_BUTTON_OPERATOR
 	{ GameButtonType_Menu }, // GAME_BUTTON_EFFECT_UP
 	{ GameButtonType_Menu }, // GAME_BUTTON_EFFECT_DOWN
+	{ GameButtonType_Menu }, // GAME_BUTTON_RESTART
 };
 
 const Game::PerButtonInfo *Game::GetPerButtonInfo( GameButton gb ) const

--- a/src/GameInput.h
+++ b/src/GameInput.h
@@ -30,6 +30,8 @@ enum GameButton
 	GAME_BUTTON_OPERATOR, /**< Access the operator menu. */
 	GAME_BUTTON_EFFECT_UP,
 	GAME_BUTTON_EFFECT_DOWN,
+	GAME_BUTTON_RESTART,	// The rare and elusive restart button
+
 	GAME_BUTTON_CUSTOM_01,
 	GAME_BUTTON_CUSTOM_02,
 	GAME_BUTTON_CUSTOM_03,
@@ -180,6 +182,7 @@ GameButton StringToGameButton( const InputScheme* pInputs, const RString& s );
 #define GAME_BUTTON_DOWN GAME_BUTTON_MENUDOWN
 #define GAME_BUTTON_START GAME_BUTTON_START
 #define GAME_BUTTON_BACK GAME_BUTTON_BACK
+#define GAME_BUTTON_RESTART GAME_BUTTON_RESTART
 /** @brief An input event specific to an InputScheme defined by a logical controller and button. */
 struct GameInput
 {

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -1,4 +1,4 @@
-﻿#include "global.h"
+#include "global.h"
 #include "Foreach.h"
 #include "Game.h"
 #include "GameConstantsAndTypes.h"
@@ -106,6 +106,7 @@ static const AutoMappings g_AutoKeyMappings_Dance = AutoMappings (
 	AutoMappingEntry( 0, KEY_Cx,		DANCE_BUTTON_DOWN,		false ),
 	AutoMappingEntry( 0, KEY_EQUAL,			GAME_BUTTON_EFFECT_UP, false),
 	AutoMappingEntry( 0, KEY_HYPHEN,		GAME_BUTTON_EFFECT_DOWN, false),
+	AutoMappingEntry( 0, KEY_ACCENT,		GAME_BUTTON_RESTART, false),
 	AutoMappingEntry( 0, KEY_KP_SLASH,		GAME_BUTTON_MENULEFT,		true ),
 	AutoMappingEntry( 0, KEY_KP_ASTERISK,	GAME_BUTTON_MENURIGHT,		true ),
 	AutoMappingEntry( 0, KEY_KP_HYPHEN,		GAME_BUTTON_MENUUP,		true ),

--- a/src/InputMapper.cpp
+++ b/src/InputMapper.cpp
@@ -1,4 +1,4 @@
-﻿#include "global.h"
+#include "global.h"
 #include "Foreach.h"
 #include "IniFile.h"
 #include "InputFilter.h"
@@ -51,22 +51,23 @@ static const AutoMappings g_DefaultKeyMappings = AutoMappings(
 	"",
 	"",
 	"",
-	AutoMappingEntry( 0, KEY_LEFT,	GAME_BUTTON_MENULEFT,	false ),
-	AutoMappingEntry( 0, KEY_RIGHT,	GAME_BUTTON_MENURIGHT,	false ),
-	AutoMappingEntry( 0, KEY_UP,	GAME_BUTTON_MENUUP,	false ),
-	AutoMappingEntry( 0, KEY_DOWN,	GAME_BUTTON_MENUDOWN,	false ),
-	AutoMappingEntry( 0, KEY_ENTER,	GAME_BUTTON_START,	false ),
-	AutoMappingEntry( 0, KEY_SLASH,	GAME_BUTTON_SELECT,	false ),
-	AutoMappingEntry( 0, KEY_ESC,	GAME_BUTTON_BACK,	false ),
-	AutoMappingEntry( 0, KEY_KP_C4,	GAME_BUTTON_MENULEFT,	true ),
-	AutoMappingEntry( 0, KEY_KP_C6,	GAME_BUTTON_MENURIGHT,	true ),
-	AutoMappingEntry( 0, KEY_KP_C8,	GAME_BUTTON_MENUUP,	true ),
-	AutoMappingEntry( 0, KEY_KP_C2,	GAME_BUTTON_MENUDOWN,	true ),
-	AutoMappingEntry( 0, KEY_KP_ENTER,	GAME_BUTTON_START,	true ),
-	AutoMappingEntry( 0, KEY_KP_C0,	GAME_BUTTON_SELECT,	true ),
-	AutoMappingEntry( 0, KEY_HYPHEN,	GAME_BUTTON_BACK,	true ), // laptop keyboards.
-	AutoMappingEntry( 0, KEY_F1,	GAME_BUTTON_COIN,	false ),
-	AutoMappingEntry( 0, KEY_SCRLLOCK,	GAME_BUTTON_OPERATOR,	false )
+	AutoMappingEntry(0, KEY_LEFT, GAME_BUTTON_MENULEFT, false),
+	AutoMappingEntry(0, KEY_RIGHT, GAME_BUTTON_MENURIGHT, false),
+	AutoMappingEntry(0, KEY_UP, GAME_BUTTON_MENUUP, false),
+	AutoMappingEntry(0, KEY_DOWN, GAME_BUTTON_MENUDOWN, false),
+	AutoMappingEntry(0, KEY_ENTER, GAME_BUTTON_START, false),
+	AutoMappingEntry(0, KEY_SLASH, GAME_BUTTON_SELECT, false),
+	AutoMappingEntry(0, KEY_ESC, GAME_BUTTON_BACK, false),
+	AutoMappingEntry(0, KEY_KP_C4, GAME_BUTTON_MENULEFT, true),
+	AutoMappingEntry(0, KEY_KP_C6, GAME_BUTTON_MENURIGHT, true),
+	AutoMappingEntry(0, KEY_KP_C8, GAME_BUTTON_MENUUP, true),
+	AutoMappingEntry(0, KEY_KP_C2, GAME_BUTTON_MENUDOWN, true),
+	AutoMappingEntry(0, KEY_KP_ENTER, GAME_BUTTON_START, true),
+	AutoMappingEntry(0, KEY_KP_C0, GAME_BUTTON_SELECT, true),
+	AutoMappingEntry(0, KEY_HYPHEN, GAME_BUTTON_BACK, true), // laptop keyboards.
+	AutoMappingEntry(0, KEY_F1, GAME_BUTTON_COIN, false),
+	AutoMappingEntry(0, KEY_SCRLLOCK, GAME_BUTTON_OPERATOR, false),
+	AutoMappingEntry(0, KEY_ACCENT, GAME_BUTTON_RESTART, false)
 );
 
 void InputMapper::AddDefaultMappingsForCurrentGameIfUnmapped()
@@ -1151,6 +1152,7 @@ static const InputScheme::GameButtonInfo g_CommonGameButtonInfo[] =
 	{ "Operator",	GAME_BUTTON_OPERATOR },
 	{ "EffectUp",	GAME_BUTTON_EFFECT_UP },
 	{ "EffectDown",	GAME_BUTTON_EFFECT_DOWN },
+	{ "RestartGameplay", GAME_BUTTON_RESTART },
 };
 
 const InputScheme::GameButtonInfo *InputScheme::GetGameButtonInfo( GameButton gb ) const

--- a/src/PrefsManager.cpp
+++ b/src/PrefsManager.cpp
@@ -1,4 +1,4 @@
-﻿#include "global.h"
+#include "global.h"
 #include "Foreach.h"
 #include "IniFile.h"
 #include "LuaManager.h"

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1,4 +1,4 @@
-﻿#include "global.h"
+#include "global.h"
 #include "ActorUtil.h"
 #include "AdjustSync.h"
 #include "ArrowEffects.h"
@@ -1887,6 +1887,21 @@ bool ScreenGameplay::Input( const InputEventPlus &input )
 
 			return true;
 		}
+
+		/* Restart gameplay button moved from theme to allow for rebinding for people who
+		 *  dont want to edit lua files :)
+		 */
+		bool bHoldingRestart = false;
+		if (GAMESTATE->GetCurrentStyle(input.pn)->GameInputToColumn(input.GameI) == Column_Invalid)
+		{
+			bHoldingRestart |= input.MenuI == GAME_BUTTON_RESTART;
+		}
+		if (bHoldingRestart)
+		{
+			SCREENMAN->GetTopScreen()->SetPrevScreenName("ScreenStageInformation");
+			BeginBackingOutFromGameplay();
+		}
+
 	}
 
 	bool bRelease = input.type == IET_RELEASE;

--- a/src/ScreenOptionsMasterPrefs.cpp
+++ b/src/ScreenOptionsMasterPrefs.cpp
@@ -571,7 +571,7 @@ static void RefreshRate( int &sel, bool ToSel, const ConfOption *pConfOption )
 
 static void DisplayAspectRatio( int &sel, bool ToSel, const ConfOption *pConfOption )
 {
-	const float mapping[] = { 3/4.f, 1, 4/3.0f, 5/4.0f, 16/10.0f, 16/9.f, 8/3.f };
+	const float mapping[] = { 5/4.0f, 4/3.0f, 16/10.0f, 16/9.f, 8/3.f };
 	MoveMap( sel, pConfOption, ToSel, mapping, ARRAYLEN(mapping) );
 }
 
@@ -748,7 +748,7 @@ static void InitializeConfOptions()
 	g_ConfOptions.back().m_iEffects = OPT_APPLY_GRAPHICS;
 	ADD( ConfOption( "DisplayResolution",		DisplayResolutionM, DisplayResolutionChoices ) );
 	g_ConfOptions.back().m_iEffects = OPT_APPLY_GRAPHICS | OPT_APPLY_ASPECT_RATIO;
-	ADD( ConfOption( "DisplayAspectRatio",		DisplayAspectRatio,	"|3:4","|1:1","|4:3","|5:4","|16:10","|16:9","|8:3" ) );
+	ADD( ConfOption( "DisplayAspectRatio",		DisplayAspectRatio,	"|5:4","|4:3","|16:10","|16:9","|8:3" ) );
 	g_ConfOptions.back().m_iEffects = OPT_APPLY_GRAPHICS | OPT_APPLY_ASPECT_RATIO;	// need OPT_APPLY_GRAPHICS because if windowed the width may change to make square pixels
 	ADD( ConfOption( "WideScreen16_10",		WideScreen16_10,	"Off", "On" ) );
 	g_ConfOptions.back().m_sPrefName = "DisplayAspectRatio";

--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -1292,10 +1292,15 @@ bool HandleGlobalInputs( const InputEventPlus &input )
 			 * (to prevent quitting without storing changes). */
 			if( SCREENMAN->AllowOperatorMenuButton() )
 			{
-				SCREENMAN->SystemMessage( SERVICE_SWITCH_PRESSED );
-				SCREENMAN->PopAllScreens();
-				GAMESTATE->Reset();
-				SCREENMAN->SetNewScreen( CommonMetrics::OPERATOR_MENU_SCREEN );
+				bool bIsCtrlHeld = INPUTFILTER->IsBeingPressed(DeviceInput(DEVICE_KEYBOARD, KEY_LCTRL), &input.InputList) ||
+					INPUTFILTER->IsBeingPressed(DeviceInput(DEVICE_KEYBOARD, KEY_RCTRL), &input.InputList);
+				if (bIsCtrlHeld) // Operator is rebound to OPERATOR + Ctrl
+				{
+					SCREENMAN->SystemMessage(SERVICE_SWITCH_PRESSED);
+					SCREENMAN->PopAllScreens();
+					GAMESTATE->Reset();
+					SCREENMAN->SetNewScreen(CommonMetrics::OPERATOR_MENU_SCREEN);
+				}
 			}
 			return true;
 			return false; // Attract needs to know because it goes to TitleMenu on > 1 credit


### PR DESCRIPTION
There is no reason for them to exist in the game's current state. If you
select them then you get very broken results in the menus.

I also changed the order of the aspect ratios very slightly to make it pretty.
To quote Foxfire and Mina:
Foxfire | Today at 7:13 PM
3:4 and 1:1 must die
gratuitous double negative usage | Today at 7:13 PM
i would but who knows what will break