### PR TITLE
Improve RestartGameplay Button Behavior

### DIFF
--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1887,20 +1887,6 @@ bool ScreenGameplay::Input( const InputEventPlus &input )
 
 			return true;
 		}
-		
-		/* Restart gameplay button moved from theme to allow for rebinding for people who
-		 *  dont want to edit lua files :)
-		 */
-		bool bHoldingRestart = false;
-		if (GAMESTATE->GetCurrentStyle(input.pn)->GameInputToColumn(input.GameI) == Column_Invalid)
-		{
-			bHoldingRestart |= input.MenuI == GAME_BUTTON_RESTART;
-		}
-		if (bHoldingRestart)
-		{
-			SCREENMAN->GetTopScreen()->SetPrevScreenName("ScreenStageInformation");
-			BeginBackingOutFromGameplay();
-		}
 	}
 
 	bool bRelease = input.type == IET_RELEASE;
@@ -1919,6 +1905,21 @@ bool ScreenGameplay::Input( const InputEventPlus &input )
 		return false;
 	}
 
+	/* Restart gameplay button moved from theme to allow for rebinding for people who
+	*  dont want to edit lua files :)
+	*/
+	bool bHoldingRestart = false;
+	if (GAMESTATE->GetCurrentStyle(input.pn)->GameInputToColumn(input.GameI) == Column_Invalid)
+	{
+		bHoldingRestart |= input.MenuI == GAME_BUTTON_RESTART;
+	}
+	if (bHoldingRestart)
+	{
+		SCREENMAN->GetTopScreen()->SetPrevScreenName("ScreenStageInformation");
+		BeginBackingOutFromGameplay();
+	}
+	
+	
 	if( GAMESTATE->m_bMultiplayer )
 	{
 		if( input.mp != MultiPlayer_Invalid  &&  GAMESTATE->IsMultiPlayerEnabled(input.mp)  &&  iCol != -1 )

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1905,18 +1905,23 @@ bool ScreenGameplay::Input( const InputEventPlus &input )
 		return false;
 	}
 
-	/* Restart gameplay button moved from theme to allow for rebinding for people who
-	*  dont want to edit lua files :)
-	*/
-	bool bHoldingRestart = false;
-	if (GAMESTATE->GetCurrentStyle(input.pn)->GameInputToColumn(input.GameI) == Column_Invalid)
+	// RestartGameplay may only be pressed when in Singleplayer.
+	// Clever theming or something can probably break this, but we should at least try.
+	if (SCREENMAN->GetTopScreen()->GetPrevScreen() == "ScreenSelectMusic")
 	{
-		bHoldingRestart |= input.MenuI == GAME_BUTTON_RESTART;
-	}
-	if (bHoldingRestart)
-	{
-		SCREENMAN->GetTopScreen()->SetPrevScreenName("ScreenStageInformation");
-		BeginBackingOutFromGameplay();
+		/* Restart gameplay button moved from theme to allow for rebinding for people who
+		*  dont want to edit lua files :)
+		*/
+		bool bHoldingRestart = false;
+		if (GAMESTATE->GetCurrentStyle(input.pn)->GameInputToColumn(input.GameI) == Column_Invalid)
+		{
+			bHoldingRestart |= input.MenuI == GAME_BUTTON_RESTART;
+		}
+		if (bHoldingRestart)
+		{
+			SCREENMAN->GetTopScreen()->SetPrevScreenName("ScreenStageInformation");
+			BeginBackingOutFromGameplay();
+		}
 	}
 	
 	


### PR DESCRIPTION
The initial changes made to allow RestartGameplay to be remapped by bringing it into the game code opened up some more questions/problems that can be resolved. 
The first is that the previous behavior of the button when it was still in the theme allowed you to press the button when you were in the middle of failing (the screen is fading out and you are leaving the song).
This changes that so you can press it any time in gameplay. You aren't locked into failing a song when you fail it.

The second is that maybe we can start to have more control over the button's use. So I decided, although we haven't polished multiplayer completely, to force the button to only be usable offline. This also came about through some observations I made with using the button. If you use the button when in multiplayer then exit the song, the whole multiplayer system breaks and you must log back in to fix it. To not have to deal with such a headache and potential abuse for letting people restart when online, I just disabled it if you aren't offline.
Note that the way I did this may not be great because it relies on the fact that the previous screen before normal gameplay is known as ScreenSelectMusic (compared to ScreenNetSelectMusic for Network). Thus, theming or screwing around may break this. And by break I mean the button just stops working.