### PR TITLE
Disable pump hold combo tick/increase again

### DIFF
--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -859,7 +859,7 @@ static const Game g_Game_Pump =
 	"pump",						// m_szName
 	g_apGame_Pump_Styles,				// m_apStyles
 	false,						// m_bCountNotesSeparately
-	true, // m_bTickHolds
+	false, // m_bTickHolds
 	false, // m_PlayersHaveSeparateStyles
 	{						// m_InputScheme
 		"pump",					// m_szName


### PR DESCRIPTION
This was not fixed. They don't work properly. Turning this off will allow at least some kind of normal gameplay instead of having -severalthousand% scores. 