### PR TITLE
Mouseover refactor

### DIFF
--- a/Themes/Til Death/BGAnimations/ScreenGameplay overlay/WifeJudgmentSpotting.lua
+++ b/Themes/Til Death/BGAnimations/ScreenGameplay overlay/WifeJudgmentSpotting.lua
@@ -347,6 +347,11 @@ local cp =
 		end
 		self:zoom(MovableValues.DisplayPercentZoom):x(MovableValues.DisplayPercentX):y(MovableValues.DisplayPercentY)
 	end,
+	Def.Quad {
+		InitCommand = function(self)
+			self:zoomto(60, 13):diffuse(color("0,0,0,0.4")):halign(1):valign(0)
+		end
+	},
 	-- Displays your current percentage score
 	LoadFont("Common Large") .. {
 		Name = "DisplayPercent",

--- a/Themes/Til Death/BGAnimations/ScreenGameplay overlay/WifeJudgmentSpotting.lua
+++ b/Themes/Til Death/BGAnimations/ScreenGameplay overlay/WifeJudgmentSpotting.lua
@@ -180,8 +180,7 @@ local t =
 			Movable.DeviceButton_t.element = noteColumns
 			Movable.DeviceButton_r.condition = true
 			Movable.DeviceButton_t.condition = true
-			lifebar:AddChild(self:GetChild("Border"))
-			-- self:RemoveChild("Border") ayy lmao
+			self:GetChild("LifeP1"):GetChild("Border"):SetFakeParent(lifebar)
 			Movable.DeviceButton_j.element = lifebar
 			Movable.DeviceButton_j.condition = true
 			Movable.DeviceButton_k.element = lifebar
@@ -209,9 +208,11 @@ local t =
 	end
 }
 
--- lifebar border, this is really ghetto i dont like it
-t[#t + 1] = MovableBorder(200, 5, 1, -35, 0)
-
+-- lifebard
+t[#t + 1] = Def.ActorFrame{
+	Name = "LifeP1",
+	MovableBorder(200, 5, 1, -35, 0)
+}
 --[[~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 																	**LaneCover**
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Themes/Til Death/BGAnimations/ScreenGameplay overlay/WifeJudgmentSpotting.lua
+++ b/Themes/Til Death/BGAnimations/ScreenGameplay overlay/WifeJudgmentSpotting.lua
@@ -135,15 +135,6 @@ local enabledJudgeCounter = playerConfig:get_data(pn_to_profile_slot(PLAYER_1)).
 local leaderboardEnabled = playerConfig:get_data(pn_to_profile_slot(PLAYER_1)).leaderboardEnabled and DLMAN:IsLoggedIn()
 local isReplay = GAMESTATE:GetPlayerState(PLAYER_1):GetPlayerController() == "PlayerController_Replay"
 
--- restart button (MOVED OUT OF THEME IN FAVOR OF REMAPPING)
---[[
-local function froot(loop)
-	if loop.DeviceInput.button == "DeviceButton_`" then
-		SCREENMAN:GetTopScreen():SetPrevScreenName("ScreenStageInformation"):begin_backing_out()
-	end
-end
-]]
-
 local function arbitraryErrorBarValue(value)
 	errorBarFrameWidth = capWideScale(get43size(value), value)
 	wscale = errorBarFrameWidth / 180
@@ -173,9 +164,6 @@ local t =
 		local endTime = os.time() + GetPlayableTime()
 		GAMESTATE:UpdateDiscordPresence(largeImageTooltip, detail, state, endTime)
 
-		--[[if SCREENMAN:GetTopScreen():GetName() == "ScreenGameplay" then
-			SCREENMAN:GetTopScreen():AddInputCallback(froot)
-		end]]
 		screen = SCREENMAN:GetTopScreen()
 		usingReverse = GAMESTATE:GetPlayerState(PLAYER_1):GetCurrentPlayerOptions():UsingReverse()
 		Notefield = screen:GetChild("PlayerP1"):GetChild("NoteField")
@@ -360,7 +348,7 @@ local cp =
 		end,
 		OnCommand = function(self)
 			if allowedCustomization then
-				self:settextf("%05.2f%%", -10000)
+				self:settextf("%05.2f%%", -10000) 
 				setBorderAlignment(self:GetParent():GetChild("Border"), 1, 0)
 				setBorderToText(self:GetParent():GetChild("Border"), self)
 			end

--- a/Themes/Til Death/BGAnimations/ScreenNetSelectMusic decorations/default.lua
+++ b/Themes/Til Death/BGAnimations/ScreenNetSelectMusic decorations/default.lua
@@ -132,7 +132,7 @@ g[#g + 1] =
 	PlayingSampleMusicMessageCommand = function(self)
 		local leaderboardEnabled =
 			playerConfig:get_data(pn_to_profile_slot(PLAYER_1)).leaderboardEnabled and DLMAN:IsLoggedIn()
-		if leaderboardEnabled then
+		if leaderboardEnabled and GAMESTATE:GetCurrentSteps(PLAYER_1) then
 			local chartkey = GAMESTATE:GetCurrentSteps(PLAYER_1):GetChartKey()
 			DLMAN:RequestChartLeaderBoardFromOnline(
 				chartkey,

--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/default.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/default.lua
@@ -46,7 +46,7 @@ t[#t + 1] =
 	PlayingSampleMusicMessageCommand = function(self)
 		local leaderboardEnabled =
 			playerConfig:get_data(pn_to_profile_slot(PLAYER_1)).leaderboardEnabled and DLMAN:IsLoggedIn()
-		if leaderboardEnabled then
+		if leaderboardEnabled and GAMESTATE:GetCurrentSteps(PLAYER_1) then
 			local chartkey = GAMESTATE:GetCurrentSteps(PLAYER_1):GetChartKey()
 			DLMAN:RequestChartLeaderBoardFromOnline(
 				chartkey,

--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/goaltracker.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/goaltracker.lua
@@ -1,8 +1,8 @@
 local t =
 	Def.ActorFrame {
 	BeginCommand = function(self)
-		self:queuecommand("Set"):visible(false)
-		self:GetChild("GoalDisplay"):xy(10, 60):visible(false)
+		self:queuecommand("Set")
+		self:GetChild("GoalDisplay"):xy(10, 60)
 	end,
 	OffCommand = function(self)
 		self:bouncebegin(0.2):xy(-500, 0):diffusealpha(0)
@@ -14,11 +14,10 @@ local t =
 		self:finishtweening(1)
 		if getTabIndex() == 6 then
 			self:queuecommand("On")
-			self:visible(true) -- input filter has a get:visible check so it doesn't eat inputs if the element isn't displayed
-			self:GetChild("GoalDisplay"):visible(true) -- however it isn't recursive, so we set the child explicitly, leaving this here to remind myself
-		else -- to look into changing the getvisible logic or adding a new recursive function maybe -mina
+			self:visible(true)
+		else
 			self:queuecommand("Off")
-			self:GetChild("GoalDisplay"):xy(10, 60):visible(false)
+			self:visible(false)
 		end
 	end,
 	TabChangedMessageCommand = function(self)

--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/playlists.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/playlists.lua
@@ -110,7 +110,7 @@ local function BroadcastIfActive(msg)
 end
 
 local function ButtonActive(self, scale)
-	return isOverScaled(self, scale) and update
+	return isOver(self) and update
 end
 
 local r =
@@ -409,19 +409,6 @@ local b2 =
 	end
 }
 
---Add chart button
--- b2[#b2+1] = LoadFont("Common Large") .. {InitCommand=cmd(zoom,0.3;x,245;settext,"Add Chart")}
--- b2[#b2+1] = Def.Quad{
--- InitCommand=function(self)
--- 	self:x(245):diffusealpha(buttondiffuse):zoomto(80,20)
--- end,
--- MouseLeftClickMessageCommand=function(self)
--- if ButtonActive(self) and singleplaylistactive then
--- pl:AddChart(GAMESTATE:GetCurrentSteps(PLAYER_1):GetChartKey())
--- end
--- end
--- }
--- Play As Course button
 b2[#b2 + 1] =
 	LoadFont("Common Large") ..
 	{
@@ -721,21 +708,6 @@ local b =
 		self:visible(true)
 	end
 }
-
--- zzzz button positioning is lame... use shortcut key for now whynot
--- New Playlist
--- b[#b+1] = LoadFont("Common Large") .. {InitCommand=cmd(zoom,0.3;settext,"New Playlist")}
--- b[#b+1] = Def.Quad{
--- InitCommand=function(self)
--- 	self:diffusealpha(buttondiffuse):zoomto(110,20)
--- end,
--- MouseLeftClickMessageCommand=function(self)
--- if ButtonActive(self,0.3) and allplaylistsactive then
--- SONGMAN:NewPlaylist()
--- MESSAGEMAN:Broadcast("DisplayAll")
--- end
--- end
--- }
 
 playlists[#playlists + 1] = b
 

--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/score.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/score.lua
@@ -45,32 +45,6 @@ else
 	defaultRateText = "All"
 end
 
-local function isOver(element)
-	if element:GetParent():GetParent():GetVisible() == false then
-		return false
-	end
-	if element:GetParent():GetVisible() == false then
-		return false
-	end
-	if element:GetVisible() == false then
-		return false
-	end
-	local x = getTrueX(element)
-	local y = getTrueY(element)
-	local hAlign = element:GetHAlign()
-	local vAlign = element:GetVAlign()
-	local w = element:GetZoomedWidth()
-	local h = element:GetZoomedHeight()
-
-	local mouseX = INPUTFILTER:GetMouseX()
-	local mouseY = INPUTFILTER:GetMouseY()
-
-	local withinX = (mouseX >= (x - (hAlign * w))) and (mouseX <= ((x + w) - (hAlign * w)))
-	local withinY = (mouseY >= (y - (vAlign * h))) and (mouseY <= ((y + h) - (vAlign * h)))
-
-	return (withinX and withinY)
-end
-
 -- should maybe make some of these generic
 local function highlight(self)
 	if self:GetVisible() then

--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/score.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/score.lua
@@ -47,7 +47,7 @@ end
 
 -- should maybe make some of these generic
 local function highlight(self)
-	if self:GetVisible() then
+	if self:IsVisible() then
 		self:queuecommand("Highlight")
 	end
 end
@@ -197,7 +197,7 @@ local ret =
 local cheese
 -- eats only inputs that would scroll to a new score
 local function input(event)
-	if cheese:GetVisible() and isOver(cheese:GetChild("FrameDisplay")) then
+	if isOver(cheese:GetChild("FrameDisplay")) then
 		if event.DeviceInput.button == "DeviceButton_mousewheel up" and event.type == "InputEventType_FirstPress" then
 			moving = true
 			if nestedTab == 1 and rtTable and rtTable[rates[rateIndex]] ~= nil then
@@ -228,7 +228,7 @@ local t =
 		SCREENMAN:GetTopScreen():AddInputCallback(input)
 	end,
 	OnCommand = function(self)
-		if nestedTab == 1 and self:GetVisible() then
+		if nestedTab == 1 and self:IsVisible() then
 			if GAMESTATE:GetCurrentSong() ~= nil then
 				rtTable = getRateTable()
 				if rtTable ~= nil then

--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/wifeTwirl.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/wifeTwirl.lua
@@ -37,7 +37,7 @@ local t =
 		if song ~= bong then
 			song = bong
 			self:queuecommand("MortyFarts")
-			if noteField and mcbootlarder:GetChild("NoteField"):GetVisible() and song then
+			if noteField and mcbootlarder:GetChild("NoteField"):IsVisible() and song then
 				song:Borp()
 			end
 		end
@@ -54,7 +54,7 @@ local t =
 			self:queuecommand("On")
 			update = true
 		else
-			if GAMESTATE:GetCurrentSong() and noteField and mcbootlarder:GetVisible() then 
+			if GAMESTATE:GetCurrentSong() and noteField and mcbootlarder:IsVisible() then 
 				mcbootlarder:visible(false)
 				mcbootlarder:GetChild("NoteField"):visible(false)
 				MESSAGEMAN:Broadcast("ChartPreviewOff")
@@ -65,7 +65,7 @@ local t =
 		end
 	end,
 	MilkyTartsCommand=function(self)	-- when entering pack screenselectmusic explicitly turns visibilty on notefield off -mina
-		if noteField and mcbootlarder:GetVisible() then 
+		if noteField and mcbootlarder:IsVisible() then 
 			mcbootlarder:visible(false)
 			MESSAGEMAN:Broadcast("ChartPreviewOff")
 			heyiwasusingthat = true
@@ -127,7 +127,7 @@ local function toggleNoteField()
 	return end
 
 	if song then 
-		if mcbootlarder:GetVisible() then
+		if mcbootlarder:IsVisible() then
 			mcbootlarder:visible(false)
 			mcbootlarder:GetChild("NoteField"):visible(false)
 			MESSAGEMAN:Broadcast("ChartPreviewOff")

--- a/Themes/Til Death/BGAnimations/ScreenSystemLayer overlay/default.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSystemLayer overlay/default.lua
@@ -49,7 +49,7 @@ local hhh = SCREEN_HEIGHT * 0.8
 local rtzoom = 0.6
 
 local function dooting(self)
-	if self:GetVisible() then
+	if self:IsVisible() then
 		self:GetChild("BGQframe"):queuecommand("dooting")
 	end
 end

--- a/Themes/Til Death/BGAnimations/_chorddensitygraph.lua
+++ b/Themes/Til Death/BGAnimations/_chorddensitygraph.lua
@@ -95,7 +95,7 @@ local t = Def.ActorFrame {
 		self:queuecommand("GraphUpdate")
 	end,
 	CurrentRateChangedMessageCommand = function(self)
-		if self:GetParent():GetVisible() then
+		if self:IsVisible() then
 			self:queuecommand("GraphUpdate")
 		end
 	end,
@@ -111,7 +111,7 @@ t[#t+1] =
 	Def.ActorMultiVertex {
 		Name = "CDGraphDrawer",
 		GraphUpdateCommand = function(self)
-			if self:GetParent():GetVisible() then
+			if self:IsVisible() then
 				updateGraphMultiVertex(cdg, self)
 				self:GetParent():linear(0.3)
 				self:GetParent():diffusealpha(1)

--- a/Themes/Til Death/BGAnimations/goaldisplay.lua
+++ b/Themes/Til Death/BGAnimations/goaldisplay.lua
@@ -24,7 +24,7 @@ local cheese
 
 -- will eat any mousewheel inputs to scroll pages while mouse is over the background frame
 local function input(event)
-	if cheese:GetVisible() and isOver(cheese:GetChild("FrameDisplay")) then
+	if isOver(cheese:GetChild("FrameDisplay")) then
 		if event.DeviceInput.button == "DeviceButton_mousewheel up" and event.type == "InputEventType_FirstPress" then
 			moving = true
 			cheese:queuecommand("PrevPage")
@@ -40,7 +40,7 @@ local function input(event)
 end
 
 local function highlight(self)
-	if cheese:GetVisible() then
+	if cheese:IsVisible() then
 		self:queuecommand("Highlight")
 	end
 end

--- a/Themes/Til Death/BGAnimations/packlistDisplay.lua
+++ b/Themes/Til Death/BGAnimations/packlistDisplay.lua
@@ -196,7 +196,7 @@ local function makePackDisplay(i)
 					highlightIfOver(self)
 				end,
 				MouseLeftClickMessageCommand = function(self)
-					if isOver(self) and self:GetParent():GetParent():GetVisible() then -- probably should have the isOver function do a recursive parent check?
+					if isOver(self) then -- now contains recursive visibility checks -mina
 						local urlstringyo = "https://etternaonline.com/pack/" .. packinfo:GetID() -- not correct value for site id
 						GAMESTATE:ApplyGameCommand("urlnoexit," .. urlstringyo)
 					end

--- a/Themes/Til Death/BGAnimations/superscoreboard.lua
+++ b/Themes/Til Death/BGAnimations/superscoreboard.lua
@@ -92,6 +92,9 @@ local o =
 		self:playcommand("Update")
 	end,
 	UpdateCommand = function(self)
+		if not scoretable then
+			scoretable = {}
+		end
 		if ind == #scoretable then
 			ind = ind - numscores
 		elseif ind > #scoretable - (#scoretable % numscores) then

--- a/Themes/Til Death/BGAnimations/superscoreboard.lua
+++ b/Themes/Til Death/BGAnimations/superscoreboard.lua
@@ -43,32 +43,6 @@ local function input(event)
 	return false
 end
 
-local function isOver(element)
-	if element:GetParent():GetParent():GetVisible() == false then
-		return false
-	end
-	if element:GetParent():GetVisible() == false then
-		return false
-	end
-	if element:GetVisible() == false then
-		return false
-	end
-	local x = getTrueX(element)
-	local y = getTrueY(element)
-	local hAlign = element:GetHAlign()
-	local vAlign = element:GetVAlign()
-	local w = element:GetZoomedWidth()
-	local h = element:GetZoomedHeight()
-
-	local mouseX = INPUTFILTER:GetMouseX()
-	local mouseY = INPUTFILTER:GetMouseY()
-
-	local withinX = (mouseX >= (x - (hAlign * w))) and (mouseX <= ((x + w) - (hAlign * w)))
-	local withinY = (mouseY >= (y - (vAlign * h))) and (mouseY <= ((y + h) - (vAlign * h)))
-
-	return (withinX and withinY)
-end
-
 local function highlight(self)
 	if self:GetVisible() then
 		self:queuecommand("Highlight")

--- a/Themes/Til Death/BGAnimations/superscoreboard.lua
+++ b/Themes/Til Death/BGAnimations/superscoreboard.lua
@@ -28,7 +28,7 @@ local isGlobalRanking = true
 
 -- will eat any mousewheel inputs to scroll pages while mouse is over the background frame
 local function input(event)
-	if cheese:GetVisible() and isOver(cheese:GetChild("FrameDisplay")) then
+	if isOver(cheese:GetChild("FrameDisplay")) then	-- visibility checks are built into isover now -mina
 		if event.DeviceInput.button == "DeviceButton_mousewheel up" and event.type == "InputEventType_FirstPress" then
 			moving = true
 			cheese:queuecommand("PrevPage")
@@ -44,7 +44,7 @@ local function input(event)
 end
 
 local function highlight(self)
-	if self:GetVisible() then
+	if self:IsVisible() then
 		self:queuecommand("Highlight")
 		self:queuecommand("WHAZZZAAAA")
 	end

--- a/Themes/Til Death/Graphics/Player combo/default.lua
+++ b/Themes/Til Death/Graphics/Player combo/default.lua
@@ -61,7 +61,7 @@ local t =
 			c.Number:visible(true)
 			c.Label:visible(true)
 			c.Number:settext(1000)
-			Movable.DeviceButton_3.propertyOffsets = {getTrueX(self) -6, getTrueY(self) + c.Number:GetHeight()*1.5}	-- centered to screen/valigned
+			Movable.DeviceButton_3.propertyOffsets = {self:GetTrueX() -6, self:GetTrueY() + c.Number:GetHeight()*1.5}	-- centered to screen/valigned
 			setBorderAlignment(c.Border, 0.5, 1)
 		end
 		arbitraryComboZoom(MovableValues.ComboZoom)

--- a/Themes/Til Death/Graphics/Player judgment/default.lua
+++ b/Themes/Til Death/Graphics/Player judgment/default.lua
@@ -51,7 +51,7 @@ local t =
 			Movable.DeviceButton_2.condition = enabledJudgment
 			Movable.DeviceButton_2.DeviceButton_up.arbitraryFunction = judgmentZoom
 			Movable.DeviceButton_2.DeviceButton_down.arbitraryFunction = judgmentZoom
-			Movable.DeviceButton_1.propertyOffsets = {getTrueX(self) , getTrueY(self) - c.Judgment:GetHeight()}	-- centered to screen/valigned
+			Movable.DeviceButton_1.propertyOffsets = {self:GetTrueX() , self:GetTrueY() - c.Judgment:GetHeight()}	-- centered to screen/valigned
 		end
 	end,
 	JudgmentMessageCommand = function(self, param)

--- a/Themes/Til Death/Graphics/StepsDisplayListRow frame.lua
+++ b/Themes/Til Death/Graphics/StepsDisplayListRow frame.lua
@@ -1,5 +1,5 @@
 local function highlight(self)
-	if self:GetParent():GetVisible() then
+	if self:IsVisible() then
 		self:queuecommand("Highlight")
 	end
 end

--- a/Themes/_fallback/Scripts/00 Utility.lua
+++ b/Themes/_fallback/Scripts/00 Utility.lua
@@ -38,14 +38,7 @@ end
 -- @tparam actor element the actor
 -- @treturn number
 function getTrueX(element)
-	if element == nil then
-		return 0
-	end
-	if element:GetParent() == nil then
-		return element:GetX() or 0
-	else
-		return element:GetX() + getTrueX(element:GetParent())
-	end
+	element:GetTrueX()
 end
 
 --- Get the actor's real Y (Not relative to the parent like self:GetY()) by recursively grabbing the parents' position
@@ -53,62 +46,15 @@ end
 -- @tparam actor element the actor
 -- @treturn number
 function getTrueY(element)
-	if element == nil then
-		return 0
-	end
-	if element:GetParent() == nil then
-		return element:GetY() or 0
-	else
-		return element:GetY() + getTrueY(element:GetParent())
-	end
+	element:GetTrueY()
 end
 
 --- Checks whether the mouse is over an actor
 -- @tparam actor element the actor
 -- @treturn bool true if the mouse is over the actor
 function isOver(element)
-	--[[
-	if element:GetVisible() == false then
-		return false
-	end;
-	--]]
-	local x = getTrueX(element)
-	local y = getTrueY(element)
-	local hAlign = element:GetHAlign()
-	local vAlign = element:GetVAlign()
-	local w = element:GetZoomedWidth()
-	local h = element:GetZoomedHeight()
-
 	local mouse = getMousePosition()
-
-	local withinX = (mouse.x >= (x - (hAlign * w))) and (mouse.x <= ((x + w) - (hAlign * w)))
-	local withinY = (mouse.y >= (y - (vAlign * h))) and (mouse.y <= ((y + h) - (vAlign * h)))
-
-	return (withinX and withinY)
-end
-
---- For when its just wrong and you need to control the scale yourself
--- @tparam actor element the actor
--- @number scale Multiplier
--- @treturn bool true if the mouse is over the actor
-function isOverScaled(element, scale)
-	if not scale then
-		scale = 1
-	end
-	local x = getTrueX(element)
-	local y = getTrueY(element)
-	local hAlign = element:GetHAlign()
-	local vAlign = element:GetVAlign()
-	local w = element:GetZoomedWidth() * scale
-	local h = element:GetZoomedHeight() * scale
-
-	local mouseX = INPUTFILTER:GetMouseX()
-	local mouseY = INPUTFILTER:GetMouseY()
-
-	local withinX = (mouseX >= (x - (hAlign * w))) and (mouseX <= ((x + w) - (hAlign * w)))
-	local withinY = (mouseY >= (y - (vAlign * h))) and (mouseY <= ((y + h) - (vAlign * h)))
-
-	return (withinX and withinY)
+	return element:IsOver(mouse.x, mouse.y)
 end
 
 --- returns true if the table contains the key.

--- a/src/Actor.cpp
+++ b/src/Actor.cpp
@@ -309,8 +309,8 @@ Actor::IsOver(float mx, float my)
 	auto y = GetTrueY();
 	auto hal = GetHorizAlign();
 	auto val = GetVertAlign();
-	auto wi = GetZoomedWidth() * GetParent()->GetTrueZoom();
-	auto hi = GetZoomedHeight() * GetParent()->GetTrueZoom();
+	auto wi = GetZoomedWidth() * GetFakeParentOrParent()->GetTrueZoom();
+	auto hi = GetZoomedHeight() * GetFakeParentOrParent()->GetTrueZoom();
 	auto lr = x - (hal * wi);
 	auto rr = x + wi - (hal * wi);
 	auto ur = y - (val * hi);
@@ -319,15 +319,26 @@ Actor::IsOver(float mx, float my)
 	bool withinY = my >= ur && my <= br;
 	return withinX && withinY;
 }
+Actor*
+Actor::GetFakeParentOrParent()
+{
+	if (!this)
+		return nullptr;
+	if (m_FakeParent)
+		return m_FakeParent;
+	if (m_pParent)
+		return m_pParent;
+	return nullptr;
+}
 float
 Actor::GetTrueX()
 {
 	if (!this)
 		return 0.f;
-	if (!m_pParent)
+	auto* mfp = GetFakeParentOrParent();
+	if (!mfp)
 		return GetX();
-	return GetX() * GetParent()->GetTrueZoom() +
-		   GetParent()->GetTrueX();
+	return GetX() * mfp->GetTrueZoom() + mfp->GetTrueX();
 }
 
 float
@@ -335,28 +346,30 @@ Actor::GetTrueY()
 {
 	if (!this)
 		return 0.f;
-	if (!m_pParent)
+	auto* mfp = GetFakeParentOrParent();
+	if (!mfp)
 		return GetY();
-	return GetY() * GetParent()->GetTrueZoom() +
-		   GetParent()->GetTrueY();
+	return GetY() * mfp->GetTrueZoom() + mfp->GetTrueY();
 }
 float
 Actor::GetTrueZoom()
 {
 	if (!this)
 		return 1.f;
-	if (!m_pParent)
+	auto* mfp = GetFakeParentOrParent();
+	if (!mfp)
 		return GetZoom();
-	return GetZoom() * GetParent()->GetTrueZoom();
+	return GetZoom() * mfp->GetTrueZoom();
 }
 bool
 Actor::IsVisible()
 {
 	if (!this)
 		return false;
-	if (!m_pParent)
+	auto* mfp = GetFakeParentOrParent();
+	if (!mfp)
 		return GetVisible();
-	return GetVisible() && GetParent()->IsVisible();
+	return GetVisible() && mfp->IsVisible();
 }
 void
 Actor::Draw()
@@ -2844,7 +2857,7 @@ class LunaActor : public Luna<Actor>
 		ADD_METHOD(GetWrapperState);
 
 		ADD_METHOD(Draw);
-		
+
 		ADD_METHOD(SaveXY);
 		ADD_METHOD(LoadXY);
 

--- a/src/Actor.h
+++ b/src/Actor.h
@@ -258,6 +258,13 @@ class Actor : public MessageSubscriber
 
 	// PartiallyOpaque broken out of Draw for reuse and clarity.
 	bool PartiallyOpaque();
+	bool IsOver(float mx, float my);
+
+	float GetTrueX();	// recursive with parent (for mouseovers) -mina
+	float GetTrueY();	// same
+	float GetTrueZoom();	// same
+	bool IsVisible();	// same but for gating updates on things that may not explicitly set visible = false -mina
+
 	/**
 	 * @brief Calls multiple functions for drawing the Actors.
 	 *

--- a/src/Actor.h
+++ b/src/Actor.h
@@ -260,6 +260,7 @@ class Actor : public MessageSubscriber
 	bool PartiallyOpaque();
 	bool IsOver(float mx, float my);
 
+	Actor* GetFakeParentOrParent(); // fake parent > parent -mina
 	float GetTrueX();	// recursive with parent (for mouseovers) -mina
 	float GetTrueY();	// same
 	float GetTrueZoom();	// same

--- a/src/ActorFrame.cpp
+++ b/src/ActorFrame.cpp
@@ -792,19 +792,6 @@ class LunaActorFrame : public Luna<ActorFrame>
 		p->SetLightDirection(vTmp);
 		COMMON_RETURN_SELF;
 	}
-
-	static int AddChild(T* p, lua_State* L)
-	{
-		if (lua_isnoneornil(L, 1)) {
-			lua_pushboolean(L, 0);
-			return 1;
-		} 
-		Actor* pActor = Luna<Actor>::check(L, 1);
-		p->AddChild(pActor);
-		lua_pushboolean(L, 1);
-		return 1;
-	}
-
 	static int AddChildFromPath(T* p, lua_State* L)
 	{
 		// this one is tricky, we need to get an Actor from Lua.
@@ -858,7 +845,6 @@ class LunaActorFrame : public Luna<ActorFrame>
 		ADD_METHOD(SetDiffuseLightColor);
 		ADD_METHOD(SetSpecularLightColor);
 		ADD_METHOD(SetLightDirection);
-		ADD_METHOD(AddChild);
 		ADD_METHOD(AddChildFromPath);
 		ADD_METHOD(RemoveChild);
 		ADD_METHOD(RemoveAllChildren);


### PR DESCRIPTION
adds c++ implementations of getTrueX, getTrueY, and isOver and a new getTrueZoom 
the internal isover correctly handled nested zooms/coordinates (but not rotations yet, though it should be easier to add now)

all custom local isovers inside scripts should be removed and fallback to the utility definition, which is now an alias

also added is a recursive visibility check IsVisible and most getvisible use has been supplanted in the theme

unexposed addchild from lua in favor of a fakeparent approach; all the new functions use a fakeparent > parent > nil wrapper to support it