### PR TITLE
Improve Replay Behavior

### DIFF
--- a/src/NoteTypes.h
+++ b/src/NoteTypes.h
@@ -209,6 +209,13 @@ struct HoldReplayResult {
 	TapNoteSubType subType;
 };
 
+struct TapReplayResult {
+	int row;
+	int track; // column
+	float offset;	// 0
+	TapNoteType type; //typically mines, holds, rolls, etc
+};
+
 extern TapNote TAP_EMPTY;			// '0'
 extern TapNote TAP_ORIGINAL_TAP;		// '1'
 extern TapNote TAP_ORIGINAL_HOLD_HEAD;		// '2'

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -2181,7 +2181,6 @@ void Player::Step( int col, int row, const std::chrono::steady_clock::time_point
 			
 			if (bHeld) //a hack to make Rolls not do weird things like count as 0ms marvs.
 			{
-				LOG->Trace("tyetestasfsdSD");
 				score = TNS_None;
 				fNoteOffset = -1.f;
 			}

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -1073,8 +1073,6 @@ void Player::UpdateHoldNotes( int iSongRow, float fDeltaTime, vector<TrackRowTap
 				tn.HoldResult.bActive = false;
 				tn.HoldResult.fLife = 0.f;
 				tn.HoldResult.hns = HNS_LetGo;
-				fLife = 0.f;
-				hns = HNS_LetGo;
 
 				// score the dead hold
 				if (COMBO_BREAK_ON_IMMEDIATE_HOLD_LET_GO)

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -39,6 +39,7 @@
 #include "NoteSkinManager.h" 
 #include "ThemeMetric.h"
 #include "HoldJudgment.h"
+#include "GamePreferences.h"
 
 RString ATTACK_DISPLAY_X_NAME( size_t p, size_t both_sides );
 void TimingWindowSecondsInit( size_t /*TimingWindow*/ i, RString &sNameOut, float &defaultValueOut );
@@ -864,7 +865,7 @@ void Player::Update( float fDeltaTime )
 			if( tn.HoldResult.fLife >= 0.5f )
 				continue;
 
-			Step( iTrack, iHeadRow, now, false, false );
+			Step( iTrack, iHeadRow, now, true, false );	// bHeld really doesnt make a difference for autoplay and replay
 			if( m_pPlayerState->m_PlayerController == PC_AUTOPLAY)
 			{
 				STATSMAN->m_CurStageStats.m_bUsedAutoplay = true;
@@ -1048,6 +1049,43 @@ void Player::UpdateHoldNotes( int iSongRow, float fDeltaTime, vector<TrackRowTap
 		//LOG->Trace("hold note has a result, skipping.");
 		return;	// we don't need to update the logic for this group
 	}
+
+	if (GamePreferences::m_AutoPlay == PC_REPLAY)
+	{
+		FOREACH(TrackRowTapNote, vTN, trtn)
+		{
+			TapNote &tn = *trtn->pTN;
+
+			// check from now until the head of the hold to see if it should die
+			// possibly really bad, but we dont REALLY care that much about fps in replays, right?
+			bool holdDropped = false;
+			for (int yeet = vTN[0].iRow; yeet <= iSongRow && !holdDropped; yeet++)
+			{
+				if (PlayerAI::DetermineIfHoldDropped(yeet, trtn->iTrack))
+				{
+					holdDropped = true;
+				}
+			}
+
+			if (holdDropped) // it should be dead
+			{
+				tn.HoldResult.bHeld = false;
+				tn.HoldResult.bActive = false;
+				tn.HoldResult.fLife = 0.f;
+				tn.HoldResult.hns = HNS_LetGo;
+				fLife = 0.f;
+				hns = HNS_LetGo;
+
+				// score the dead hold
+				if (COMBO_BREAK_ON_IMMEDIATE_HOLD_LET_GO)
+					IncrementMissCombo();
+				SetHoldJudgment(tn, iFirstTrackWithMaxEndRow, iSongRow);
+				HandleHoldScore(tn);
+				return;
+			}
+		}
+	}
+
 
 	//LOG->Trace("hold note doesn't already have result, let's check.");
 
@@ -2140,25 +2178,32 @@ void Player::Step( int col, int row, const std::chrono::steady_clock::time_point
 			break;
 
 		case PC_REPLAY:
-
-			fNoteOffset = PlayerAI::GetTapNoteOffsetForReplay(pTN, iRowOfOverlappingNoteOrRow, col);
-
-			if (fNoteOffset == -2.f)
+			
+			if (bHeld) //a hack to make Rolls not do weird things like count as 0ms marvs.
 			{
-				CHECKPOINT_M("mine hit");
-				score = TNS_HitMine;
-			}
-			else if (pTN->type == TapNoteType_Mine)
-			{
-				return;
+				LOG->Trace("tyetestasfsdSD");
+				score = TNS_None;
+				fNoteOffset = -1.f;
 			}
 			else
 			{
-				if ( pTN->IsNote() )
-					score = PlayerAI::GetTapNoteScoreForReplay(m_pPlayerState, fNoteOffset);
+				fNoteOffset = PlayerAI::GetTapNoteOffsetForReplay(pTN, iRowOfOverlappingNoteOrRow, col);
+				if (fNoteOffset == -2.f) // we hit a mine
+				{
+					score = TNS_HitMine;
+				}
+				else if (pTN->type == TapNoteType_Mine) // we are looking at a mine but missed it
+				{
+					return;
+				}
+				else // every other case
+				{
+					if (pTN->IsNote())
+						score = PlayerAI::GetTapNoteScoreForReplay(m_pPlayerState, fNoteOffset);
+				}
 			}
 			
-
+			
 			break;
 		default:
 			FAIL_M(ssprintf("Invalid player controller type: %i", m_pPlayerState->m_PlayerController));
@@ -2197,8 +2242,15 @@ void Player::Step( int col, int row, const std::chrono::steady_clock::time_point
 
 				if ( pTN->result.tns != TNS_None )
 				{
-					SetJudgment(iRowOfOverlappingNoteOrRow, col, *pTN);
-					HandleTapRowScore(iRowOfOverlappingNoteOrRow);
+					if (pTN->type == TapNoteType_HoldHead && m_pPlayerState->m_PlayerController == PC_REPLAY && bHeld)
+					{
+						// odd hack to make roll taps (Step() with bHeld true) not count as marvs
+					}
+					else
+					{
+						SetJudgment(iRowOfOverlappingNoteOrRow, col, *pTN);
+						HandleTapRowScore(iRowOfOverlappingNoteOrRow);
+					}
 				}
 			}
 		}
@@ -2243,11 +2295,22 @@ void Player::Step( int col, int row, const std::chrono::steady_clock::time_point
 		}
 	}
 	// XXX:
+	
 	if( !bRelease )
 	{
 		if( m_pNoteField != nullptr )
-		{
-			m_pNoteField->Step( col, score );
+		{	// skip tapping in replay mode on misses to emulate... missing.
+			if (m_pPlayerState->m_PlayerController == PC_REPLAY)
+			{
+				if (score != TNS_Miss)
+				{
+					m_pNoteField->Step(col, score);
+				}
+			}
+			else
+			{
+				m_pNoteField->Step(col, score);
+			}
 		}
 		Message msg( "Step" );
 		msg.SetParam( "PlayerNumber", m_pPlayerState->m_PlayerNumber );

--- a/src/PlayerAI.h
+++ b/src/PlayerAI.h
@@ -13,13 +13,25 @@ const int NUM_SKILL_LEVELS = 6;	// 0-5
 class PlayerAI
 {
 public:
+	// Pointer to real high score data for a replay
+
 	static HighScore* pScoreData;
+
+	// Pulled from pScoreData on initialization
+
+	// A map with indices for each row of the chart, pointing to nothing or a Normal Result
+	static map<int, vector<TapReplayResult>> m_ReplayTapMap;
+	// A map with indices for each row of the chart, pointing to nothing or hold drop results.
+	static map<int, vector<HoldReplayResult>> m_ReplayHoldMap;
 
 	static void InitFromDisk();
 	static TapNoteScore GetTapNoteScore( const PlayerState* pPlayerState );
 	static void SetScoreData(HighScore* pHighScore);
+
 	static float GetTapNoteOffsetForReplay(TapNote* pTN, int noteRow, int col);
 	static TapNoteScore GetTapNoteScoreForReplay(const PlayerState* pPlayerState, float fNoteOffset);
+	static bool DetermineIfHoldDropped(int noteRow, int col);
+
 
 };
 

--- a/src/ScreenEvaluation.cpp
+++ b/src/ScreenEvaluation.cpp
@@ -674,10 +674,7 @@ void ScreenEvaluation::Init()
 		default:
 			break;
 	}
-	if (GamePreferences::m_AutoPlay == PC_REPLAY)
-	{
-		STATSMAN->m_vPlayedStageStats.pop_back();
-	}
+
 }
 
 bool ScreenEvaluation::Input( const InputEventPlus &input )

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -2044,8 +2044,8 @@ void ScreenGameplay::StageFinished( bool bBackedOut )
 	FOREACH_HumanPlayer( pn )
 		STATSMAN->m_CurStageStats.m_player[pn].CalcAwards( pn, STATSMAN->m_CurStageStats.m_bGaveUp, STATSMAN->m_CurStageStats.m_bUsedAutoplay );
 	STATSMAN->m_CurStageStats.FinalizeScores( false );
-	GAMESTATE->CommitStageStats();
-
+	if ( GamePreferences::m_AutoPlay == PC_HUMAN )
+		GAMESTATE->CommitStageStats();
 	// save current stage stats
 	STATSMAN->m_vPlayedStageStats.push_back( STATSMAN->m_CurStageStats );
 


### PR DESCRIPTION
New functionality: Holds and Rolls now drop. Since we don't keep track of actual taps (ghost taps, etc) the holds just drop instantly precisely when they drop in gameplay and we can't simulate the random tapping of rolls or holds. Along with this, the drops score correctly.
Mines should now work correctly. They don't bias to the left. Probably. I tested this once.
Rolls don't count as a bunch of 0ms marvs.
Also it was reported that play time, notes hit, and number of plays increased when viewing replays. That should be fixed, too.

Replays have yet to be tested on anything other than single 4k. It would be nice to see them work there.
This format is incompatible with old (non-column recording) replays. This shouldn't require too much work to make it happen, but in its current state it will not function.

Bugs: Rare replay desync? Score graphs don't always match the replay.