### PR TITLE
Made title menu elements color configurable

### DIFF
--- a/Themes/Til Death/BGAnimations/ScreenTitleMenu underlay.lua
+++ b/Themes/Til Death/BGAnimations/ScreenTitleMenu underlay.lua
@@ -64,14 +64,15 @@ t[#t + 1] =
 }
 
 --Theme text
-t[#t + 1] = LoadFont("Common Normal") .. {
-	InitCommand=function(self)
-		self:xy(95,frameY-52):zoom(0.65):valign(1):halign(0):diffuse(getMainColor('positive'))
-		-- previousX, 42, previousY, frameY(-62)
-	end
-	OnCommand=function(self)
+t[#t + 1] =
+	LoadFont("Common Normal") .. 
+	{
+		InitCommand=function(self)
+			self:xy(95,frameY-52):zoom(0.65):valign(1):halign(0):diffuse(getMainColor('positive'))
+		end
+		OnCommand=function(self)
 		self:settext(getThemeName())
-	end
+		end
 }
 
 -- lazy game update button -mina

--- a/Themes/Til Death/BGAnimations/ScreenTitleMenu underlay.lua
+++ b/Themes/Til Death/BGAnimations/ScreenTitleMenu underlay.lua
@@ -31,7 +31,7 @@ t[#t + 1] =
 t[#t + 1] =
 	Def.Quad {
 	InitCommand = function(self)
-		self:xy(250, 0):halign(0):valign(0):zoomto(1000, 900):diffuse(color('BG_Right')):diffusealpha(1)
+		self:xy(250, 0):halign(0):valign(0):zoomto(1000, 900):diffuse(getTitleColor('BG_Right')):diffusealpha(1)
 	end
 }
 
@@ -39,7 +39,7 @@ t[#t + 1] =
 t[#t + 1] =
 	Def.Quad {
 	InitCommand = function(self)
-		self:xy(250, 0):halign(0):valign(0):zoomto(10, 900):diffuse(color('Line_Left')):diffusealpha(1)
+		self:xy(250, 0):halign(0):valign(0):zoomto(10, 900):diffuse(getTitleColor('Line_Left')):diffusealpha(1)
 	end
 }
 
@@ -47,7 +47,7 @@ t[#t + 1] =
 t[#t + 1] =
 	Def.Quad {
 	InitCommand = function(self)
-		self:xy(260, 0):halign(0):valign(0):zoomto(10, 900):diffuse(color('Line_Right')):diffusealpha(1)
+		self:xy(260, 0):halign(0):valign(0):zoomto(10, 900):diffuse(getTitleColor('Line_Right')):diffusealpha(1)
 	end
 }
 

--- a/Themes/Til Death/BGAnimations/ScreenTitleMenu underlay.lua
+++ b/Themes/Til Death/BGAnimations/ScreenTitleMenu underlay.lua
@@ -23,7 +23,7 @@ local frameY = THEME:GetMetric("ScreenTitleMenu", "ScrollerY")
 t[#t + 1] =
 	Def.Quad {
 	InitCommand = function(self)
-		self:xy(0, 0):halign(0):valign(0):zoomto(250, 900):diffuse(color("#161515")):diffusealpha(1)
+		self:xy(0, 0):halign(0):valign(0):zoomto(250, 900):diffuse(getTitleColor('BG_Left')):diffusealpha(1)
 	end
 }
 
@@ -31,7 +31,7 @@ t[#t + 1] =
 t[#t + 1] =
 	Def.Quad {
 	InitCommand = function(self)
-		self:xy(250, 0):halign(0):valign(0):zoomto(1000, 900):diffuse(color("#222222")):diffusealpha(1)
+		self:xy(250, 0):halign(0):valign(0):zoomto(1000, 900):diffuse(color('BG_Right')):diffusealpha(1)
 	end
 }
 
@@ -39,7 +39,7 @@ t[#t + 1] =
 t[#t + 1] =
 	Def.Quad {
 	InitCommand = function(self)
-		self:xy(250, 0):halign(0):valign(0):zoomto(10, 900):diffuse(color("#b87cf0")):diffusealpha(1)
+		self:xy(250, 0):halign(0):valign(0):zoomto(10, 900):diffuse(color('Line_Left')):diffusealpha(1)
 	end
 }
 
@@ -47,20 +47,32 @@ t[#t + 1] =
 t[#t + 1] =
 	Def.Quad {
 	InitCommand = function(self)
-		self:xy(260, 0):halign(0):valign(0):zoomto(10, 900):diffuse(color("#59307f")):diffusealpha(1)
+		self:xy(260, 0):halign(0):valign(0):zoomto(10, 900):diffuse(color('Line_Right')):diffusealpha(1)
 	end
 }
 
+--Title text
 t[#t + 1] =
 	LoadFont("Common Large") ..
 	{
-		InitCommand = function(self)
-			self:xy(42, frameY - 62):zoom(0.65):valign(1):halign(0):diffuse(color("#b87cf0"))
-		end,
-		OnCommand = function(self)
-			self:settext(getThemeName())
+		InitCommand=function(self)
+			self:xy(75,frameY-82):zoom(0.65):valign(1):halign(0):diffuse(getMainColor('positive'))
 		end
-	}
+		OnCommand=function(self)
+			self:settext("Etterna")
+		end
+}
+
+--Theme text
+t[#t + 1] = LoadFont("Common Normal") .. {
+	InitCommand=function(self)
+		self:xy(95,frameY-52):zoom(0.65):valign(1):halign(0):diffuse(getMainColor('positive'))
+		-- previousX, 42, previousY, frameY(-62)
+	end
+	OnCommand=function(self)
+		self:settext(getThemeName())
+	end
+}
 
 -- lazy game update button -mina
 local gameneedsupdating = false

--- a/Themes/Til Death/Graphics/ScreenTitleMenu scroll.lua
+++ b/Themes/Til Death/Graphics/ScreenTitleMenu scroll.lua
@@ -8,7 +8,7 @@ return Def.ActorFrame {
 				self:xy(280, -78):halign(0):valign(0)
 			end,
 			GainFocusCommand = function(self)
-				self:zoom(0.57):diffuse(color("#59307f"))
+				self:zoom(0.57):diffuse(getMainColor('positive'))
 			end,
 			LoseFocusCommand = function(self)
 				self:zoom(0.55):diffuse(color("#b87cf0"))

--- a/Themes/Til Death/Scripts/01 color_config.lua
+++ b/Themes/Til Death/Scripts/01 color_config.lua
@@ -1,4 +1,10 @@
 local defaultConfig = {
+	title = {
+		BG_Left		= "#161515",
+		BG_Right	= "#222222",
+		Line_Left	= "#b87cf0",
+		Line_Right	= "#59307f"
+	},
 	main = {
 		highlight = "#614080",
 		frames = "#000111",
@@ -135,6 +141,10 @@ end
 
 function getVividDifficultyColor(diff)
 	return color(colorConfig:get_data().difficultyVivid[diff]) or color("#ffffff")
+end
+
+function getTitleColor(type)
+	return color(colorConfig:get_data().title[type])
 end
 
 -- expecting ms input (153, 13.321, etc) so convert to seconds to compare to judgment windows -mina


### PR DESCRIPTION
This adds a new category to the color config screen and allows elements to use getTitleColor() to assign a color from the new category. Highlighted text on menu scroll is now 'positive' instead of a static color.

The text on the left side has been adjusted to look nicer (more focus on Etterna, the game, rather than til death) and now uses 'positive' as the color.