### PR TITLE
Rebind the Service Switch

### DIFF
--- a/src/StepMania.cpp
+++ b/src/StepMania.cpp
@@ -1292,10 +1292,15 @@ bool HandleGlobalInputs( const InputEventPlus &input )
 			 * (to prevent quitting without storing changes). */
 			if( SCREENMAN->AllowOperatorMenuButton() )
 			{
-				SCREENMAN->SystemMessage( SERVICE_SWITCH_PRESSED );
-				SCREENMAN->PopAllScreens();
-				GAMESTATE->Reset();
-				SCREENMAN->SetNewScreen( CommonMetrics::OPERATOR_MENU_SCREEN );
+				bool bIsCtrlHeld = INPUTFILTER->IsBeingPressed(DeviceInput(DEVICE_KEYBOARD, KEY_LCTRL), &input.InputList) ||
+					INPUTFILTER->IsBeingPressed(DeviceInput(DEVICE_KEYBOARD, KEY_RCTRL), &input.InputList);
+				if (bIsCtrlHeld) // Operator is rebound to OPERATOR + Ctrl
+				{
+					SCREENMAN->SystemMessage(SERVICE_SWITCH_PRESSED);
+					SCREENMAN->PopAllScreens();
+					GAMESTATE->Reset();
+					SCREENMAN->SetNewScreen(CommonMetrics::OPERATOR_MENU_SCREEN);
+				}
 			}
 			return true;
 			return false; // Attract needs to know because it goes to TitleMenu on > 1 credit


### PR DESCRIPTION
For your consideration: It has been brought up from time to time to move or remove the service switch from the game because you can hit it in almost every menu and it sits next to the screenshot button. As a compromise (because the button has a legitimate use) I have simply added the requirement to hold Ctrl when pressing Scroll Lock to cause the "Service Switch" to be triggered. Thus, there is a much lower probability of hitting it in normal gameplay and when hitting the screenshot button.

The change can probably be done in a more efficient way. The boolean assigned that checks for Ctrl is actually equivalent to the one that checks later on for things like Ctrl+F4, etc. So it could probably be moved further up instead.

Regardless, this is a start.