### PR TITLE
Weak bandaid to stop noteskin changes from crashing in music select

### DIFF
--- a/src/NoteField.cpp
+++ b/src/NoteField.cpp
@@ -298,6 +298,14 @@ NoteField::ensure_note_displays_have_skin()
 	sNoteSkinLower.MakeLower();
 	map<RString, NoteDisplayCols*>::iterator it =
 	  m_NoteDisplays.find(sNoteSkinLower);
+
+	if (it == m_NoteDisplays.end() && GAMESTATE->m_bIsChartPreviewActive) {
+		m_NoteDisplays.clear(); // this may leak some RString memory
+		m_NoteDisplays.insert(
+		  pair<RString, NoteDisplayCols*>(sNoteSkinLower, badIdea));
+		it = m_NoteDisplays.find(sNoteSkinLower);
+	}
+
 	ASSERT_M(it != m_NoteDisplays.end(),
 			 ssprintf("iterator != m_NoteDisplays.end() [sNoteSkinLower = %s]",
 					  sNoteSkinLower.c_str()));


### PR DESCRIPTION
Pull request made for the purpose of code review; not likely final.
All this does is stop the crashing you get if you change noteskins with an existing (visible or not) notefield. This will not change your noteskin unless you deliberately force the notefield to regenerate.