### PR TITLE
Fix strange non-single filtering

### DIFF
--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -384,7 +384,7 @@ void MusicWheel::GetSongList( vector<Song*> &arraySongs, SortOrder so )
 			// dance-double steps will show up when dance-single was selected, with
 			// no playable steps.  Then the game will crash when trying to play it.
 			// -Kyz
-			if(CommonMetrics::AUTO_SET_STYLE && !NSMAN->isSMOnline)
+			if(CommonMetrics::AUTO_SET_STYLE)
 			{
 				// with AUTO_SET_STYLE on and Autogen off, some songs may get
 				// hidden. Search through every playable StepsType until you


### PR DESCRIPTION
So this should fix #230 
I'm not sure if exactly what has been done here is smart or correct. From what I can tell based on the reproduction steps for the bug, this should fix it.
The bug involves entering any non-single-style chart like solo or double and then exiting by any means. It will then filter every chart you have to that type. Only files that contain a diff with that style in it will appear.
It was seemingly narrowed down to only be happening whenever the user is logged in to smo/multiplayer.

So the steps to reproduce the bug are: Open the game, Open multiplayer, Log in to any game server (smo), Don't open a room or anything, just back out to the menu after logging in, Try any non single style chart and immediately leave the file. You should now only see compatible diffs.
I tested these exact steps after making these changes and it was fixed.
More changes should perhaps be made to phase out the used fallback metric here, AutoSetStyle. Just do a search for AUTO_SET_STYLE in the source.