### PR TITLE
Adding Visual Studio 2015/2017 cache/options directory to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ PBProject/Hardware.plist
 *.dmg
 .DS_Store
 
+# Visual Studio 2015/2017 cache/options directory
+.vs/
+
 # Visual Studio
 *.sln
 *.vcxproj


### PR DESCRIPTION
The temporary files created in this folder are created by Visual Studio 2015/2017 when you open a project with it, and are not ignored, which is problematic if you want to stash files/commit while having the project opened in Visual Studio. (for example : 
![alt text](http://vivide.re/22VV66nC.png "Example image")