### PR TITLE
Add scrolling to replays

### DIFF
--- a/Themes/Til Death/BGAnimations/ScreenGameplay overlay/default.lua
+++ b/Themes/Til Death/BGAnimations/ScreenGameplay overlay/default.lua
@@ -2,7 +2,6 @@
 local t = Def.ActorFrame{}
 t[#t+1] = LoadActor("WifeJudgmentSpotting")
 t[#t+1] = LoadActor("titlesplash")
-SCREENMAN:SystemMessage( GAMESTATE:GetPlayerState(PLAYER_1):GetPlayerController() )
 if GAMESTATE:GetPlayerState(PLAYER_1):GetPlayerController() == "PlayerController_Replay" then
 	t[#t+1] = LoadActor("replayscrolling")
 end

--- a/Themes/Til Death/BGAnimations/ScreenGameplay overlay/default.lua
+++ b/Themes/Til Death/BGAnimations/ScreenGameplay overlay/default.lua
@@ -2,4 +2,8 @@
 local t = Def.ActorFrame{}
 t[#t+1] = LoadActor("WifeJudgmentSpotting")
 t[#t+1] = LoadActor("titlesplash")
+SCREENMAN:SystemMessage( GAMESTATE:GetPlayerState(PLAYER_1):GetPlayerController() )
+if GAMESTATE:GetPlayerState(PLAYER_1):GetPlayerController() == "PlayerController_Replay" then
+	t[#t+1] = LoadActor("replayscrolling")
+end
 return t

--- a/Themes/Til Death/BGAnimations/ScreenGameplay overlay/replayscrolling.lua
+++ b/Themes/Til Death/BGAnimations/ScreenGameplay overlay/replayscrolling.lua
@@ -71,8 +71,9 @@ scroller = Def.ActorFrame {
 	end,
 	ReplayRateCommand = function(self)
 		newrate = getNewRate()
-		realnewrate = notShit.round(SCREENMAN:GetTopScreen():SetReplayRate( newrate ), 3)
-		if realnewrate ~= nil then
+		givenrate = SCREENMAN:GetTopScreen():SetReplayRate( newrate )
+		if givenrate ~= nil then
+			realnewrate = notShit.round(givenrate, 3)
 			SCREENMAN:SystemMessage(string.format("Set rate to %f", realnewrate))
 		end
 	end,

--- a/Themes/Til Death/BGAnimations/ScreenGameplay overlay/replayscrolling.lua
+++ b/Themes/Til Death/BGAnimations/ScreenGameplay overlay/replayscrolling.lua
@@ -1,8 +1,6 @@
 local modifierPressed = false
 local forward = true
 
-local queuecommand = Actor.queuecommand
-
 local scroller -- just an alias for the actor that runs the commands
 
 local function input(event)
@@ -28,6 +26,8 @@ local function input(event)
 			else
 				scroller:queuecommand("ReplayScroll")
 			end
+		elseif event.GameButton == "Coin" then
+			scroller:queuecommand("ReplayPauseToggle")
 		end
 	end
 end
@@ -40,7 +40,7 @@ local function getNewSongPos()
 end
 
 local function getNewRate()
-	currentrate = getCurRateValue()
+	currentrate = GAMESTATE:GetSongOptionsObject('ModsLevel_Preferred'):MusicRate()
 	newrate = currentrate + (modifierPressed and 0.05 or 0.1) * (forward and 1 or -1)
 	SCREENMAN:SystemMessage(string.format("%f to %f", currentrate, newrate))
 	return newrate
@@ -61,6 +61,9 @@ scroller = Def.ActorFrame {
 	ReplayRateCommand = function(self)
 		newrate = getNewRate()
 		SCREENMAN:GetTopScreen():SetReplayRate( newrate )
+	end,
+	ReplayPauseToggleCommand = function(self)
+		SCREENMAN:GetTopScreen():ToggleReplayPause()
 	end
 	
 

--- a/Themes/Til Death/BGAnimations/ScreenGameplay overlay/replayscrolling.lua
+++ b/Themes/Til Death/BGAnimations/ScreenGameplay overlay/replayscrolling.lua
@@ -35,14 +35,14 @@ end
 local function getNewSongPos()
 	currentpos = SCREENMAN:GetTopScreen():GetSongPosition()
 	newpos = currentpos + (modifierPressed and 0.1 or 5) * (forward and 1 or -1)
-	SCREENMAN:SystemMessage(string.format("%f to %f", currentpos, newpos))
+	--SCREENMAN:SystemMessage(string.format("%f to %f", currentpos, newpos))
 	return newpos
 end
 
 local function getNewRate()
 	currentrate = GAMESTATE:GetSongOptionsObject('ModsLevel_Preferred'):MusicRate()
 	newrate = currentrate + (modifierPressed and 0.05 or 0.1) * (forward and 1 or -1)
-	SCREENMAN:SystemMessage(string.format("%f to %f", currentrate, newrate))
+	--SCREENMAN:SystemMessage(string.format("%f to %f", currentrate, newrate))
 	return newrate
 end
 
@@ -60,7 +60,10 @@ scroller = Def.ActorFrame {
 	end,
 	ReplayRateCommand = function(self)
 		newrate = getNewRate()
-		SCREENMAN:GetTopScreen():SetReplayRate( newrate )
+		realnewrate = notShit.round(SCREENMAN:GetTopScreen():SetReplayRate( newrate ), 3)
+		if realnewrate ~= nil then
+			SCREENMAN:SystemMessage(string.format("Set rate to %f", realnewrate))
+		end
 	end,
 	ReplayPauseToggleCommand = function(self)
 		SCREENMAN:GetTopScreen():ToggleReplayPause()

--- a/Themes/Til Death/BGAnimations/ScreenGameplay overlay/replayscrolling.lua
+++ b/Themes/Til Death/BGAnimations/ScreenGameplay overlay/replayscrolling.lua
@@ -1,0 +1,68 @@
+local modifierPressed = false
+local forward = true
+
+local queuecommand = Actor.queuecommand
+
+local scroller -- just an alias for the actor that runs the commands
+
+local function input(event)
+	--SCREENMAN:SystemMessage(event.DeviceInput.button)
+	if event.DeviceInput.button == "DeviceButton_right ctrl" or event.DeviceInput.button == "DeviceButton_left ctrl" then
+		modifierPressed = not (event.type == "InputEventType_Release")
+	end
+	if event.DeviceInput.button == "DeviceButton_right shift" or event.DeviceInput.button == "DeviceButton_left shift" then
+		ratePressed = not (event.type == "InputEventType_Release")
+	end
+	if event.type ~= "InputEventType_Release" then
+		if event.GameButton == "EffectUp" then
+			forward = true
+			if ratePressed then
+				scroller:queuecommand("ReplayRate")
+			else
+				scroller:queuecommand("ReplayScroll")
+			end
+		elseif event.GameButton == "EffectDown" then
+			forward = false
+			if ratePressed then
+				scroller:queuecommand("ReplayRate")
+			else
+				scroller:queuecommand("ReplayScroll")
+			end
+		end
+	end
+end
+
+local function getNewSongPos()
+	currentpos = SCREENMAN:GetTopScreen():GetSongPosition()
+	newpos = currentpos + (modifierPressed and 0.1 or 5) * (forward and 1 or -1)
+	SCREENMAN:SystemMessage(string.format("%f to %f", currentpos, newpos))
+	return newpos
+end
+
+local function getNewRate()
+	currentrate = getCurRateValue()
+	newrate = currentrate + (modifierPressed and 0.05 or 0.1) * (forward and 1 or -1)
+	SCREENMAN:SystemMessage(string.format("%f to %f", currentrate, newrate))
+	return newrate
+end
+
+
+
+scroller = Def.ActorFrame {
+	Name = "ScrollManager",
+	OnCommand = function(self)
+		SCREENMAN:GetTopScreen():AddInputCallback( input )
+		scroller = self
+	end,
+	ReplayScrollCommand = function(self)
+		newpos = getNewSongPos()
+		SCREENMAN:GetTopScreen():SetReplayPosition( newpos )
+	end,
+	ReplayRateCommand = function(self)
+		newrate = getNewRate()
+		SCREENMAN:GetTopScreen():SetReplayRate( newrate )
+	end
+	
+
+}
+return scroller

--- a/Themes/Til Death/BGAnimations/ScreenGameplay overlay/replayscrolling.lua
+++ b/Themes/Til Death/BGAnimations/ScreenGameplay overlay/replayscrolling.lua
@@ -11,8 +11,15 @@ local function input(event)
 	if event.DeviceInput.button == "DeviceButton_right shift" or event.DeviceInput.button == "DeviceButton_left shift" then
 		ratePressed = not (event.type == "InputEventType_Release")
 	end
+	if event.DeviceInput.button == "DeviceButton_right alt" or event.DeviceInput.button == "DeviceButton_left alt" then
+		bookmarkPressed = not (event.type == "InputEventType_Release")
+	end
 	if event.type ~= "InputEventType_Release" then
 		if event.GameButton == "EffectUp" then
+			if bookmarkPressed then
+				scroller:queuecommand("ReplayBookmarkSet")
+				return 0
+			end
 			forward = true
 			if ratePressed then
 				scroller:queuecommand("ReplayRate")
@@ -20,6 +27,10 @@ local function input(event)
 				scroller:queuecommand("ReplayScroll")
 			end
 		elseif event.GameButton == "EffectDown" then
+			if bookmarkPressed then
+				scroller:queuecommand("ReplayBookmarkGoto")
+				return 0
+			end
 			forward = false
 			if ratePressed then
 				scroller:queuecommand("ReplayRate")
@@ -67,6 +78,13 @@ scroller = Def.ActorFrame {
 	end,
 	ReplayPauseToggleCommand = function(self)
 		SCREENMAN:GetTopScreen():ToggleReplayPause()
+	end,
+	ReplayBookmarkSetCommand = function(self)
+		position = SCREENMAN:GetTopScreen():GetSongPosition()
+		SCREENMAN:GetTopScreen():SetReplayBookmark(position)
+	end,
+	ReplayBookmarkGotoCommand = function(self)
+		SCREENMAN:GetTopScreen():JumpToReplayBookmark()
 	end
 	
 

--- a/Themes/_fallback/Scripts/09 SimNSkinPreview.lua
+++ b/Themes/_fallback/Scripts/09 SimNSkinPreview.lua
@@ -2,13 +2,52 @@
 -- @usage LoadNSkinPreview("Get", "Down", "Tap Note");
 -- @module 09_SimNSkinPreview
 
+local function NSkinPreviewChange(Container,Player)
+	return function(event)
+		for i, n in pairs(NOTESKIN:GetNoteSkinNames()) do
+			Container:GetChild("N"..i):visible(false)
+		end
+		for i = 1,SCREENMAN:GetTopScreen():GetNumRows()-1 do
+			if SCREENMAN:GetTopScreen():GetOptionRow(i):GetName() == "NoteSkins" then
+				local nSkin = Container:GetChild("N"..SCREENMAN:GetTopScreen():GetOptionRow(i):GetChoiceInRowWithFocus(Player)+1)
+				nSkin:visible(true)
+			end
+		end
+	end
+end
+
+local function SimChild(Container, Type)
+	local notable,Count
+	local rType = {}
+	local Child = {Container}
+	repeat
+		notable = true
+		Count = Child
+		Child = {}
+		for no in pairs(Count) do
+			if lua.CheckType("ActorFrame",Count[no]) then
+
+				for _, cld in pairs(Count[no]:GetChildren()) do
+					if lua.CheckType("ActorFrame",cld) then
+						notable = false
+						Child[#Child+1] = cld
+					elseif lua.CheckType(Type,cld) then
+						rType[#rType+1] = cld
+					end
+				end
+			end
+		end
+	until notable == true
+	return rType
+end
+
 --- Load a NoteSkin preview actor
 -- @tparam string Noteskin Noteskin name. If "Get" then it does the currently selected noteskin, and updates itself when it changes. Defaults to "Get"
 -- @tparam string Button Ex: "Up". Defaults to "Down"
 -- @tparam string Element Defaults to "Tap Note"
 -- @treturn ActorFrame containing the noteskin preview
 function LoadNSkinPreview(Noteskin, Button, Element)
-	local Player = Player or PLAYER_1
+	local Player = PLAYER_1
 	Noteskin = Noteskin or "Get"
 	Button = Button or "Tap Note"
 	Element = Element or "Down"
@@ -52,44 +91,4 @@ function LoadNSkinPreview(Noteskin, Button, Element)
 	else
 		return NOTESKIN:LoadActorForNoteSkin(Button, Element, NOTESKIN:DoesNoteSkinExist(Noteskin) and Noteskin or "default");	
 	end
-end
-
-local function NSkinPreviewChange(Container,Player)
-	return function(event)
-		for i, n in pairs(NOTESKIN:GetNoteSkinNames()) do
-			Container:GetChild("N"..i):visible(false)
-		end
-		for i = 1,SCREENMAN:GetTopScreen():GetNumRows()-1 do
-			if SCREENMAN:GetTopScreen():GetOptionRow(i):GetName() == "NoteSkins" then
-				local nSkin = Container:GetChild("N"..SCREENMAN:GetTopScreen():GetOptionRow(i):GetChoiceInRowWithFocus(Player)+1)
-				nSkin:visible(true)
-			end
-		end
-	end
-end
-
-
-local function SimChild(Container, Type)
-	local notable,Count
-	local rType = {}
-	local Child = {Container}
-	repeat
-		notable = true
-		Count = Child
-		Child = {}
-		for no in pairs(Count) do
-			if lua.CheckType("ActorFrame",Count[no]) then
-
-				for _, cld in pairs(Count[no]:GetChildren()) do
-					if lua.CheckType("ActorFrame",cld) then
-						notable = false
-						Child[#Child+1] = cld
-					elseif lua.CheckType(Type,cld) then
-						rType[#rType+1] = cld
-					end
-				end
-			end
-		end
-	until notable == true
-	return rType
 end

--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -2,6 +2,7 @@
 #include "Actor.h"
 #include "ActorFrame.h"
 #include "ActorUtil.h"
+#include "GamePreferences.h"
 #include "LuaBinding.h"
 #include "LuaReference.h"
 #include "MessageManager.h"
@@ -925,7 +926,7 @@ void Actor::BeginTweening( float time, ITween *pTween )
 
 	// If the number of tweens to ever gets this large, there's probably an infinitely 
 	// recursing ActorCommand.
-	if( m_Tweens.size() > 50 )
+	if( m_Tweens.size() > 50 && !GamePreferences::m_AutoPlay == PC_REPLAY)
 	{
 		LuaHelpers::ReportScriptErrorFmt("Tween overflow: \"%s\"; infinitely recursing ActorCommand?", GetLineage().c_str());
 		this->FinishTweening();

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -3251,6 +3251,33 @@ void Player::IncrementComboOrMissCombo(bool bComboOrMissCombo)
 		SendComboMessages( iOldCombo, iOldMissCombo );
 }
 
+void Player::RejudgeNoteDataRange(int startRow, int lastRow)
+{
+	NoteData nd = m_NoteData;
+
+	FOREACH_NONEMPTY_ROW_ALL_TRACKS_RANGE(nd, row, startRow, lastRow)
+	{
+		for (int track = 0; track < nd.GetNumTracks(); track++)
+		{
+			TapNote *pTN = NULL;
+			NoteData::iterator iter = nd.FindTapNote(track, row);
+			DEBUG_ASSERT(iter != m_NoteData.end(col));
+			pTN = &iter->second;
+			
+
+			if (pTN->type == TapNoteType_Empty)
+				continue;
+			if (pTN->result.tns != TNS_None)
+			{
+				LOG->Trace("reset note");
+				pTN->Init();
+			}
+		}
+	}
+
+	m_pNoteField->DrawPrimitives();
+}
+
 // lua start
 #include "LuaBinding.h"
 

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -3256,15 +3256,18 @@ void Player::RenderAllNotesIgnoreScores()
 	int firstRow = 0;
 	int lastRow = m_NoteData.GetLastRow() + 1;
 
+	// Go over every single non empty row and their tracks
 	FOREACH_NONEMPTY_ROW_ALL_TRACKS(m_NoteData, row)
 	{
 		for (int track = 0; track < m_NoteData.GetNumTracks(); track++)
 		{
+			// Find the tapnote we are on
 			TapNote *pTN = NULL;
 			NoteData::iterator iter = m_NoteData.FindTapNote(track, row);
 			DEBUG_ASSERT(iter != m_NoteData.end(col));
 			pTN = &iter->second;
-			
+
+			// Reset the score so it can be visible
 			if (iter != m_NoteData.end(track))
 			{
 				if (iter->second.type == TapNoteType_Empty)
@@ -3276,6 +3279,7 @@ void Player::RenderAllNotesIgnoreScores()
 			}
 		}
 	}
+	// Draw the results
 	m_pNoteField->DrawPrimitives();
 }
 

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -3251,30 +3251,31 @@ void Player::IncrementComboOrMissCombo(bool bComboOrMissCombo)
 		SendComboMessages( iOldCombo, iOldMissCombo );
 }
 
-void Player::RejudgeNoteDataRange(int startRow, int lastRow)
+void Player::RenderAllNotesIgnoreScores()
 {
-	NoteData nd = m_NoteData;
+	int firstRow = 0;
+	int lastRow = m_NoteData.GetLastRow() + 1;
 
-	FOREACH_NONEMPTY_ROW_ALL_TRACKS_RANGE(nd, row, startRow, lastRow)
+	FOREACH_NONEMPTY_ROW_ALL_TRACKS(m_NoteData, row)
 	{
-		for (int track = 0; track < nd.GetNumTracks(); track++)
+		for (int track = 0; track < m_NoteData.GetNumTracks(); track++)
 		{
 			TapNote *pTN = NULL;
-			NoteData::iterator iter = nd.FindTapNote(track, row);
+			NoteData::iterator iter = m_NoteData.FindTapNote(track, row);
 			DEBUG_ASSERT(iter != m_NoteData.end(col));
 			pTN = &iter->second;
 			
-
-			if (pTN->type == TapNoteType_Empty)
-				continue;
-			if (pTN->result.tns != TNS_None)
+			if (iter != m_NoteData.end(track))
 			{
-				LOG->Trace("reset note");
-				pTN->Init();
+				if (iter->second.type == TapNoteType_Empty)
+					continue;
+				if (iter->second.type == TapNoteType_HoldHead)
+					iter->second.HoldResult.hns = HNS_None;
+				iter->second.result.bHidden = false;
+				iter->second.result.tns = TNS_None;
 			}
 		}
 	}
-
 	m_pNoteField->DrawPrimitives();
 }
 

--- a/src/Player.h
+++ b/src/Player.h
@@ -118,6 +118,7 @@ public:
 	void SetActorWithComboPosition( Actor *pActor ) { m_pActorWithComboPosition = pActor; }
 
 	void SetSendJudgmentAndComboMessages( bool b ) { m_bSendJudgmentAndComboMessages = b; }
+	void RejudgeNoteDataRange(int startRow, int lastRow);
 
 	// Lua
 	void PushSelf( lua_State *L ) override;

--- a/src/Player.h
+++ b/src/Player.h
@@ -118,7 +118,7 @@ public:
 	void SetActorWithComboPosition( Actor *pActor ) { m_pActorWithComboPosition = pActor; }
 
 	void SetSendJudgmentAndComboMessages( bool b ) { m_bSendJudgmentAndComboMessages = b; }
-	void RejudgeNoteDataRange(int startRow, int lastRow);
+	void RenderAllNotesIgnoreScores();
 
 	// Lua
 	void PushSelf( lua_State *L ) override;

--- a/src/PlayerAI.cpp
+++ b/src/PlayerAI.cpp
@@ -150,6 +150,8 @@ void PlayerAI::SetScoreData(HighScore* pHighScore)
 {
 	pHighScore->LoadReplayData();
 	pScoreData = pHighScore;
+	m_ReplayTapMap.clear();
+	m_ReplayHoldMap.clear();
 	auto replayNoteRowVector = pHighScore->GetCopyOfNoteRowVector();
 	auto replayOffsetVector = pHighScore->GetCopyOfOffsetVector();
 	auto replayTapNoteTypeVector = pHighScore->GetCopyOfTapNoteTypeVector();

--- a/src/ScreenEvaluation.cpp
+++ b/src/ScreenEvaluation.cpp
@@ -758,12 +758,14 @@ void ScreenEvaluation::HandleMenuStart()
 	{
 		float oldRate = GAMEMAN->m_fPreviousRate;
 		const RString mods = GAMEMAN->m_sModsToReset;
+		/* // Reset mods
 		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetSong().FromString("clearall");
 		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetCurrent().FromString("clearall");
 		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetPreferred().FromString("clearall");
 		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetSong().FromString(mods);
 		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetCurrent().FromString(mods);
 		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetPreferred().FromString(mods);
+		*/
 		GAMESTATE->m_SongOptions.GetSong().m_fMusicRate = oldRate;
 		GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate = oldRate;
 		GAMESTATE->m_SongOptions.GetPreferred().m_fMusicRate = oldRate;

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -2879,7 +2879,7 @@ public:
 	}
 	static int JumpToReplayBookmark(T* p, lua_State* L)
 	{
-		if (GamePreferences::m_AutoPlay == PC_REPLAY)
+		if (GamePreferences::m_AutoPlay == PC_REPLAY && GAMESTATE->GetPaused())
 		{
 			p->SetSongPosition(p->m_fReplayBookmarkSeconds);
 			return 1;

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -338,6 +338,7 @@ void ScreenGameplay::Init()
 	GAMESTATE->BeginStage();
 	
 	GAMESTATE->SetPaused(false);
+	m_fReplayBookmarkSeconds = 0.f;
 
 	int player = 1;
 	FOREACH_EnabledPlayerInfo( m_vPlayerInfo, pi )
@@ -2866,6 +2867,25 @@ public:
 		p->ToggleReplayPause();
 		return 1;
 	}
+	static int SetReplayBookmark(T* p, lua_State* L)
+	{
+		float position = FArg(1);
+		if (GamePreferences::m_AutoPlay == PC_REPLAY)
+		{
+			p->m_fReplayBookmarkSeconds = position;
+			return 1;
+		}
+		return 0;
+	}
+	static int JumpToReplayBookmark(T* p, lua_State* L)
+	{
+		if (GamePreferences::m_AutoPlay == PC_REPLAY)
+		{
+			p->SetSongPosition(p->m_fReplayBookmarkSeconds);
+			return 1;
+		}
+		return 0;
+	}
 	
 	LunaScreenGameplay()
 	{
@@ -2881,6 +2901,8 @@ public:
 		ADD_METHOD(SetReplayPosition);
 		ADD_METHOD(SetReplayRate);
 		ADD_METHOD(ToggleReplayPause);
+		ADD_METHOD(SetReplayBookmark);
+		ADD_METHOD(JumpToReplayBookmark);
 	}
 };
 

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -2774,6 +2774,34 @@ public:
 		lua_pushnumber(L, true_bps);
 		return 1;
 	}
+	static int GetSongPosition(T* p, lua_State* L)
+	{
+		float pos = p->GetSongPosition();
+		lua_pushnumber(L, pos);
+		return 1;
+	}
+	static int SetReplayPosition(T* p, lua_State* L)
+	{
+		float newpos = FArg(1);
+		if (GamePreferences::m_AutoPlay != PC_REPLAY)
+		{
+			SCREENMAN->SystemMessage("You cannot move the song position outside of a Replay.");
+			return 0;
+		}
+		p->SetSongPosition(newpos);
+		return 1;
+	}
+	static int SetReplayRate(T* p, lua_State* L)
+	{
+		float newrate = FArg(1);
+		if (GamePreferences::m_AutoPlay != PC_REPLAY)
+		{
+			SCREENMAN->SystemMessage("You cannot change the rate outside of a Replay.");
+			return 0;
+		}
+		p->SetRate(newrate);
+		return 1;
+	}
 	
 	LunaScreenGameplay()
 	{
@@ -2784,6 +2812,9 @@ public:
 		// sm-ssc additions:
 		ADD_METHOD(begin_backing_out);
 		ADD_METHOD( GetTrueBPS );
+		ADD_METHOD(GetSongPosition);
+		ADD_METHOD(SetReplayPosition);
+		ADD_METHOD(SetReplayRate);
 	}
 };
 

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -2538,10 +2538,12 @@ void ScreenGameplay::SaveReplay()
 	}
 }
 
-void ScreenGameplay::SetRate(float newRate)
+float ScreenGameplay::SetRate(float newRate)
 {
+	float rate = GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate;
+
 	if (newRate < 0.3f || newRate > 5.f)
-		return;
+		return rate;
 	bool paused = GAMESTATE->GetPaused();
 	m_pSoundMusic->Stop();
 	RageTimer tm;
@@ -2574,6 +2576,7 @@ void ScreenGameplay::SetRate(float newRate)
 
 	GAMESTATE->m_Position.m_fMusicSeconds = fSeconds;
 	UpdateSongPosition(0);
+	return newRate;
 }
 
 void ScreenGameplay::SetSongPosition(float newPositionSeconds)
@@ -2747,10 +2750,12 @@ void ScreenGameplay::ToggleReplayPause()
 		m_pSoundMusic->Play(false, &p);
 		GAMESTATE->m_Position.m_fMusicSeconds = fSeconds;
 		UpdateSongPosition(0);
+		SCREENMAN->SystemMessage("Unpaused Replay");
 	}
 	else
 	{
 		m_pSoundMusic->Pause(newPause);
+		SCREENMAN->SystemMessage("Paused Replay");
 	}
 	GAMESTATE->SetPaused(newPause);
 
@@ -2871,14 +2876,16 @@ public:
 		if (!GAMESTATE->GetPaused())
 		{
 			SCREENMAN->SystemMessage("You must be paused to change the rate of a Replay.");
+			lua_pushnumber(L, -1.f);
 			return 0;
 		}
 		if (GamePreferences::m_AutoPlay != PC_REPLAY)
 		{
 			SCREENMAN->SystemMessage("You cannot change the rate outside of a Replay.");
+			lua_pushnumber(L, -1.f);
 			return 0;
 		}
-		p->SetRate(newrate);
+		lua_pushnumber(L, p->SetRate(newrate));
 		return 1;
 	}
 	static int ToggleReplayPause(T* p, lua_State* L)

--- a/src/ScreenGameplay.h
+++ b/src/ScreenGameplay.h
@@ -154,6 +154,18 @@ public:
 	void FailFadeRemovePlayer(PlayerInfo* pi);
 	void FailFadeRemovePlayer(PlayerNumber pn);
 	void BeginBackingOutFromGameplay();
+	
+	// Set the playback rate in the middle of gameplay
+	void SetRate(float newRate);
+	// Move the current position of the song in the middle of gameplay
+	void SetSongPosition(float newPositionSeconds);
+	// Get current position of the song during gameplay
+	const float GetSongPosition();
+	// Recalculate the scores for notes we haven't passed yet
+	// This is intended to apply only to replays.
+	// It should only be used if we scroll backwards in time for some reason.
+	void RecalcJudgedNotesForReplay();
+	
 protected:
 	virtual void UpdateStageStats( MultiPlayer /* mp */ ) {};	// overridden for multiplayer
 
@@ -194,6 +206,7 @@ protected:
 	void SendCrossedMessages();
 
 	void PlayTicks();
+	// Used to update some pointers
 	void UpdateSongPosition( float fDeltaTime );
 	void UpdateLyrics( float fDeltaTime );
 	void SongFinished();

--- a/src/ScreenGameplay.h
+++ b/src/ScreenGameplay.h
@@ -165,6 +165,10 @@ public:
 	// This is intended to apply only to replays.
 	// It should only be used if we scroll backwards in time for some reason.
 	void RecalcJudgedNotesForReplay();
+	// Toggle pause. Don't use this outside of replays.
+	// Please.
+	// I'm serious.
+	void ToggleReplayPause();
 	
 protected:
 	virtual void UpdateStageStats( MultiPlayer /* mp */ ) {};	// overridden for multiplayer

--- a/src/ScreenGameplay.h
+++ b/src/ScreenGameplay.h
@@ -165,6 +165,7 @@ public:
 	// Please.
 	// I'm serious.
 	void ToggleReplayPause();
+	float m_fReplayBookmarkSeconds;
 	
 protected:
 	virtual void UpdateStageStats( MultiPlayer /* mp */ ) {};	// overridden for multiplayer

--- a/src/ScreenGameplay.h
+++ b/src/ScreenGameplay.h
@@ -156,7 +156,7 @@ public:
 	void BeginBackingOutFromGameplay();
 	
 	// Set the playback rate in the middle of gameplay
-	void SetRate(float newRate);
+	float SetRate(float newRate);
 	// Move the current position of the song in the middle of gameplay
 	void SetSongPosition(float newPositionSeconds);
 	// Get current position of the song during gameplay

--- a/src/ScreenGameplay.h
+++ b/src/ScreenGameplay.h
@@ -161,10 +161,6 @@ public:
 	void SetSongPosition(float newPositionSeconds);
 	// Get current position of the song during gameplay
 	const float GetSongPosition();
-	// Recalculate the scores for notes we haven't passed yet
-	// This is intended to apply only to replays.
-	// It should only be used if we scroll backwards in time for some reason.
-	void RecalcJudgedNotesForReplay();
 	// Toggle pause. Don't use this outside of replays.
 	// Please.
 	// I'm serious.

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -89,6 +89,8 @@ void ScreenSelectMusic::Init()
 	}
 	if (GamePreferences::m_AutoPlay == PC_REPLAY)
 		GamePreferences::m_AutoPlay.Set(PC_HUMAN);
+	if (GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerController == PC_REPLAY)
+		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerController = PC_HUMAN;
 
 	IDLE_COMMENT_SECONDS.Load(m_sName, "IdleCommentSeconds");
 	SAMPLE_MUSIC_DELAY_INIT.Load(m_sName, "SampleMusicDelayInit");
@@ -1900,6 +1902,7 @@ public:
 		// lock the game into replay mode and GO
 		LOG->Trace("Viewing replay for score key %s", hs->GetScoreKey().c_str());
 		GamePreferences::m_AutoPlay.Set(PC_REPLAY);
+		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerController = PC_REPLAY;
 		p->SelectCurrent(PLAYER_1);
 
 		// set mods back to what they were before

--- a/src/ScreenSelectMusic.cpp
+++ b/src/ScreenSelectMusic.cpp
@@ -1892,12 +1892,14 @@ public:
 
 		// set mods based on the score, hopefully
 		// it is known that xmod->cmod and back does not work most of the time.
+		/*
 		CHECKPOINT_M("Setting mods for Replay Viewing.");
 		RString mods = hs->GetModifiers();
 		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetSong().FromString(mods);
 		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetCurrent().FromString(mods);
 		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetPreferred().FromString(mods);
 		CHECKPOINT_M("Replay mods set.");
+		*/
 
 		// lock the game into replay mode and GO
 		LOG->Trace("Viewing replay for score key %s", hs->GetScoreKey().c_str());


### PR DESCRIPTION
Added these to lua so that we can make it work out.
The buttons for this are bound to the game buttons.
Pause -> Insert Coin
Move forward -> Effect Up
Move backward -> Effect Down
Increase rate toggle -> Shift (hold)
Smaller increment toggle -> Ctrl (hold)
How to bookmark a position and jump to it:
1. Hold Alt
2. Press Effect Up to set a position
3. Press Effect Down to jump to a position

Also fixed a lua error in playeroptions
Also undid changing modifiers for replays until we get that working better