### PR TITLE
Fix lua error in online profile scoreboard

### DIFF
--- a/src/DownloadManager.cpp
+++ b/src/DownloadManager.cpp
@@ -1658,7 +1658,7 @@ public:
 		lua_setfield(L, -2, "chartkey");
 		LuaHelpers::Push(L, onlineScore.difficulty);
 		lua_setfield(L, -2, "difficulty");
-		lua_pushstring(L, GradeToString(PlayerStageStats::GetGrade(onlineScore.wifeScore)));
+		LuaHelpers::Push(L,PlayerStageStats::GetGrade(onlineScore.wifeScore));
 		lua_setfield(L, -2, "grade");
 		return 1;
 	}


### PR DESCRIPTION
This is being caused by a discrepancy between expected values when flipping between online and local in the profile section of the screen.
Local grades return score.grade, which is an enum like expected in most of the lua.
Online grades return score.grade, which is a string that doesnt match the table that is searched by getGradeColor() in 01 color_config.lua.

I have changed the value that gets pushed from DLMAN from a string to the actual grade enum so that the values are more correct.
I've tested this in most places that grades and grade colors get called. It appears this exact lua function is only called once anyways, so since it works in this screen I would expect it to work everywhere else.

This fixes #245 