### PR TITLE
Make replay viewer compatible with old (pre v0.60) replays

### DIFF
--- a/src/HighScore.cpp
+++ b/src/HighScore.cpp
@@ -709,7 +709,7 @@ bool HighScore::LoadReplayDataBasic() {
 }
 
 bool HighScore::LoadReplayDataFull() {
-	if (m_Impl->vNoteRowVector.size() > 4 && m_Impl->vOffsetVector.size() > 4) {
+	if (m_Impl->vNoteRowVector.size() > 4 && m_Impl->vOffsetVector.size() > 4 && m_Impl->vTrackVector.size() > 4) {
 		m_Impl->ReplayType = 2;
 		return true;
 	}


### PR DESCRIPTION
This should allow you to load any older replay and view it like normal, assuming the score exists within your Etterna.xml as well as existing in your /Replays/ folder. If you can view the graph, you can view the replay.

There is a catch to how this works, though. Since old replays do not save data about dropped holds, note types, mines, or columns, some compromises had to be made. But really, the replays look almost identical.
Any hold/roll that is tapped is viewed in the replay as fully held, and never drops.
Mines are very rarely hit, if ever.
Simultaneous notes are judged in a seemingly random order instead of by column. Due to chord cohesion, you may end up with different judgements on the notes that make up a simultaneous note (jump, hand, quad, etc). This should not affect the overall score unless the misjudged note happened to cause a hold to be judged as missed. Mines are ignored in this process to protect the replay score from getting bombed for no reason.
I have admittedly not tested this on Rolls for old replays. I'm assuming it will work fine since I did not modify the way it works.

I utilized the replay type stuff mina threw in a few months back. I fixed (?) something that seemed to make it so that if you loaded an old replay twice, it considered the old replay to be a new replay.

Known bugs:
1. Replays don't show the correct BPM for rates while in gameplay for some reason. Haven't looked into it. It doesn't affect anything serious.
2. Very dense misses or near misses like vibro stuff may cause Replay to fail (like dense mines do for new replays)
3. Judge conversion on the eval screen can be VERY wrong.
4. Playing replays which were made in a different judge can cause incorrect end of file wife scores.