### PR TITLE
Fix Lua Error Resulting From Restart Gameplay Button Change

### DIFF
--- a/Themes/Til Death/BGAnimations/ScreenGameplay overlay/WifeJudgmentSpotting.lua
+++ b/Themes/Til Death/BGAnimations/ScreenGameplay overlay/WifeJudgmentSpotting.lua
@@ -675,9 +675,9 @@ local t = Def.ActorFrame{
 		local endTime = os.time() + GetPlayableTime()
 		GAMESTATE:UpdateDiscordPresence(largeImageTooltip, detail, state, endTime)
 
-		if SCREENMAN:GetTopScreen():GetName() == "ScreenGameplay" then
+		--[[if SCREENMAN:GetTopScreen():GetName() == "ScreenGameplay" then
 			SCREENMAN:GetTopScreen():AddInputCallback(froot)
-		end
+		end]]
 		if(playerConfig:get_data(pn_to_profile_slot(PLAYER_1)).CustomizeGameplay) then
 			SCREENMAN:GetTopScreen():AddInputCallback(firstHalfInput)
 			SCREENMAN:GetTopScreen():AddInputCallback(secondHalfInput)


### PR DESCRIPTION
yikes
I didn't check to see if the function I removed was referenced anywhere else and this is what happens when you don't do that. This lua error probably breaks a lot of stuff and might need to be fixed asap.
Minor change; just commented the erroring code if we ever want to go back.