### PR TITLE
Update 01 timing_windows_config.lua

### DIFF
--- a/Themes/Til Death/Scripts/01 timing_windows_config.lua
+++ b/Themes/Til Death/Scripts/01 timing_windows_config.lua
@@ -42,7 +42,7 @@ local defaultConfig = {
 			boo = 121.0
 		},
 		judgeWeights = {
-			marv = 3.2,
+			marv = 3,
 			perf = 3,
 			great = 2,
 			good = 1,


### PR DESCRIPTION
change the osu! marvelous rating to 3, as the 3.2 is only the weighting in score, not the accuracy