### PR TITLE
Fix and Improve a lot of Replay things; Fix some minor theme stuff

### DIFF
--- a/Themes/Til Death/BGAnimations/ScreenEvaluation decorations/default.lua
+++ b/Themes/Til Death/BGAnimations/ScreenEvaluation decorations/default.lua
@@ -373,7 +373,7 @@ function scoreBoard(pn,position)
 				self:queuecommand("Set")
 			end,
 			SetCommand=function(self) 
-				self:settextf("%03d/%03d",score:GetRadarValues():GetValue("RadarCategory_"..fart[i]),pss:GetRadarPossible():GetValue("RadarCategory_"..fart[i]))
+				self:settextf("%03d/%03d",pss:GetRadarActual():GetValue("RadarCategory_"..fart[i]),pss:GetRadarPossible():GetValue("RadarCategory_"..fart[i]))
 			end,
 			ScoreChangedMessageCommand = function(self) self:queuecommand("Set"); end,
 		};

--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/score.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/score.lua
@@ -507,7 +507,7 @@ t[#t+1] = LoadFont("Common Normal")..{
 t[#t+1] = LoadFont("Common Normal")..{
 	Name="ReplayViewer",
 	InitCommand=function(self)
-		self:y(frameHeight-headeroffY - 30 - offsetY):zoom(0.5):halign(-2):settext("")
+		self:xy((frameWidth-offsetX- frameX)/2 + 25,frameHeight-headeroffY - 30 - offsetY):zoom(0.5):halign(1):settext("")
 	end,
 	DisplayCommand=function(self)
 		if score:HasReplayData() then 
@@ -530,7 +530,7 @@ t[#t+1] = LoadFont("Common Normal")..{
 t[#t+1] = LoadFont("Common Normal")..{
 	Name="EvalViewer",
 	InitCommand=function(self)
-		self:y(frameHeight-headeroffY - 30 - offsetY):zoom(0.5):halign(-3):settext("")
+		self:xy(frameWidth-offsetX- frameX,frameHeight-headeroffY - 30 - offsetY):zoom(0.5):halign(1):settext("")
 	end,
 	DisplayCommand=function(self)
 		if score:HasReplayData() then 

--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/score.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/score.lua
@@ -565,7 +565,7 @@ function nestedTabButton(i)
   return  
   Def.ActorFrame{
     InitCommand=function(self) 
-      self:xy(frameX + offsetX + (i-1)*(nestedTabButtonWidth), frameY + headeroffY)
+      self:xy(frameX + offsetX + (i-1)*(nestedTabButtonWidth-80), frameY + headeroffY)
 	  self:SetUpdateFunction(highlight)
     end, 
 	CollapseCommand=function(self)
@@ -576,7 +576,7 @@ function nestedTabButton(i)
 	end,
     LoadFont("Common normal") .. { 
       InitCommand=function(self) 
-        self:diffuse(getMainColor('positive')):maxwidth(nestedTabButtonWidth):maxheight(40):zoom(0.75):settext(nestedTabs[i]):halign(0)
+        self:diffuse(getMainColor('positive')):maxwidth(nestedTabButtonWidth-80):maxheight(40):zoom(0.75):settext(nestedTabs[i]):halign(0)
       end, 
 	  HighlightCommand=function(self)
 		if isOver(self) and nestedTab ~= i then

--- a/src/DownloadManager.cpp
+++ b/src/DownloadManager.cpp
@@ -574,8 +574,12 @@ void DownloadManager::UpdatePacks(float fDeltaSeconds)
 			}
 		}
 	}
-	if(finishedADownload)
+	if (finishedADownload)
+	{
 		UpdateDLSpeed();
+		if (downloads.empty())
+			MESSAGEMAN->Broadcast("AllDownloadsCompleted");
+	}
 	if (installedPacks) {
 		auto screen = SCREENMAN->GetScreen(0);
 		if (screen && screen->GetName() == "ScreenSelectMusic")

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -2746,6 +2746,8 @@ static const Game *g_Games[] =
 
 GameManager::GameManager()
 {
+	m_bSetSongRateInEvalScreen = false;
+	m_fPreviousRate = 1.f;
 	// Register with Lua.
 	{
 		Lua *L = LUA->Get();

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -2746,8 +2746,9 @@ static const Game *g_Games[] =
 
 GameManager::GameManager()
 {
-	m_bSetSongRateInEvalScreen = false;
+	m_bResetModifiers = false;
 	m_fPreviousRate = 1.f;
+	m_sModsToReset;
 	// Register with Lua.
 	{
 		Lua *L = LUA->Get();

--- a/src/GameManager.h
+++ b/src/GameManager.h
@@ -49,6 +49,9 @@ public:
 	const Style* GameAndStringToStyle( const Game* pGame, const RString &sStyle );
 	RString StyleToLocalizedString( const Style* s );
 
+	bool m_bSetSongRateInEvalScreen;
+	float m_fPreviousRate;
+
 
 	// Lua
 	void PushSelf( lua_State *L );

--- a/src/GameManager.h
+++ b/src/GameManager.h
@@ -49,8 +49,9 @@ public:
 	const Style* GameAndStringToStyle( const Game* pGame, const RString &sStyle );
 	RString StyleToLocalizedString( const Style* s );
 
-	bool m_bSetSongRateInEvalScreen;
+	bool m_bResetModifiers;
 	float m_fPreviousRate;
+	RString m_sModsToReset;
 
 
 	// Lua

--- a/src/HighScore.cpp
+++ b/src/HighScore.cpp
@@ -748,14 +748,15 @@ bool HighScore::LoadReplayDataFull() {
 
 		if (tokens[0] == "H") {
 			HoldReplayResult hrr;
-			hrr.row = std::stoi(tokens[0]);
-			hrr.track = std::stoi(tokens[1]);
-			tmp = tokens.size() > 2 ? ::stoi(tokens[2]) : TapNoteSubType_Hold;
+			hrr.row = std::stoi(tokens[1]);
+			hrr.track = std::stoi(tokens[2]);
+			tmp = tokens.size() > 3 ? ::stoi(tokens[3]) : TapNoteSubType_Hold;
 			if (tmp < 0 || tmp >= NUM_TapNoteSubType || !(typeid(tmp) == typeid(int))) {
 				LOG->Warn("Failed to load replay data at %s (\"Tapnotesubtype value is not of type TapNoteSubType\")", path.c_str());
 			}
 			hrr.subType = static_cast<TapNoteSubType>(tmp);
 			vHoldReplayDataVector.emplace_back(hrr);
+			tokens.clear();
 			continue;
 		}
 		noteRow = std::stoi(tokens[0]);

--- a/src/NoteDataWithScoring.cpp
+++ b/src/NoteDataWithScoring.cpp
@@ -7,6 +7,7 @@
 #include "PlayerStageStats.h"
 #include "ThemeMetric.h"
 #include "TimingData.h"
+#include "GamePreferences.h"
 
 namespace
 {
@@ -21,36 +22,62 @@ int LastTapNoteScoreTrack( const NoteData &in, unsigned iRow, PlayerNumber pn )
 {
 	float scoretime = -9999;
 	int best_track = -1;
-	for( int t=0; t<in.GetNumTracks(); t++ )
+	if (GamePreferences::m_AutoPlay == PC_REPLAY)
 	{
-		/* Skip empty tracks and mines */
-		const TapNote &tn = in.GetTapNote( t, iRow );
-		if (tn.type == TapNoteType_Empty ||
-			tn.type == TapNoteType_Mine ||
-			tn.type == TapNoteType_Fake ||
-			tn.type == TapNoteType_AutoKeysound) 
-			continue;
-		if( tn.pn != PLAYER_INVALID && tn.pn != pn && pn != PLAYER_INVALID )
-			continue;
-
-		TapNoteScore tns = tn.result.tns;
-		
-		if ( tns == TNS_Miss || (!GAMESTATE->CountNotesSeparately() && tns == TNS_None) )
+		// In replay mode, judging misses as the "last" tap of every single row breaks judge counting.
+		// Since we judge left to right in Replay, we just check to see which track was last judged.
+		for (int t = in.GetNumTracks() - 1; t >= 0; t--)
 		{
+			const TapNote &tn = in.GetTapNote(t, iRow);
+			if (tn.type == TapNoteType_Empty ||
+				tn.type == TapNoteType_Mine ||
+				tn.type == TapNoteType_Fake ||
+				tn.type == TapNoteType_AutoKeysound)
+				continue;
+			if (tn.pn != PLAYER_INVALID && tn.pn != pn && pn != PLAYER_INVALID)
+				continue;
+
+			TapNoteScore tns = tn.result.tns;
+			if (tns == TNS_None)
+				continue;
+			best_track = t;
 			return t;
 		}
-		if ( tns == TNS_None )
-			continue;
+		return best_track;
+	}
+	else
+	{
+		for( int t=0; t<in.GetNumTracks(); t++ )
+		{
+			/* Skip empty tracks and mines */
+			const TapNote &tn = in.GetTapNote( t, iRow );
+			if (tn.type == TapNoteType_Empty ||
+				tn.type == TapNoteType_Mine ||
+				tn.type == TapNoteType_Fake ||
+				tn.type == TapNoteType_AutoKeysound) 
+				continue;
+			if( tn.pn != PLAYER_INVALID && tn.pn != pn && pn != PLAYER_INVALID )
+				continue;
+
+			TapNoteScore tns = tn.result.tns;
+		
+			if ( tns == TNS_Miss || (!GAMESTATE->CountNotesSeparately() && tns == TNS_None) )
+			{
+				return t;
+			}
+			if ( tns == TNS_None )
+				continue;
 			
 
-		float tm = tn.result.fTapNoteOffset;
-		if(tm < scoretime) continue;
+			float tm = tn.result.fTapNoteOffset;
+			if(tm < scoretime) continue;
 
-		scoretime = tm;
-		best_track = t;
+			scoretime = tm;
+			best_track = t;
+		}
+
+		return best_track;
 	}
-
-	return best_track;
 }
 
 /* Return the minimum tap score of a row: the lowest grade of the tap in the row.

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -2195,7 +2195,7 @@ void Player::Step( int col, int row, const std::chrono::steady_clock::time_point
 				}
 				else // every other case
 				{
-					if (pTN->IsNote())
+					if (pTN->IsNote() || pTN->type == TapNoteType_Lift)
 						score = PlayerAI::GetTapNoteScoreForReplay(m_pPlayerState, fNoteOffset);
 				}
 			}

--- a/src/PlayerAI.cpp
+++ b/src/PlayerAI.cpp
@@ -267,6 +267,11 @@ float PlayerAI::GetTapNoteOffsetForReplay(TapNote* pTN, int noteRow, int col)
 				{
 					if (trr.type == TapNoteType_Mine) // hack for mines
 						return -2.f;
+					if (pTN->type == TapNoteType_Lift)
+					{
+						if (trr.type != TapNoteType_Lift)
+							continue;
+					}
 					return -trr.offset;
 				}
 			}

--- a/src/ScreenEvaluation.cpp
+++ b/src/ScreenEvaluation.cpp
@@ -219,8 +219,14 @@ void ScreenEvaluation::Init()
 	}
 
 	// update persistent statistics
-	if( SUMMARY && GamePreferences::m_AutoPlay != PC_REPLAY)
-		m_pStageStats->FinalizeScores( true );
+	if (SUMMARY && GamePreferences::m_AutoPlay == PC_REPLAY)
+	{
+		m_pStageStats->m_player[PLAYER_1].m_HighScore.SetRadarValues(m_pStageStats->m_player[PLAYER_1].m_radarActual);
+	}
+	else if (SUMMARY && GamePreferences::m_AutoPlay != PC_REPLAY)
+	{
+		m_pStageStats->FinalizeScores(true);
+	}
 
 	// Run this here, so STATSMAN->m_CurStageStats is available to overlays.
 	ScreenWithMenuElements::Init();

--- a/src/ScreenEvaluation.cpp
+++ b/src/ScreenEvaluation.cpp
@@ -768,6 +768,7 @@ void ScreenEvaluation::HandleMenuStart()
 		GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate = oldRate;
 		GAMESTATE->m_SongOptions.GetPreferred().m_fMusicRate = oldRate;
 		GAMEMAN->m_bResetModifiers = false;
+		GAMEMAN->m_sModsToReset = "";
 		MESSAGEMAN->Broadcast("RateChanged");
 	}
 	StartTransitioningScreen( SM_GoToNextScreen );

--- a/src/ScreenEvaluation.cpp
+++ b/src/ScreenEvaluation.cpp
@@ -754,6 +754,16 @@ void ScreenEvaluation::HandleMenuStart()
 	stepsid.FromSteps(GAMESTATE->m_pCurSteps[PLAYER_1]);
 	SongID songid;
 	songid.FromSong(GAMESTATE->m_pCurSong);
+	if (GAMEMAN->m_bSetSongRateInEvalScreen)
+	{
+		float oldRate = GAMEMAN->m_fPreviousRate;
+		GAMESTATE->m_SongOptions.GetSong().m_fMusicRate = oldRate;
+		GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate = oldRate;
+		GAMESTATE->m_SongOptions.GetPreferred().m_fMusicRate = oldRate;
+		GAMEMAN->m_bSetSongRateInEvalScreen = false;
+		MESSAGEMAN->Broadcast("RateChanged");
+
+	}
 	StartTransitioningScreen( SM_GoToNextScreen );
 }
 

--- a/src/ScreenEvaluation.cpp
+++ b/src/ScreenEvaluation.cpp
@@ -754,15 +754,21 @@ void ScreenEvaluation::HandleMenuStart()
 	stepsid.FromSteps(GAMESTATE->m_pCurSteps[PLAYER_1]);
 	SongID songid;
 	songid.FromSong(GAMESTATE->m_pCurSong);
-	if (GAMEMAN->m_bSetSongRateInEvalScreen)
+	if (GAMEMAN->m_bResetModifiers)
 	{
 		float oldRate = GAMEMAN->m_fPreviousRate;
+		const RString mods = GAMEMAN->m_sModsToReset;
+		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetSong().FromString("clearall");
+		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetCurrent().FromString("clearall");
+		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetPreferred().FromString("clearall");
+		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetSong().FromString(mods);
+		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetCurrent().FromString(mods);
+		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetPreferred().FromString(mods);
 		GAMESTATE->m_SongOptions.GetSong().m_fMusicRate = oldRate;
 		GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate = oldRate;
 		GAMESTATE->m_SongOptions.GetPreferred().m_fMusicRate = oldRate;
-		GAMEMAN->m_bSetSongRateInEvalScreen = false;
+		GAMEMAN->m_bResetModifiers = false;
 		MESSAGEMAN->Broadcast("RateChanged");
-
 	}
 	StartTransitioningScreen( SM_GoToNextScreen );
 }

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -1599,6 +1599,7 @@ void ScreenGameplay::Update( float fDeltaTime )
 							GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate = oldRate;
 							GAMESTATE->m_SongOptions.GetPreferred().m_fMusicRate = oldRate;
 							GAMEMAN->m_bResetModifiers = false;
+							GAMEMAN->m_sModsToReset = "";
 							MESSAGEMAN->Broadcast("RateChanged");
 						}
 						GamePreferences::m_AutoPlay.Set(PC_HUMAN);
@@ -1910,6 +1911,7 @@ bool ScreenGameplay::Input( const InputEventPlus &input )
 						GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate = oldRate;
 						GAMESTATE->m_SongOptions.GetPreferred().m_fMusicRate = oldRate;
 						GAMEMAN->m_bResetModifiers = false;
+						GAMEMAN->m_sModsToReset = "";
 						MESSAGEMAN->Broadcast("RateChanged");
 					}
 					GamePreferences::m_AutoPlay.Set(PC_HUMAN);

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -9,6 +9,7 @@
 #include "Foreground.h"
 #include "Game.h"
 #include "GameConstantsAndTypes.h"
+#include "GameManager.h"
 #include "GamePreferences.h"
 #include "GameSoundManager.h"
 #include "GameState.h"
@@ -1583,7 +1584,25 @@ void ScreenGameplay::Update( float fDeltaTime )
 				if(GIVING_UP_GOES_TO_PREV_SCREEN && !m_skipped_song)
 				{
 					if (GamePreferences::m_AutoPlay == PC_REPLAY)
+					{
+						if (GAMEMAN->m_bResetModifiers)
+						{
+							float oldRate = GAMEMAN->m_fPreviousRate;
+							const RString mods = GAMEMAN->m_sModsToReset;
+							GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetSong().FromString("clearall");
+							GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetCurrent().FromString("clearall");
+							GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetPreferred().FromString("clearall");
+							GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetSong().FromString(mods);
+							GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetCurrent().FromString(mods);
+							GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetPreferred().FromString(mods);
+							GAMESTATE->m_SongOptions.GetSong().m_fMusicRate = oldRate;
+							GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate = oldRate;
+							GAMESTATE->m_SongOptions.GetPreferred().m_fMusicRate = oldRate;
+							GAMEMAN->m_bResetModifiers = false;
+							MESSAGEMAN->Broadcast("RateChanged");
+						}
 						GamePreferences::m_AutoPlay.Set(PC_HUMAN);
+					}
 					BeginBackingOutFromGameplay();
 				}
 				else
@@ -1876,7 +1895,25 @@ bool ScreenGameplay::Input( const InputEventPlus &input )
 			{
 				LOG->Trace("Player %i went back", input.pn+1);
 				if (GamePreferences::m_AutoPlay == PC_REPLAY)
+				{
+					if (GAMEMAN->m_bResetModifiers)
+					{
+						float oldRate = GAMEMAN->m_fPreviousRate;
+						const RString mods = GAMEMAN->m_sModsToReset;
+						GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetSong().FromString("clearall");
+						GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetCurrent().FromString("clearall");
+						GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetPreferred().FromString("clearall");
+						GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetSong().FromString(mods);
+						GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetCurrent().FromString(mods);
+						GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetPreferred().FromString(mods);
+						GAMESTATE->m_SongOptions.GetSong().m_fMusicRate = oldRate;
+						GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate = oldRate;
+						GAMESTATE->m_SongOptions.GetPreferred().m_fMusicRate = oldRate;
+						GAMEMAN->m_bResetModifiers = false;
+						MESSAGEMAN->Broadcast("RateChanged");
+					}
 					GamePreferences::m_AutoPlay.Set(PC_HUMAN);
+				}
 				BeginBackingOutFromGameplay();
 			}
 			else if( PREFSMAN->m_bDelayedBack && input.type==IET_FIRST_PRESS )

--- a/src/ScreenInstallOverlay.cpp
+++ b/src/ScreenInstallOverlay.cpp
@@ -160,8 +160,7 @@ void ScreenInstallOverlay::Update(float fDeltaTime)
 			msg.SetParam("queuedpacks", RString(""));
 		}
 		MESSAGEMAN->Broadcast(msg);
-	} else
-		MESSAGEMAN->Broadcast("AllDownloadsCompleted");		// silly to handle this through updates but im not sure where is better atm -mina
+	}
 #endif
 }
 

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -1878,14 +1878,20 @@ public:
 
 		// set the heck out of the current rate to make sure everything runs correctly
 		float scoreRate = hs->GetMusicRate();
+		float oldRate = GAMESTATE->m_SongOptions.GetPreferred().m_fMusicRate;
 		GAMESTATE->m_SongOptions.GetSong().m_fMusicRate = scoreRate;
 		GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate = scoreRate;
 		GAMESTATE->m_SongOptions.GetPreferred().m_fMusicRate = scoreRate;
 		MESSAGEMAN->Broadcast("RateChanged");
 
 		// lock the game into replay mode and GO
+		LOG->Trace("Viewing replay for score key %s", hs->GetScoreKey());
 		GamePreferences::m_AutoPlay.Set(PC_REPLAY);
 		p->SelectCurrent(PLAYER_1);
+
+		// set rate back to what it was before
+		GAMEMAN->m_bSetSongRateInEvalScreen = true;
+		GAMEMAN->m_fPreviousRate = oldRate;
 		return 1;
 	}
 
@@ -1931,13 +1937,20 @@ public:
 		// this might confuse the player after leaving eval screen because of the new rate
 		// but whatever, for now
 		float scoreRate = hs->GetMusicRate();
+		float oldRate = GAMESTATE->m_SongOptions.GetPreferred().m_fMusicRate;
 		GAMESTATE->m_SongOptions.GetSong().m_fMusicRate = scoreRate;
 		GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate = scoreRate;
 		GAMESTATE->m_SongOptions.GetPreferred().m_fMusicRate = scoreRate;
 		MESSAGEMAN->Broadcast("RateChanged");
 
 		// go
+		LOG->Trace("Viewing evaluation screen for score key %s", score->GetScoreKey());
 		SCREENMAN->SetNewScreen("ScreenEvaluationNormal");
+
+		// set rate back to what it was before
+		GAMEMAN->m_bSetSongRateInEvalScreen = true;
+		GAMEMAN->m_fPreviousRate = oldRate;
+
 		return 1;
 	}
 	

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -40,6 +40,7 @@
 #include "DownloadManager.h"
 #include "GamePreferences.h"
 #include "PlayerAI.h"
+#include "PlayerOptions.h"
 
 static const char *SelectionStateNames[] = {
 	"SelectingSong",
@@ -1925,6 +1926,7 @@ public:
 		auto& pss = ss.m_player[0];
 		pss.m_HighScore = *score;
 		pss.CurWifeScore = score->GetWifeScore();
+		pss.m_fWifeScore = score->GetWifeScore();
 		pss.m_vNoteRowVector = score->GetNoteRowVector();
 		pss.m_vOffsetVector = score->GetOffsetVector();
 		pss.m_vTapNoteTypeVector = score->GetTapNoteTypeVector();
@@ -1933,7 +1935,6 @@ public:
 		pss.m_iSongsPassed = 1;
 		pss.m_iSongsPlayed = 1;
 		pss.everusedautoplay = true;
-		hs->SetRadarValues(pss.m_radarActual);
 		for (int i = TNS_Miss; i<NUM_TapNoteScore; i++)
 		{
 			pss.m_iTapNoteScores[i] = score->GetTapNoteScore((TapNoteScore)i);
@@ -1947,8 +1948,6 @@ public:
 		STATSMAN->m_vPlayedStageStats.emplace_back(ss);
 
 		// set the rate so the MSD and rate display doesnt look weird
-		// this might confuse the player after leaving eval screen because of the new rate
-		// but whatever, for now
 		float scoreRate = hs->GetMusicRate();
 		float oldRate = GAMESTATE->m_SongOptions.GetPreferred().m_fMusicRate;
 		GAMESTATE->m_SongOptions.GetSong().m_fMusicRate = scoreRate;
@@ -1961,7 +1960,7 @@ public:
 		SCREENMAN->SetNewScreen("ScreenEvaluationNormal");
 
 		// set rate back to what it was before
-		GAMEMAN->m_bSetSongRateInEvalScreen = true;
+		GAMEMAN->m_bResetModifiers = true;
 		GAMEMAN->m_fPreviousRate = oldRate;
 
 		return 1;

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -1910,6 +1910,7 @@ public:
 		{
 			pss.m_iHoldNoteScores[i] = score->GetHoldNoteScore((HoldNoteScore)i);
 		}
+		ss.m_vpPlayedSongs.emplace_back(GAMESTATE->m_pCurSong);
 		STATSMAN->m_CurStageStats = ss;
 		STATSMAN->m_vPlayedStageStats.emplace_back(ss);
 		SCREENMAN->SetNewScreen("ScreenEvaluationNormal");

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -1902,6 +1902,7 @@ public:
 		pss.m_iSongsPassed = 1;
 		pss.m_iSongsPlayed = 1;
 		pss.everusedautoplay = true;
+		hs->SetRadarValues(pss.m_radarActual);
 		for (int i = TNS_Miss; i<NUM_TapNoteScore; i++)
 		{
 			pss.m_iTapNoteScores[i] = score->GetTapNoteScore((TapNoteScore)i);

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -1876,6 +1876,9 @@ public:
 		HighScore* hs = Luna<HighScore>::check(L, 1);
 		PlayerAI::SetScoreData(hs);
 
+		// prepare old mods to return to
+		const RString oldMods = GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetCurrent().GetString();
+
 		// set the heck out of the current rate to make sure everything runs correctly
 		float scoreRate = hs->GetMusicRate();
 		float oldRate = GAMESTATE->m_SongOptions.GetPreferred().m_fMusicRate;
@@ -1884,14 +1887,24 @@ public:
 		GAMESTATE->m_SongOptions.GetPreferred().m_fMusicRate = scoreRate;
 		MESSAGEMAN->Broadcast("RateChanged");
 
+		// set mods based on the score, hopefully
+		// it is known that xmod->cmod and back does not work most of the time.
+		CHECKPOINT_M("Setting mods for Replay Viewing.");
+		RString mods = hs->GetModifiers();
+		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetSong().FromString(mods);
+		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetCurrent().FromString(mods);
+		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetPreferred().FromString(mods);
+		CHECKPOINT_M("Replay mods set.");
+
 		// lock the game into replay mode and GO
 		LOG->Trace("Viewing replay for score key %s", hs->GetScoreKey());
 		GamePreferences::m_AutoPlay.Set(PC_REPLAY);
 		p->SelectCurrent(PLAYER_1);
 
-		// set rate back to what it was before
-		GAMEMAN->m_bSetSongRateInEvalScreen = true;
+		// set mods back to what they were before
+		GAMEMAN->m_bResetModifiers = true;
 		GAMEMAN->m_fPreviousRate = oldRate;
+		GAMEMAN->m_sModsToReset = oldMods;
 		return 1;
 	}
 


### PR DESCRIPTION
Replay features and fixes:
1. Judge counts are less wrong and misses wont overcount and kill you for no reason
2. Opening the eval screen and then doing literally anything doesn't crash anymore
3. Radar values aren't negative (or shouldn't be.)
4. Lifts work in replays. Osu support.
5. Rate display in eval screen and thus, bpm display in replay gameplay is fixed.
6. Rate resets back to what it was before entering a replay if it was different.
7. Replays try to load the modifiers you had set on the score. For some reason, cmod->xmod doesn't work. The modifiers should unload after the replay.
8. Moved buttons around in the score tab due to overlap on smaller aspect ratios.

Less buggy in general, I would say. Shuffle or Turn replays are going to be broken until we care enough to deal with them. They still run, they just fail. Less/no crashing at all.