### PR TITLE
Misc. Replay & Eval Viewer Fixes

### DIFF
--- a/src/HighScore.cpp
+++ b/src/HighScore.cpp
@@ -892,6 +892,7 @@ HighScore::LoadReplayDataFull()
 	SetOffsetVector(vOffsetVector);
 	SetTrackVector(vTrackVector);
 	SetTapNoteTypeVector(vTapNoteTypeVector);
+	SetHoldReplayDataVector(vHoldReplayDataVector);
 
 	m_Impl->ReplayType = 2;
 	LOG->Trace("Loaded replay data at %s", path.c_str());

--- a/src/PlayerAI.cpp
+++ b/src/PlayerAI.cpp
@@ -455,9 +455,12 @@ PlayerAI::GetTapNoteOffsetForReplay(TapNote* pTN, int noteRow, int col)
 		// this is done to be able to judge simultaneous taps differently
 		// due to CC Off this results in possibly incorrect precise per tap
 		// judges, but the correct judgement ends up being made overall.
-		m_ReplayTapMap[noteRow].pop_back();
-		if (m_ReplayTapMap[noteRow].empty()) {
-			m_ReplayTapMap.erase(noteRow);
+
+		if (!pScoreData->GetChordCohesion()) {
+			m_ReplayTapMap[noteRow].pop_back();
+			if (m_ReplayTapMap[noteRow].empty()) {
+				m_ReplayTapMap.erase(noteRow);
+			}
 		}
 
 		return -offset;

--- a/src/PlayerAI.h
+++ b/src/PlayerAI.h
@@ -63,6 +63,8 @@ class PlayerAI
 	static int GetAdjustedRowFromUnadjustedCoordinates(int row, int col);
 	// Remove a given Tap from the fallback and Full replay data vectors
 	static void RemoveTapFromVectors(int row, int col);
+	// Go through the replay data to fill out the radar values for the eval screen
+	static void CalculateRadarValuesForReplay(RadarValues& rv, RadarValues& possibleRV);
 };
 
 #endif

--- a/src/PlayerStageStats.cpp
+++ b/src/PlayerStageStats.cpp
@@ -1037,9 +1037,12 @@ LuaFunction(GetGradeFromPercent, GetGradeFromPercent(FArg(1)))
 	// Convert to MS so lua doesn't have to
 	static int GetOffsetVector(T* p, lua_State* L)
 	{
-		vector<float> doot = p->m_vOffsetVector;
-		for (size_t i = 0; i < doot.size(); ++i)
-			doot[i] = doot[i] * 1000;
+		auto& offs = p->m_vOffsetVector;
+		auto& type = p->m_vTapNoteTypeVector;
+		vector<float> doot;
+		for (size_t i = 0; i < offs.size(); ++i)
+			if (type[i] != TapNoteType_Mine)
+				doot.emplace_back(offs[i] * 1000);
 		LuaHelpers::CreateTableFromArray(doot, L);
 		return 1;
 	}

--- a/src/ScreenGameplay.cpp
+++ b/src/ScreenGameplay.cpp
@@ -2232,6 +2232,19 @@ ScreenGameplay::SaveStats()
 		pss.m_radarActual += rv;
 		GAMESTATE->SetProcessedTimingData(NULL);
 	}
+	if (GamePreferences::m_AutoPlay.Get() == PC_REPLAY) {
+		// We need to replace the newly created replay data with the actual old
+		// data Because to keep consistently lazy practices, we can just hack
+		// things together instead of fixing the real issue -poco
+		// (doing this fixes a lot of issues in the eval screen)
+		PlayerStageStats* pss = m_vPlayerInfo[PLAYER_1].GetPlayerStageStats();
+		HighScore* hs = PlayerAI::pScoreData;
+		pss->m_vHoldReplayData = hs->GetHoldReplayDataVector();
+		pss->m_vNoteRowVector = hs->GetNoteRowVector();
+		pss->m_vOffsetVector = hs->GetOffsetVector();
+		pss->m_vTapNoteTypeVector = hs->GetTapNoteTypeVector();
+		pss->m_vTrackVector = hs->GetTrackVector();
+	}
 }
 
 void


### PR DESCRIPTION
Fix inconsistent results when restarting the game and converting judges.
Fix incorrect hold replay data loading.
Fix incorrect radar value numbers.