### PR TITLE
Add Top Score/All Scores Toggle so it can perform like EO Leaderboards

### DIFF
--- a/Themes/Til Death/BGAnimations/superscoreboard.lua
+++ b/Themes/Til Death/BGAnimations/superscoreboard.lua
@@ -84,6 +84,7 @@ local function byAchieved(scoregoal)
 end
 
 local filts = {"All Rates", "Current Rate"}
+local topornah = {"Top Scores", "All Scores"}
 
 local scoretable
 local o = Def.ActorFrame{
@@ -254,6 +255,28 @@ local o = Def.ActorFrame{
 		MouseLeftClickMessageCommand=function(self)
 			if isOver(self) then
 				DLMAN:ToggleRateFilter()
+				ind = 0
+				self:GetParent():queuecommand("ChartLeaderboardUpdate")
+			end
+		end,
+	},
+	LoadFont("Common normal") .. {	--top score/all score toggle
+		InitCommand=function(self)
+			self:xy(c5x - 115, headeroff):zoom(tzoom):halign(1)
+		end,
+		HighlightCommand=function(self)
+			highlightIfOver(self)
+		end,
+		UpdateCommand=function(self)
+			if DLMAN:GetTopScoresOnlyFilter() then 
+				self:settext(topornah[1])
+			else
+				self:settext(topornah[2])
+			end
+		end,
+		MouseLeftClickMessageCommand=function(self)
+			if isOver(self) then
+				DLMAN:ToggleTopScoresOnlyFilter()
 				ind = 0
 				self:GetParent():queuecommand("ChartLeaderboardUpdate")
 			end

--- a/Themes/Til Death/BGAnimations/superscoreboard.lua
+++ b/Themes/Til Death/BGAnimations/superscoreboard.lua
@@ -262,7 +262,11 @@ local o = Def.ActorFrame{
 	},
 	LoadFont("Common normal") .. {	--top score/all score toggle
 		InitCommand=function(self)
-			self:xy(c5x - 115, headeroff):zoom(tzoom):halign(1)
+			if collapsed then
+				self:xy(c5x - 175, headeroff):zoom(tzoom):halign(1)
+			else
+				self:xy(c5x - 115, headeroff):zoom(tzoom):halign(1)
+			end
 		end,
 		HighlightCommand=function(self)
 			highlightIfOver(self)

--- a/src/DownloadManager.cpp
+++ b/src/DownloadManager.cpp
@@ -1141,8 +1141,9 @@ void DownloadManager::RequestChartLeaderBoard(string chartkey)
 				// it seems prudent to maintain the eo functionality in this way and screen out multiple scores from the same user 
 				// even more prudent would be to put this last where it belongs, we don't want to screen out scores for players who wouldn't
 				// have had them registered in the first place -mina
-				if (userswithscores.count(tmp.username) == 1)
-					continue;
+				// Moved this filtering to the Lua call. -poco
+				//if (userswithscores.count(tmp.username) == 1)
+				//	continue;
 
 				userswithscores.emplace(tmp.username);
 				vec.emplace_back(tmp);
@@ -1787,11 +1788,15 @@ public:
 		//p->RequestChartLeaderBoard(SArg(1));
 		p->MakeAThing(SArg(1));
 		vector<HighScore*> wot;
+		unordered_set<string> userswithscores;
 		float currentrate = GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate;
 		for (auto& zoop : p->athing) {
 			if (lround(zoop.GetMusicRate() * 10000.f) != lround(currentrate * 10000.f) && p->currentrateonly)
 				continue;
+			if (userswithscores.count(zoop.GetName()) == 1 && p->topscoresonly)
+				continue;
 			wot.push_back(&zoop);
+			userswithscores.emplace(zoop.GetName());
 		}
 		LuaHelpers::CreateTableFromArray(wot, L);
 		return 1;
@@ -1803,6 +1808,14 @@ public:
 	}
 	static int GetCurrentRateFilter(T* p, lua_State* L) {
 		lua_pushboolean(L, p->currentrateonly);
+		return 1;
+	}
+	static int ToggleTopScoresOnlyFilter(T* p, lua_State* L) {
+		p->topscoresonly = !p->topscoresonly;
+		return 0;
+	}
+	static int GetTopScoresOnlyFilter(T* p, lua_State* L) {
+		lua_pushboolean(L, p->topscoresonly);
 		return 1;
 	}
 
@@ -1828,6 +1841,8 @@ public:
 		ADD_METHOD(RequestChartLeaderBoard);
 		ADD_METHOD(ToggleRateFilter);
 		ADD_METHOD(GetCurrentRateFilter);
+		ADD_METHOD(ToggleTopScoresOnlyFilter);
+		ADD_METHOD(GetTopScoresOnlyFilter);
 		ADD_METHOD(Logout);
 	}
 };

--- a/src/DownloadManager.cpp
+++ b/src/DownloadManager.cpp
@@ -1077,7 +1077,7 @@ void DownloadManager::RequestChartLeaderBoard(string chartkey)
 	auto done = [chartkey](HTTPRequest& req, CURLMsg *) {
 		vector<OnlineScore> & vec = DLMAN->chartLeaderboards[chartkey];
 		vec.clear();
-		unordered_set<string> userswithscores;
+		//unordered_set<string> userswithscores;
 		Message msg("ChartLeaderboardUpdate");
 		try {
 			auto j = json::parse(req.result);
@@ -1145,7 +1145,7 @@ void DownloadManager::RequestChartLeaderBoard(string chartkey)
 				//if (userswithscores.count(tmp.username) == 1)
 				//	continue;
 
-				userswithscores.emplace(tmp.username);
+				//userswithscores.emplace(tmp.username);
 				vec.emplace_back(tmp);
 			}
 		}

--- a/src/DownloadManager.h
+++ b/src/DownloadManager.h
@@ -213,6 +213,7 @@ public:
 	void MakeAThing(string chartkey);
 	vector<HighScore> athing;
 	bool currentrateonly = false;
+	bool topscoresonly = true;
 	void RequestChartLeaderBoard(string chartkey);
 	void RefreshUserData();
 	void RefreshUserRank();


### PR DESCRIPTION
Originally, only top scores were being shown. This means that nobody could have a score on the leaderboard twice. I added a toggle between top scores and all scores like how EO does it. The default behavior is exactly the same as before, where it only shows top scores. Clicking the top scores toggle changes it to all scores, allowing duplicate entries on the leaderboard.

This was done by moving the lines referenced in #237 to the Lua call. Now, the original function just builds the entire list of scores. This doesn't seem to change anything negatively.
Added 2 Lua functions to DLMAN: GetTopScoresOnlyFilter and ToggleTopScoresOnlyFilter.

Fixes #237 by proxy since the Lua was using the chopped up lists that were built before.