### PR TITLE
Widely remove the dependency on NUM_PLAYERS

### DIFF
--- a/src/ArrowEffects.cpp
+++ b/src/ArrowEffects.cpp
@@ -128,7 +128,7 @@ struct PerPlayerData
 	float m_fBeatFactor;
 	float m_fExpandSeconds;
 };
-PerPlayerData g_EffectData[NUM_PLAYERS];
+PerPlayerData g_EffectData;
 } // namespace;
 
 void
@@ -140,17 +140,17 @@ ArrowEffects::Update()
 	FOREACH_EnabledPlayer(pn)
 	{
 		const Style* pStyle = GAMESTATE->GetCurrentStyle(pn);
-		const Style::ColumnInfo* pCols = pStyle->m_ColumnInfo[pn];
+		const Style::ColumnInfo* pCols = pStyle->m_ColumnInfo;
 		const SongPosition& position =
 		  GAMESTATE->m_bIsUsingStepTiming
-			? GAMESTATE->m_pPlayerState[pn]->m_Position
+			? GAMESTATE->m_pPlayerState->m_Position
 			: GAMESTATE->m_Position;
-		const float field_zoom = GAMESTATE->m_pPlayerState[pn]->m_NotefieldZoom;
-		const float* effects = GAMESTATE->m_pPlayerState[pn]
+		const float field_zoom = GAMESTATE->m_pPlayerState->m_NotefieldZoom;
+		const float* effects = GAMESTATE->m_pPlayerState
 								 ->m_PlayerOptions.GetCurrent()
 								 .m_fEffects;
 
-		PerPlayerData& data = g_EffectData[pn];
+		PerPlayerData& data = g_EffectData;
 
 		if (!position.m_bFreeze || !position.m_bDelay) {
 			data.m_fExpandSeconds += fTime - fLastTime;
@@ -350,7 +350,7 @@ ArrowEffects::GetYOffset(const PlayerState* pPlayerState,
 
 	float fSongBeat = position.m_fSongBeatVisible;
 	PlayerNumber pn = pPlayerState->m_PlayerNumber;
-	Steps* pCurSteps = GAMESTATE->m_pCurSteps[pn];
+	Steps* pCurSteps = GAMESTATE->m_pCurSteps;
 
 	/* Usually, fTimeSpacing is 0 or 1, in which case we use entirely beat
 	 * spacing or entirely time spacing (respectively). Occasionally, we tween
@@ -455,7 +455,7 @@ ArrowEffects::GetYOffset(const PlayerState* pPlayerState,
 
 	if (fAccels[PlayerOptions::ACCEL_EXPAND] != 0) {
 		// TODO: Don't index by PlayerNumber.
-		PerPlayerData& data = g_EffectData[pPlayerState->m_PlayerNumber];
+		PerPlayerData& data = g_EffectData;
 
 		float fExpandMultiplier = SCALE(
 		  RageFastCos(data.m_fExpandSeconds * EXPAND_MULTIPLIER_FREQUENCY),
@@ -524,7 +524,7 @@ ArrowEffects::GetYPos(int iCol,
 	// Doing the math with a precalculated result of 0 should be faster than
 	// checking whether tipsy is on. -Kyz
 	// TODO: Don't index by PlayerNumber.
-	PerPlayerData& data = g_EffectData[curr_options->m_pn];
+	PerPlayerData& data = g_EffectData;
 	f += fEffects[PlayerOptions::EFFECT_TIPSY] * data.m_tipsy_result[iCol];
 
 	// In beware's DDR Extreme-focused fork of StepMania 3.9, this value is
@@ -545,7 +545,7 @@ ArrowEffects::GetYOffsetFromYPos(int iCol,
 	// Doing the math with a precalculated result of 0 should be faster than
 	// checking whether tipsy is on. -Kyz
 	// TODO: Don't index by PlayerNumber.
-	PerPlayerData& data = g_EffectData[curr_options->m_pn];
+	PerPlayerData& data = g_EffectData;
 	f +=
 	  fEffects[PlayerOptions::EFFECT_TIPSY] * data.m_tipsy_offset_result[iCol];
 
@@ -572,8 +572,8 @@ ArrowEffects::GetXPos(const PlayerState* pPlayerState,
 
 	// TODO: Don't index by PlayerNumber.
 	const Style::ColumnInfo* pCols =
-	  pStyle->m_ColumnInfo[pPlayerState->m_PlayerNumber];
-	PerPlayerData& data = g_EffectData[pPlayerState->m_PlayerNumber];
+	  pStyle->m_ColumnInfo;
+	PerPlayerData& data = g_EffectData;
 
 	if (fEffects[PlayerOptions::EFFECT_TORNADO] != 0) {
 		const float fRealPixelOffset =

--- a/src/AutoKeysounds.h
+++ b/src/AutoKeysounds.h
@@ -23,7 +23,7 @@ class AutoKeysounds
 	{
 		if (pn == PLAYER_INVALID)
 			return NULL;
-		return m_pPlayerSounds[pn];
+		return m_pPlayerSounds;
 	}
 
   protected:
@@ -32,11 +32,11 @@ class AutoKeysounds
 						   RageSoundReader*& pGlobal,
 						   RageSoundReader*& pPlayer1);
 
-	NoteData m_ndAutoKeysoundsOnly[NUM_PLAYERS];
+	NoteData m_ndAutoKeysoundsOnly;
 	vector<RageSound> m_vKeysounds;
 	RageSound m_sSound;
 	RageSoundReader* m_pChain;					   // owned by m_sSound
-	RageSoundReader* m_pPlayerSounds[NUM_PLAYERS]; // owned by m_sSound
+	RageSoundReader* m_pPlayerSounds; // owned by m_sSound
 	RageSoundReader* m_pSharedSound;			   // owned by m_sSound
 };
 

--- a/src/Background.cpp
+++ b/src/Background.cpp
@@ -63,7 +63,7 @@ class BrightnessOverlay : public ActorFrame
 	void Set(float fBrightness);
 
   private:
-	Quad m_quadBGBrightness[NUM_PLAYERS];
+	Quad m_quadBGBrightness;
 	Quad m_quadBGBrightnessFade;
 };
 
@@ -938,7 +938,7 @@ bool
 BackgroundImpl::IsDangerAllVisible()
 {
 	// The players are never in danger in FAIL_OFF.
-	if (GAMESTATE->GetPlayerFailType(GAMESTATE->m_pPlayerState[PLAYER_1]) ==
+	if (GAMESTATE->GetPlayerFailType(GAMESTATE->m_pPlayerState) ==
 			 FailType_Off) return false;
 	if (!g_bShowDanger)
 		return false;
@@ -956,17 +956,12 @@ BrightnessOverlay::BrightnessOverlay()
 	float fQuadWidth = (RIGHT_EDGE - LEFT_EDGE) / 2;
 	fQuadWidth -= g_fBackgroundCenterWidth / 2;
 
-	m_quadBGBrightness[0].StretchTo( RectF(LEFT_EDGE,TOP_EDGE,LEFT_EDGE+fQuadWidth,BOTTOM_EDGE) );
+	m_quadBGBrightness.StretchTo( RectF(LEFT_EDGE,TOP_EDGE,LEFT_EDGE+fQuadWidth,BOTTOM_EDGE) );
 	m_quadBGBrightnessFade.StretchTo( RectF(LEFT_EDGE+fQuadWidth,TOP_EDGE,RIGHT_EDGE-fQuadWidth,BOTTOM_EDGE) );
-	//m_quadBGBrightness[1].StretchTo( RectF(RIGHT_EDGE-fQuadWidth,TOP_EDGE,RIGHT_EDGE,BOTTOM_EDGE) );
-
-	m_quadBGBrightness[0].SetName("BrightnessOverlay");
-	ActorUtil::LoadAllCommands(m_quadBGBrightness[0], "Background");
-	this->AddChild(&m_quadBGBrightness[0]);
-
-	//m_quadBGBrightness[1].SetName( "BrightnessOverlay" );
-	//ActorUtil::LoadAllCommands( m_quadBGBrightness[1], "Background" );
-	//this->AddChild( &m_quadBGBrightness[1] );
+	
+	m_quadBGBrightness.SetName("BrightnessOverlay");
+	ActorUtil::LoadAllCommands(m_quadBGBrightness, "Background");
+	this->AddChild(&m_quadBGBrightness);
 
 	m_quadBGBrightnessFade.SetName("BrightnessOverlay");
 	ActorUtil::LoadAllCommands(m_quadBGBrightnessFade, "Background");
@@ -988,8 +983,8 @@ BrightnessOverlay::Update(float fDeltaTime)
 void
 BrightnessOverlay::SetActualBrightness()
 {
-	float fLeftBrightness = 1-GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetCurrent().m_fCover;
-	float fRightBrightness = 1-GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetCurrent().m_fCover;
+	float fLeftBrightness = 1-GAMESTATE->m_pPlayerState->m_PlayerOptions.GetCurrent().m_fCover;
+	float fRightBrightness = 1-GAMESTATE->m_pPlayerState->m_PlayerOptions.GetCurrent().m_fCover;
 
 	float fBaseBGBrightness = g_fBGBrightness;
 
@@ -1011,7 +1006,7 @@ BrightnessOverlay::SetActualBrightness()
 	RageColor LeftColor = GetBrightnessColor(fLeftBrightness);
 	RageColor RightColor = GetBrightnessColor(fRightBrightness);
 
-	m_quadBGBrightness[PLAYER_1].SetDiffuse( LeftColor );
+	m_quadBGBrightness.SetDiffuse( LeftColor );
 	m_quadBGBrightnessFade.SetDiffuseLeftEdge( LeftColor );
 	m_quadBGBrightnessFade.SetDiffuseRightEdge( RightColor );
 }
@@ -1021,7 +1016,7 @@ BrightnessOverlay::Set(float fBrightness)
 {
 	RageColor c = GetBrightnessColor(fBrightness);
 
-	m_quadBGBrightness[PLAYER_1].SetDiffuse(c);
+	m_quadBGBrightness.SetDiffuse(c);
 	m_quadBGBrightnessFade.SetDiffuse(c);
 }
 

--- a/src/CodeDetector.cpp
+++ b/src/CodeDetector.cpp
@@ -171,7 +171,7 @@ CodeDetector::ChangeScrollSpeed(GameController controller, bool bIncrement)
 	// opt = PlayerOptions
 	// setup
 	PlayerNumber pn = INPUTMAPPER->ControllerToPlayerNumber( controller );
-	PlayerOptions po = GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.GetPreferred();
+	PlayerOptions po = GAMESTATE->m_pPlayerState->m_PlayerOptions.GetPreferred();
 
 	/* what this code seems to be doing is:
 	 * 1) getting the Speed line from the theme
@@ -235,7 +235,7 @@ CodeDetector::DetectAndAdjustMusicOptions(GameController controller)
 		auto code = static_cast<Code>(c);
 
 		PlayerOptions po =
-		  GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.GetPreferred();
+		  GAMESTATE->m_pPlayerState->m_PlayerOptions.GetPreferred();
 
 		if (EnteredCode(controller, code)) {
 			switch (code) {
@@ -282,7 +282,7 @@ CodeDetector::DetectAndAdjustMusicOptions(GameController controller)
 					break;
 			}
 
-			GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.Assign(
+			GAMESTATE->m_pPlayerState->m_PlayerOptions.Assign(
 			  ModsLevel_Preferred, po);
 
 			return true; // don't check any more

--- a/src/DancingCharacters.cpp
+++ b/src/DancingCharacters.cpp
@@ -47,19 +47,17 @@ const float CAMERA_STILL_HEIGHT_VARIANCE = 5.f;
 const float CAMERA_STILL_LOOK_AT_HEIGHT = -10.f;
 
 const float MODEL_X_ONE_PLAYER = 0;
-const float MODEL_X_TWO_PLAYERS[NUM_PLAYERS] = { 0 };
-const float MODEL_ROTATIONY_TWO_PLAYERS[NUM_PLAYERS] = { 0 };
 
 DancingCharacters::DancingCharacters()
 {
 	PlayerNumber p = PLAYER_1;
-	m_pCharacter[p] = new Model;
-	m_2DIdleTimer[p].SetZero();
-	m_i2DAnimState[p] = AS2D_IDLE; // start on idle state
+	m_pCharacter = new Model;
+	m_2DIdleTimer.SetZero();
+	m_i2DAnimState = AS2D_IDLE; // start on idle state
 	if (!GAMESTATE->IsPlayerEnabled(p))
 		return;
 
-	Character* pChar = GAMESTATE->m_pCurCharacters[p];
+	Character* pChar = GAMESTATE->m_pCurCharacters;
 	if (pChar == nullptr)
 		return;
 
@@ -70,91 +68,88 @@ DancingCharacters::DancingCharacters()
 	if (DoesFileExist(sCurrentAnim +
 						"/BGAnimation.ini")) // check 2D Idle BGAnim exists
 	{
-		m_bgIdle[p].Load(sCurrentAnim);
-		m_bgIdle[p]->SetXY(DC_X(p), DC_Y(p));
+		m_bgIdle.Load(sCurrentAnim);
+		m_bgIdle->SetXY(DC_X(p), DC_Y(p));
 	}
 
 	sCurrentAnim = sCharacterDirectory + "2DMiss";
 	if (DoesFileExist(sCurrentAnim +
 						"/BGAnimation.ini")) // check 2D Idle BGAnim exists
 	{
-		m_bgMiss[p].Load(sCurrentAnim);
-		m_bgMiss[p]->SetXY(DC_X(p), DC_Y(p));
+		m_bgMiss.Load(sCurrentAnim);
+		m_bgMiss->SetXY(DC_X(p), DC_Y(p));
 	}
 
 	sCurrentAnim = sCharacterDirectory + "2DGood";
 	if (DoesFileExist(sCurrentAnim +
 						"/BGAnimation.ini")) // check 2D Idle BGAnim exists
 	{
-		m_bgGood[p].Load(sCurrentAnim);
-		m_bgGood[p]->SetXY(DC_X(p), DC_Y(p));
+		m_bgGood.Load(sCurrentAnim);
+		m_bgGood->SetXY(DC_X(p), DC_Y(p));
 	}
 
 	sCurrentAnim = sCharacterDirectory + "2DGreat";
 	if (DoesFileExist(sCurrentAnim +
 						"/BGAnimation.ini")) // check 2D Idle BGAnim exists
 	{
-		m_bgGreat[p].Load(sCurrentAnim);
-		m_bgGreat[p]->SetXY(DC_X(p), DC_Y(p));
+		m_bgGreat.Load(sCurrentAnim);
+		m_bgGreat->SetXY(DC_X(p), DC_Y(p));
 	}
 
 	sCurrentAnim = sCharacterDirectory + "2DFever";
 	if (DoesFileExist(sCurrentAnim +
 						"/BGAnimation.ini")) // check 2D Idle BGAnim exists
 	{
-		m_bgFever[p].Load(sCurrentAnim);
-		m_bgFever[p]->SetXY(DC_X(p), DC_Y(p));
+		m_bgFever.Load(sCurrentAnim);
+		m_bgFever->SetXY(DC_X(p), DC_Y(p));
 	}
 
 	sCurrentAnim = sCharacterDirectory + "2DFail";
 	if (DoesFileExist(sCurrentAnim +
 						"/BGAnimation.ini")) // check 2D Idle BGAnim exists
 	{
-		m_bgFail[p].Load(sCurrentAnim);
-		m_bgFail[p]->SetXY(DC_X(p), DC_Y(p));
+		m_bgFail.Load(sCurrentAnim);
+		m_bgFail->SetXY(DC_X(p), DC_Y(p));
 	}
 
 	sCurrentAnim = sCharacterDirectory + "2DWin";
 	if (DoesFileExist(sCurrentAnim +
 						"/BGAnimation.ini")) // check 2D Idle BGAnim exists
 	{
-		m_bgWin[p].Load(sCurrentAnim);
-		m_bgWin[p]->SetXY(DC_X(p), DC_Y(p));
+		m_bgWin.Load(sCurrentAnim);
+		m_bgWin->SetXY(DC_X(p), DC_Y(p));
 	}
 
 	sCurrentAnim = sCharacterDirectory + "2DWinFever";
 	if (DoesFileExist(sCurrentAnim +
 						"/BGAnimation.ini")) // check 2D Idle BGAnim exists
 	{
-		m_bgWinFever[p].Load(sCurrentAnim);
-		m_bgWinFever[p]->SetXY(DC_X(p), DC_Y(p));
+		m_bgWinFever.Load(sCurrentAnim);
+		m_bgWinFever->SetXY(DC_X(p), DC_Y(p));
 	}
 
 	if (pChar->GetModelPath().empty())
 		return;
 
-	if (GAMESTATE->GetNumPlayersEnabled() == 2)
-		m_pCharacter[p]->SetX(MODEL_X_TWO_PLAYERS[p]);
-	else
-		m_pCharacter[p]->SetX(MODEL_X_ONE_PLAYER);
+	m_pCharacter->SetX(MODEL_X_ONE_PLAYER);
 
-	m_pCharacter[p]->LoadMilkshapeAscii(pChar->GetModelPath());
-	m_pCharacter[p]->LoadMilkshapeAsciiBones("rest",
+	m_pCharacter->LoadMilkshapeAscii(pChar->GetModelPath());
+	m_pCharacter->LoadMilkshapeAsciiBones("rest",
 												pChar->GetRestAnimationPath());
-	m_pCharacter[p]->LoadMilkshapeAsciiBones(
+	m_pCharacter->LoadMilkshapeAsciiBones(
 		"warmup", pChar->GetWarmUpAnimationPath());
-	m_pCharacter[p]->LoadMilkshapeAsciiBones(
+	m_pCharacter->LoadMilkshapeAsciiBones(
 		"dance", pChar->GetDanceAnimationPath());
-	m_pCharacter[p]->SetCullMode(CULL_NONE); // many of the models floating
+	m_pCharacter->SetCullMode(CULL_NONE); // many of the models floating
 												// around have the vertex order
 												// flipped
 
-	m_pCharacter[p]->RunCommands(pChar->m_cmdInit);
+	m_pCharacter->RunCommands(pChar->m_cmdInit);
 }
 
 DancingCharacters::~DancingCharacters()
 {
-	delete m_pCharacter[PLAYER_1];
+	delete m_pCharacter;
 }
 
 void
@@ -174,7 +169,7 @@ DancingCharacters::LoadNextSong()
 	m_fThisCameraEndBeat = GAMESTATE->m_pCurSong->GetFirstBeat();
 
 	if (GAMESTATE->IsPlayerEnabled(PLAYER_1))
-		m_pCharacter[PLAYER_1]->PlayAnimation("rest");
+		m_pCharacter->PlayAnimation("rest");
 }
 
 int
@@ -201,14 +196,14 @@ DancingCharacters::Update(float fDelta)
 		fUpdateScale *= GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate;
 
 		if (GAMESTATE->IsPlayerEnabled(PLAYER_1))
-			m_pCharacter[PLAYER_1]->Update(fDelta * fUpdateScale);
+			m_pCharacter->Update(fDelta * fUpdateScale);
 	}
 
 	static bool bWasGameplayStarting = false;
 	bool bGameplayStarting = GAMESTATE->m_bGameplayLeadIn;
 	if (!bWasGameplayStarting && bGameplayStarting) {
 		if (GAMESTATE->IsPlayerEnabled(PLAYER_1))
-		  m_pCharacter[PLAYER_1]->PlayAnimation("warmup");
+		  m_pCharacter->PlayAnimation("warmup");
 	}
 	bWasGameplayStarting = bGameplayStarting;
 
@@ -216,7 +211,7 @@ DancingCharacters::Update(float fDelta)
 	float firstBeat = GAMESTATE->m_pCurSong->GetFirstBeat();
 	float fThisBeat = GAMESTATE->m_Position.m_fSongBeat;
 	if (fLastBeat < firstBeat && fThisBeat >= firstBeat) {
-		m_pCharacter[PLAYER_1]->PlayAnimation("dance");
+		m_pCharacter->PlayAnimation("dance");
 	}
 	fLastBeat = fThisBeat;
 
@@ -267,11 +262,10 @@ DancingCharacters::Update(float fDelta)
 	/*
 	// is there any of this still around? This block of code is _ugly_. -Colby
 	// update any 2D stuff
-	PlayerNumber p = PLAYER_1;
-	if( m_bgIdle[p].IsLoaded() )
+	if( m_bgIdle.IsLoaded() )
 	{
-		if( m_bgIdle[p].IsLoaded() && m_i2DAnimState[p] == AS2D_IDLE )
-			m_bgIdle[p]->Update( fDelta );
+		if( m_bgIdle.IsLoaded() && m_i2DAnimState[p] == AS2D_IDLE )
+			m_bgIdle->Update( fDelta );
 		if( m_bgMiss[p].IsLoaded() && m_i2DAnimState[p] == AS2D_MISS )
 			m_bgMiss[p]->Update( fDelta );
 		if( m_bgGood[p].IsLoaded() && m_i2DAnimState[p] == AS2D_GOOD )
@@ -314,7 +308,7 @@ DancingCharacters::Change2DAnimState(PlayerNumber pn, int iState)
 	ASSERT(pn < NUM_PLAYERS);
 	ASSERT(iState < AS2D_MAXSTATES);
 
-	m_i2DAnimState[pn] = iState;
+	m_i2DAnimState = iState;
 }
 
 void
@@ -347,7 +341,7 @@ DancingCharacters::DrawPrimitives()
 
 	FOREACH_EnabledPlayer(p)
 	{
-		bool bFailed = STATSMAN->m_CurStageStats.m_player[p].m_bFailed;
+		bool bFailed = STATSMAN->m_CurStageStats.m_player.m_bFailed;
 		bool bDanger = m_bDrawDangerLight;
 
 		DISPLAY->SetLighting(true);
@@ -365,14 +359,14 @@ DancingCharacters::DrawPrimitives()
 		  0, ambient, diffuse, specular, RageVector3(-3, -7.5f, +9));
 
 		if (PREFSMAN->m_bCelShadeModels) {
-			m_pCharacter[p]->DrawCelShaded();
+			m_pCharacter->DrawCelShaded();
 
 			DISPLAY->SetLightOff(0);
 			DISPLAY->SetLighting(false);
 			continue;
 		}
 
-		m_pCharacter[p]->Draw();
+		m_pCharacter->Draw();
 
 		DISPLAY->SetLightOff(0);
 		DISPLAY->SetLighting(false);
@@ -384,9 +378,8 @@ DancingCharacters::DrawPrimitives()
 	// Ugly! -Colby
 	// now draw any potential 2D stuff
 	{
-		PlayerNumber p = PLAYER_1;
-		if(m_bgIdle[p].IsLoaded() && m_i2DAnimState[p] == AS2D_IDLE)
-			m_bgIdle[p]->Draw();
+		if(m_bgIdle.IsLoaded() && m_i2DAnimState[p] == AS2D_IDLE)
+			m_bgIdle->Draw();
 		if(m_bgMiss[p].IsLoaded() && m_i2DAnimState[p] == AS2D_MISS)
 			m_bgMiss[p]->Draw();
 		if(m_bgGood[p].IsLoaded() && m_i2DAnimState[p] == AS2D_GOOD)

--- a/src/DancingCharacters.h
+++ b/src/DancingCharacters.h
@@ -1,4 +1,4 @@
-﻿#ifndef DancingCharacters_H
+#ifndef DancingCharacters_H
 #define DancingCharacters_H
 
 #include "ActorFrame.h"
@@ -38,7 +38,7 @@ class DancingCharacters : public ActorFrame
 	void Change2DAnimState(PlayerNumber pn, int iState);
 
   protected:
-	Model* m_pCharacter[NUM_PLAYERS];
+	Model* m_pCharacter;
 
 	/** @brief How far away is the camera from the dancer? */
 	float m_CameraDistance{ 0 };
@@ -50,19 +50,19 @@ class DancingCharacters : public ActorFrame
 	float m_fThisCameraStartBeat{ 0 };
 	float m_fThisCameraEndBeat{ 0 };
 
-	bool m_bHas2DElements[NUM_PLAYERS];
+	bool m_bHas2DElements;
 
-	AutoActor m_bgIdle[NUM_PLAYERS];
-	AutoActor m_bgMiss[NUM_PLAYERS];
-	AutoActor m_bgGood[NUM_PLAYERS];
-	AutoActor m_bgGreat[NUM_PLAYERS];
-	AutoActor m_bgFever[NUM_PLAYERS];
-	AutoActor m_bgFail[NUM_PLAYERS];
-	AutoActor m_bgWin[NUM_PLAYERS];
-	AutoActor m_bgWinFever[NUM_PLAYERS];
-	RageTimer m_2DIdleTimer[NUM_PLAYERS];
+	AutoActor m_bgIdle;
+	AutoActor m_bgMiss;
+	AutoActor m_bgGood;
+	AutoActor m_bgGreat;
+	AutoActor m_bgFever;
+	AutoActor m_bgFail;
+	AutoActor m_bgWin;
+	AutoActor m_bgWinFever;
+	RageTimer m_2DIdleTimer;
 
-	int m_i2DAnimState[NUM_PLAYERS];
+	int m_i2DAnimState;
 };
 
 #endif

--- a/src/DifficultyList.cpp
+++ b/src/DifficultyList.cpp
@@ -54,7 +54,7 @@ StepsDisplayList::LoadFromNode(const XNode* pNode)
 			ActorUtil::GetWhere(pNode).c_str(),
 			PLAYER_1 + 1);
 	} else {
-		m_Cursors[PLAYER_1].LoadActorFromNode(pChild, this);
+		m_Cursors.LoadActorFromNode(pChild, this);
 	}
 
 	/* Hack: we need to tween cursors both up to down (cursor motion) and
@@ -71,9 +71,9 @@ StepsDisplayList::LoadFromNode(const XNode* pNode)
 			ActorUtil::GetWhere(pNode).c_str(),
 			PLAYER_1 + 1);
 	} else {
-		m_CursorFrames[PLAYER_1].LoadFromNode(pChild);
-		m_CursorFrames[PLAYER_1].AddChild(m_Cursors[PLAYER_1]);
-		this->AddChild(&m_CursorFrames[PLAYER_1]);
+		m_CursorFrames.LoadFromNode(pChild);
+		m_CursorFrames.AddChild(m_Cursors);
+		this->AddChild(&m_CursorFrames);
 	}
 
 	for (unsigned m = 0; m < m_Lines.size(); ++m) {
@@ -95,11 +95,11 @@ StepsDisplayList::GetCurrentRowIndex(PlayerNumber pn) const
 	for (unsigned i = 0; i < m_Rows.size(); i++) {
 		const Row& row = m_Rows[i];
 
-		if (GAMESTATE->m_pCurSteps[pn] == NULL) {
+		if (GAMESTATE->m_pCurSteps == NULL) {
 			if (row.m_dc == ClosestDifficulty)
 				return i;
 		} else {
-			if (GAMESTATE->m_pCurSteps[pn].Get() == row.m_Steps)
+			if (GAMESTATE->m_pCurSteps.Get() == row.m_Steps)
 				return i;
 		}
 	}
@@ -111,8 +111,7 @@ StepsDisplayList::GetCurrentRowIndex(PlayerNumber pn) const
 void
 StepsDisplayList::UpdatePositions()
 {
-	int iCurrentRow[NUM_PLAYERS];
-	FOREACH_HumanPlayer(p) iCurrentRow[p] = GetCurrentRowIndex(p);
+	int iCurrentRow= GetCurrentRowIndex(PLAYER_1);
 
 	const int total = NUM_SHOWN_ITEMS;
 	const int halfsize = total / 2;
@@ -120,7 +119,7 @@ StepsDisplayList::UpdatePositions()
 	int first_start, first_end, second_start, second_end;
 
 	// Choices for each player. If only one player is active, it's the same for both.
-	int P1Choice = iCurrentRow[PLAYER_1];
+	int P1Choice = iCurrentRow;
 
 	vector<Row>& Rows = m_Rows;
 
@@ -230,17 +229,14 @@ StepsDisplayList::PositionItems()
 		m_Lines[m].m_Meter.SetDiffuseAlpha(fDiffuseAlpha);
 	}
 
-	FOREACH_HumanPlayer(pn)
-	{
-		int iCurrentRow = GetCurrentRowIndex(pn);
+	int iCurrentRow = GetCurrentRowIndex(PLAYER_1);
 
-		float fY = 0;
-		if (iCurrentRow < (int)m_Rows.size())
-			fY = m_Rows[iCurrentRow].m_fY;
+	float fY = 0;
+	if (iCurrentRow < (int)m_Rows.size())
+		fY = m_Rows[iCurrentRow].m_fY;
 
-		m_CursorFrames[pn].PlayCommand("Change");
-		m_CursorFrames[pn].SetY(fY);
-	}
+	m_CursorFrames.PlayCommand("Change");
+	m_CursorFrames.SetY(fY);
 }
 
 void
@@ -303,7 +299,7 @@ StepsDisplayList::HideRows()
 void
 StepsDisplayList::TweenOnScreen()
 {
-	FOREACH_HumanPlayer(pn) ON_COMMAND(m_Cursors[pn]);
+	ON_COMMAND(m_Cursors);
 
 	for (int m = 0; m < MAX_METERS; ++m)
 		ON_COMMAND(m_Lines[m].m_Meter);
@@ -318,7 +314,7 @@ StepsDisplayList::TweenOnScreen()
 	HideRows();
 	PositionItems();
 
-	FOREACH_HumanPlayer(pn) COMMAND(m_Cursors[pn], "TweenOn");
+	COMMAND(m_Cursors, "TweenOn");
 }
 
 void
@@ -336,7 +332,7 @@ StepsDisplayList::Show()
 	HideRows();
 	PositionItems();
 
-	FOREACH_HumanPlayer(pn) COMMAND(m_Cursors[pn], "Show");
+	COMMAND(m_Cursors, "Show");
 }
 
 void
@@ -345,7 +341,7 @@ StepsDisplayList::Hide()
 	m_bShown = false;
 	PositionItems();
 
-	FOREACH_HumanPlayer(pn) COMMAND(m_Cursors[pn], "Hide");
+	COMMAND(m_Cursors, "Hide");
 }
 
 void

--- a/src/DifficultyList.h
+++ b/src/DifficultyList.h
@@ -39,8 +39,8 @@ class StepsDisplayList : public ActorFrame
 	ThemeMetric<bool> CAPITALIZE_DIFFICULTY_NAMES;
 	ThemeMetric<apActorCommands> MOVE_COMMAND;
 
-	AutoActor m_Cursors[NUM_PLAYERS];
-	ActorFrame m_CursorFrames[NUM_PLAYERS]; // contains Cursor so that color can
+	AutoActor m_Cursors;
+	ActorFrame m_CursorFrames; // contains Cursor so that color can
 											// fade independent of other tweens
 
 	struct Line

--- a/src/DownloadManager.cpp
+++ b/src/DownloadManager.cpp
@@ -1900,9 +1900,9 @@ DownloadManager::OnLogin()
 		DLMAN->UploadScores();
 		DLMAN->UpdateOnlineScoreReplayData();
 	}
-	if (GAMESTATE->m_pCurSteps[PLAYER_1] != nullptr)
+	if (GAMESTATE->m_pCurSteps != nullptr)
 		DLMAN->RequestChartLeaderBoard(
-		  GAMESTATE->m_pCurSteps[PLAYER_1]->GetChartKey());
+		  GAMESTATE->m_pCurSteps->GetChartKey());
 	MESSAGEMAN->Broadcast("Login");
 	DLMAN->loggingIn = false;
 }

--- a/src/DualScrollBar.cpp
+++ b/src/DualScrollBar.cpp
@@ -12,21 +12,21 @@ DualScrollBar::DualScrollBar()
 void
 DualScrollBar::Load(const RString& sType)
 {
-	m_sprScrollThumbUnderHalf[PLAYER_1].Load(
+	m_sprScrollThumbUnderHalf.Load(
 		THEME->GetPathG(sType, ssprintf("thumb p%i", PLAYER_1 + 1)));
-	m_sprScrollThumbUnderHalf[PLAYER_1]->SetName(ssprintf("ThumbP%i", PLAYER_1 + 1));
-	this->AddChild(m_sprScrollThumbUnderHalf[PLAYER_1]);
+	m_sprScrollThumbUnderHalf->SetName(ssprintf("ThumbP%i", PLAYER_1 + 1));
+	this->AddChild(m_sprScrollThumbUnderHalf);
 
-	m_sprScrollThumbOverHalf[PLAYER_1].Load(
+	m_sprScrollThumbOverHalf.Load(
 		THEME->GetPathG(sType, ssprintf("thumb p%i", PLAYER_1 + 1)));
-	m_sprScrollThumbOverHalf[PLAYER_1]->SetName(ssprintf("ThumbP%i", PLAYER_1 + 1));
-	this->AddChild(m_sprScrollThumbOverHalf[PLAYER_1]);
+	m_sprScrollThumbOverHalf->SetName(ssprintf("ThumbP%i", PLAYER_1 + 1));
+	this->AddChild(m_sprScrollThumbOverHalf);
 
-	m_sprScrollThumbUnderHalf[0]->SetCropLeft(.5f);
-	m_sprScrollThumbUnderHalf[1]->SetCropRight(.5f);
+	m_sprScrollThumbUnderHalf->SetCropLeft(.5f);
+	m_sprScrollThumbUnderHalf->SetCropRight(.5f);
 
-	m_sprScrollThumbOverHalf[0]->SetCropRight(.5f);
-	m_sprScrollThumbOverHalf[1]->SetCropLeft(.5f);
+	m_sprScrollThumbOverHalf->SetCropRight(.5f);
+	m_sprScrollThumbOverHalf->SetCropLeft(.5f);
 
 	SetPercentage(PLAYER_1, 0);
 
@@ -36,25 +36,25 @@ DualScrollBar::Load(const RString& sType)
 void
 DualScrollBar::EnablePlayer(PlayerNumber pn, bool on)
 {
-	m_sprScrollThumbUnderHalf[pn]->SetVisible(on);
-	m_sprScrollThumbOverHalf[pn]->SetVisible(on);
+	m_sprScrollThumbUnderHalf->SetVisible(on);
+	m_sprScrollThumbOverHalf->SetVisible(on);
 }
 
 void
 DualScrollBar::SetPercentage(PlayerNumber pn, float fPercent)
 {
 	const float bottom =
-	  m_fBarHeight / 2 - m_sprScrollThumbUnderHalf[pn]->GetZoomedHeight() / 2;
+	  m_fBarHeight / 2 - m_sprScrollThumbUnderHalf->GetZoomedHeight() / 2;
 	const float top = -bottom;
 
 	/* Position both thumbs. */
-	m_sprScrollThumbUnderHalf[pn]->StopTweening();
-	m_sprScrollThumbUnderHalf[pn]->BeginTweening(m_fBarTime);
-	m_sprScrollThumbUnderHalf[pn]->SetY(SCALE(fPercent, 0, 1, top, bottom));
+	m_sprScrollThumbUnderHalf->StopTweening();
+	m_sprScrollThumbUnderHalf->BeginTweening(m_fBarTime);
+	m_sprScrollThumbUnderHalf->SetY(SCALE(fPercent, 0, 1, top, bottom));
 
-	m_sprScrollThumbOverHalf[pn]->StopTweening();
-	m_sprScrollThumbOverHalf[pn]->BeginTweening(m_fBarTime);
-	m_sprScrollThumbOverHalf[pn]->SetY(SCALE(fPercent, 0, 1, top, bottom));
+	m_sprScrollThumbOverHalf->StopTweening();
+	m_sprScrollThumbOverHalf->BeginTweening(m_fBarTime);
+	m_sprScrollThumbOverHalf->SetY(SCALE(fPercent, 0, 1, top, bottom));
 }
 
 /*

--- a/src/DualScrollBar.h
+++ b/src/DualScrollBar.h
@@ -21,8 +21,8 @@ class DualScrollBar : public ActorFrame
 	float m_fBarHeight;
 	float m_fBarTime;
 
-	AutoActor m_sprScrollThumbOverHalf[NUM_PLAYERS];
-	AutoActor m_sprScrollThumbUnderHalf[NUM_PLAYERS];
+	AutoActor m_sprScrollThumbOverHalf;
+	AutoActor m_sprScrollThumbUnderHalf;
 };
 
 #endif

--- a/src/FilterManager.cpp
+++ b/src/FilterManager.cpp
@@ -9,8 +9,8 @@ FilterManager::FilterManager()
 	// filter stuff - mina
 	ZERO(SSFilterLowerBounds);
 	ZERO(SSFilterUpperBounds);
-	m_pPlayerState[PLAYER_1] = new PlayerState;
-	m_pPlayerState[PLAYER_1]->SetPlayerNumber(PLAYER_1);
+	m_pPlayerState = new PlayerState;
+	m_pPlayerState->SetPlayerNumber(PLAYER_1);
 
 	// Register with Lua.
 	{
@@ -24,7 +24,7 @@ FilterManager::FilterManager()
 
 FilterManager::~FilterManager()
 {
-	SAFE_DELETE(m_pPlayerState[PLAYER_1]);
+	SAFE_DELETE(m_pPlayerState);
 
 	// Unregister with Lua.
 	LUA->UnsetGlobal("FILTERMAN");
@@ -113,7 +113,7 @@ class LunaFilterManager : public Luna<FilterManager>
 	static int SetMaxFilterRate(T* p, lua_State* L)
 	{
 		float mfr = FArg(1);
-		auto loot = p->m_pPlayerState[0];
+		auto loot = p->m_pPlayerState;
 		CLAMP(mfr, loot->wtFFF, 3.f);
 		p->MaxFilterRate = mfr;
 		return 0;
@@ -127,13 +127,13 @@ class LunaFilterManager : public Luna<FilterManager>
 	{
 		float mfr = FArg(1);
 		CLAMP(mfr, 0.7f, p->MaxFilterRate);
-		auto loot = p->m_pPlayerState[0];
+		auto loot = p->m_pPlayerState;
 		loot->wtFFF = mfr;
 		return 0;
 	}
 	static int GetMinFilterRate(T* p, lua_State* L)
 	{
-		auto loot = p->m_pPlayerState[0];
+		auto loot = p->m_pPlayerState;
 		lua_pushnumber(L, loot->wtFFF);
 		return 1;
 	}

--- a/src/FilterManager.h
+++ b/src/FilterManager.h
@@ -11,7 +11,7 @@ class FilterManager
 	FilterManager();
 	~FilterManager();
 
-	PlayerState* m_pPlayerState[NUM_PLAYERS];
+	PlayerState* m_pPlayerState;
 
 	float SSFilterLowerBounds[NUM_Skillset + 1];
 	float SSFilterUpperBounds[NUM_Skillset + 1];

--- a/src/Foreground.cpp
+++ b/src/Foreground.cpp
@@ -45,7 +45,7 @@ Foreground::LoadFromSong(const Song* pSong)
 		if (DoesFileExist(sLuaFile)) {
 			LOG->Warn("Mod map detected, invalidating sequential assumption.");
 			TimingData* td =
-			  GAMESTATE->m_pCurSteps[GAMESTATE->GetMasterPlayerNumber()]
+			  GAMESTATE->m_pCurSteps
 				->GetTimingData();
 			td->InvalidateSequentialAssmption();
 

--- a/src/GameCommand.cpp
+++ b/src/GameCommand.cpp
@@ -81,9 +81,7 @@ GameCommand::DescribesCurrentMode(PlayerNumber pn) const
 	// doesn't match the difficulty of m_pCurSteps.
 	if (m_pSteps == NULL && m_dc != Difficulty_Invalid) {
 		// Why is this checking for all players?
-		FOREACH_HumanPlayer(
-		  human) if (GAMESTATE->m_PreferredDifficulty[human] !=
-					 m_dc) return false;
+		if (GAMESTATE->m_PreferredDifficulty != m_dc) return false;
 	}
 
 	if (m_sAnnouncer != "" && m_sAnnouncer != ANNOUNCER->GetCurAnnouncerName())
@@ -91,24 +89,24 @@ GameCommand::DescribesCurrentMode(PlayerNumber pn) const
 
 	if (m_sPreferredModifiers != "") {
 		PlayerOptions po =
-		  GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.GetPreferred();
+		  GAMESTATE->m_pPlayerState->m_PlayerOptions.GetPreferred();
 		SongOptions so = GAMESTATE->m_SongOptions.GetPreferred();
 		po.FromString(m_sPreferredModifiers);
 		so.FromString(m_sPreferredModifiers);
 
-		if (po != GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.GetPreferred())
+		if (po != GAMESTATE->m_pPlayerState->m_PlayerOptions.GetPreferred())
 			return false;
 		if (so != GAMESTATE->m_SongOptions.GetPreferred())
 			return false;
 	}
 	if (m_sStageModifiers != "") {
 		PlayerOptions po =
-		  GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.GetStage();
+		  GAMESTATE->m_pPlayerState->m_PlayerOptions.GetStage();
 		SongOptions so = GAMESTATE->m_SongOptions.GetStage();
 		po.FromString(m_sStageModifiers);
 		so.FromString(m_sStageModifiers);
 
-		if (po != GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.GetStage())
+		if (po != GAMESTATE->m_pPlayerState->m_PlayerOptions.GetStage())
 			return false;
 		if (so != GAMESTATE->m_SongOptions.GetStage())
 			return false;
@@ -116,10 +114,10 @@ GameCommand::DescribesCurrentMode(PlayerNumber pn) const
 
 	if (m_pSong && GAMESTATE->m_pCurSong.Get() != m_pSong)
 		return false;
-	if (m_pSteps && GAMESTATE->m_pCurSteps[pn].Get() != m_pSteps)
+	if (m_pSteps && GAMESTATE->m_pCurSteps.Get() != m_pSteps)
 		return false;
 	if ((m_pCharacter != nullptr) &&
-		GAMESTATE->m_pCurCharacters[pn] != m_pCharacter)
+		GAMESTATE->m_pCurCharacters != m_pCharacter)
 		return false;
 	if (!m_sSongGroup.empty() &&
 		GAMESTATE->m_sPreferredSongGroup != m_sSongGroup)
@@ -482,7 +480,7 @@ GameCommand::ApplySelf(const vector<PlayerNumber>& vpns) const
 	}
 	if (m_dc != Difficulty_Invalid)
 		FOREACH_CONST(PlayerNumber, vpns, pn)
-	GAMESTATE->m_PreferredDifficulty[*pn].Set(m_dc);
+	GAMESTATE->m_PreferredDifficulty.Set(m_dc);
 	if (m_sAnnouncer != "")
 		ANNOUNCER->SwitchAnnouncer(m_sAnnouncer);
 	if (m_sPreferredModifiers != "")
@@ -511,11 +509,9 @@ GameCommand::ApplySelf(const vector<PlayerNumber>& vpns) const
 		GAMESTATE->m_pPreferredSong = m_pSong;
 	}
 	if (m_pSteps)
-		FOREACH_CONST(PlayerNumber, vpns, pn)
-	GAMESTATE->m_pCurSteps[*pn].Set(m_pSteps);
+		GAMESTATE->m_pCurSteps.Set(m_pSteps);
 	if (m_pCharacter)
-		FOREACH_CONST(PlayerNumber, vpns, pn)
-	GAMESTATE->m_pCurCharacters[*pn] = m_pCharacter;
+		GAMESTATE->m_pCurCharacters = m_pCharacter;
 	for (map<RString, RString>::const_iterator i = m_SetEnv.begin();
 		 i != m_SetEnv.end();
 		 i++) {
@@ -566,7 +562,7 @@ GameCommand::ApplySelf(const vector<PlayerNumber>& vpns) const
 		// applying options affects only the current stage
 		PlayerOptions po;
 		GAMESTATE->GetDefaultPlayerOptions(po);
-		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.Assign(
+		GAMESTATE->m_pPlayerState->m_PlayerOptions.Assign(
 			ModsLevel_Stage, po);
 
 		SongOptions so;

--- a/src/GameConstantsAndTypes.cpp
+++ b/src/GameConstantsAndTypes.cpp
@@ -13,6 +13,7 @@
 RString
 StepsTypeToString(StepsType st);
 
+// This was formerly used to fill in RANKING_TO_FILL_IN_MARKER when it was a vector of RStrings. -poco
 static vector<RString>
 GenerateRankingToFillInMarker()
 {
@@ -20,8 +21,7 @@ GenerateRankingToFillInMarker()
 	vRankings.push_back(ssprintf("#P%d#", PLAYER_1 + 1));
 	return vRankings;
 }
-extern const vector<RString> RANKING_TO_FILL_IN_MARKER(
-  GenerateRankingToFillInMarker());
+extern const RString RANKING_TO_FILL_IN_MARKER("#P1#");
 
 extern const RString GROUP_ALL = "---Group All---";
 

--- a/src/GameConstantsAndTypes.h
+++ b/src/GameConstantsAndTypes.h
@@ -373,7 +373,7 @@ const RString&
 ProfileSlotToString(ProfileSlot ps);
 LuaDeclareType(ProfileSlot);
 
-extern const vector<RString> RANKING_TO_FILL_IN_MARKER;
+extern const RString RANKING_TO_FILL_IN_MARKER;
 inline bool
 IsRankingToFillIn(const RString& sName)
 {

--- a/src/GameManager.cpp
+++ b/src/GameManager.cpp
@@ -151,13 +151,13 @@ static const Style g_Style_Dance_Single =
 	StepsType_dance_single,	// m_StepsType
 	StyleType_OnePlayerOneSide,		// m_StyleType
 	4,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-DANCE_COL_SPACING*1.5f, NULL },
-			{ TRACK_2,	-DANCE_COL_SPACING*0.5f, NULL },
-			{ TRACK_3,	+DANCE_COL_SPACING*0.5f, NULL },
-			{ TRACK_4,	+DANCE_COL_SPACING*1.5f, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-DANCE_COL_SPACING*1.5f, NULL },
+		{ TRACK_2,	-DANCE_COL_SPACING*0.5f, NULL },
+		{ TRACK_3,	+DANCE_COL_SPACING*0.5f, NULL },
+		{ TRACK_4,	+DANCE_COL_SPACING*1.5f, NULL },
+		
 	},
 	{	// m_iInputColumn[NUM_GameController][NUM_GameButton]
 		{ 0, 3, 2, 1, Style::END_MAPPING },
@@ -179,17 +179,17 @@ static const Style g_Style_Dance_Double =
 	StepsType_dance_double,	// m_StepsType
 	StyleType_OnePlayerTwoSides,		// m_StyleType
 	8,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-DANCE_COL_SPACING*3.5f, NULL },
-			{ TRACK_2,	-DANCE_COL_SPACING*2.5f, NULL },
-			{ TRACK_3,	-DANCE_COL_SPACING*1.5f, NULL },
-			{ TRACK_4,	-DANCE_COL_SPACING*0.5f, NULL },
-			{ TRACK_5,	+DANCE_COL_SPACING*0.5f, NULL },
-			{ TRACK_6,	+DANCE_COL_SPACING*1.5f, NULL },
-			{ TRACK_7,	+DANCE_COL_SPACING*2.5f, NULL },
-			{ TRACK_8,	+DANCE_COL_SPACING*3.5f, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-DANCE_COL_SPACING*3.5f, NULL },
+		{ TRACK_2,	-DANCE_COL_SPACING*2.5f, NULL },
+		{ TRACK_3,	-DANCE_COL_SPACING*1.5f, NULL },
+		{ TRACK_4,	-DANCE_COL_SPACING*0.5f, NULL },
+		{ TRACK_5,	+DANCE_COL_SPACING*0.5f, NULL },
+		{ TRACK_6,	+DANCE_COL_SPACING*1.5f, NULL },
+		{ TRACK_7,	+DANCE_COL_SPACING*2.5f, NULL },
+		{ TRACK_8,	+DANCE_COL_SPACING*3.5f, NULL },
+		
 	},
 	{	// m_iInputColumn[NUM_GameController][NUM_GameButton]
 		{ 0, 3, 2, 1, Style::END_MAPPING },
@@ -212,15 +212,15 @@ static const Style g_Style_Dance_Solo = {
 	StepsType_dance_solo,		// m_StepsType
 	StyleType_OnePlayerOneSide,		// m_StyleType
 	6,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-DANCE_COL_SPACING*2.5f, NULL },
-			{ TRACK_2,	-DANCE_COL_SPACING*1.5f, NULL },
-			{ TRACK_3,	-DANCE_COL_SPACING*0.5f, NULL },
-			{ TRACK_4,	+DANCE_COL_SPACING*0.5f, NULL },
-			{ TRACK_5,	+DANCE_COL_SPACING*1.5f, NULL },
-			{ TRACK_6,	+DANCE_COL_SPACING*2.5f, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-DANCE_COL_SPACING*2.5f, NULL },
+		{ TRACK_2,	-DANCE_COL_SPACING*1.5f, NULL },
+		{ TRACK_3,	-DANCE_COL_SPACING*0.5f, NULL },
+		{ TRACK_4,	+DANCE_COL_SPACING*0.5f, NULL },
+		{ TRACK_5,	+DANCE_COL_SPACING*1.5f, NULL },
+		{ TRACK_6,	+DANCE_COL_SPACING*2.5f, NULL },
+		
 	},
 	{	// m_iInputColumn[NUM_GameController][NUM_GameButton]
 		{ 0, 5, 3, 2, 1, 4, Style::END_MAPPING },
@@ -242,12 +242,12 @@ static const Style g_Style_Dance_ThreePanel =
 	StepsType_dance_threepanel,		// m_StepsType
 	StyleType_OnePlayerOneSide,		// m_StyleType
 	3,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-DANCE_COL_SPACING*1.0f, NULL },
-			{ TRACK_2,	+DANCE_COL_SPACING*0.0f, NULL },
-			{ TRACK_3,	+DANCE_COL_SPACING*1.0f, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-DANCE_COL_SPACING*1.0f, NULL },
+		{ TRACK_2,	+DANCE_COL_SPACING*0.0f, NULL },
+		{ TRACK_3,	+DANCE_COL_SPACING*1.0f, NULL },
+		
 	},
 	{	// m_iInputColumn[NUM_GameController][NUM_GameButton]
 		// 4 3 5
@@ -339,14 +339,14 @@ static const Style g_Style_Pump_Single = {
 	StepsType_pump_single,		// m_StepsType
 	StyleType_OnePlayerOneSide,		// m_StyleType
 	5,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-PUMP_COL_SPACING*2.0f, NULL },
-			{ TRACK_2,	-PUMP_COL_SPACING*1.0f, NULL },
-			{ TRACK_3,	+PUMP_COL_SPACING*0.0f, NULL },
-			{ TRACK_4,	+PUMP_COL_SPACING*1.0f, NULL },
-			{ TRACK_5,	+PUMP_COL_SPACING*2.0f, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-PUMP_COL_SPACING*2.0f, NULL },
+		{ TRACK_2,	-PUMP_COL_SPACING*1.0f, NULL },
+		{ TRACK_3,	+PUMP_COL_SPACING*0.0f, NULL },
+		{ TRACK_4,	+PUMP_COL_SPACING*1.0f, NULL },
+		{ TRACK_5,	+PUMP_COL_SPACING*2.0f, NULL },
+		
 	},
 	{
 	  // m_iInputColumn[NUM_GameController][NUM_GameButton]
@@ -369,15 +369,15 @@ static const Style g_Style_Pump_HalfDouble =
 	StepsType_pump_halfdouble,	// m_StepsType
 	StyleType_OnePlayerTwoSides,		// m_StyleType
 	6,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-PUMP_COL_SPACING*2.5f-4, NULL },
-			{ TRACK_2,	-PUMP_COL_SPACING*1.5f-4, NULL },
-			{ TRACK_3,	-PUMP_COL_SPACING*0.5f-4, NULL },
-			{ TRACK_4,	+PUMP_COL_SPACING*0.5f+4, NULL },
-			{ TRACK_5,	+PUMP_COL_SPACING*1.5f+4, NULL },
-			{ TRACK_6,	+PUMP_COL_SPACING*2.5f+4, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-PUMP_COL_SPACING*2.5f-4, NULL },
+		{ TRACK_2,	-PUMP_COL_SPACING*1.5f-4, NULL },
+		{ TRACK_3,	-PUMP_COL_SPACING*0.5f-4, NULL },
+		{ TRACK_4,	+PUMP_COL_SPACING*0.5f+4, NULL },
+		{ TRACK_5,	+PUMP_COL_SPACING*1.5f+4, NULL },
+		{ TRACK_6,	+PUMP_COL_SPACING*2.5f+4, NULL },
+		
 	},
 	{	// m_iInputColumn[NUM_GameController][NUM_GameButton]
 		{ Style::NO_MAPPING, 1, 0, Style::NO_MAPPING, 2, Style::END_MAPPING },
@@ -400,19 +400,19 @@ static const Style g_Style_Pump_Double =
 	StepsType_pump_double,		// m_StepsType
 	StyleType_OnePlayerTwoSides,		// m_StyleType
 	10,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-PUMP_COL_SPACING*4.5f-4, NULL },
-			{ TRACK_2,	-PUMP_COL_SPACING*3.5f-4, NULL },
-			{ TRACK_3,	-PUMP_COL_SPACING*2.5f-4, NULL },
-			{ TRACK_4,	-PUMP_COL_SPACING*1.5f-4, NULL },
-			{ TRACK_5,	-PUMP_COL_SPACING*0.5f-4, NULL },
-			{ TRACK_6,	+PUMP_COL_SPACING*0.5f+4, NULL },
-			{ TRACK_7,	+PUMP_COL_SPACING*1.5f+4, NULL },
-			{ TRACK_8,	+PUMP_COL_SPACING*2.5f+4, NULL },
-			{ TRACK_9,	+PUMP_COL_SPACING*3.5f+4, NULL },
-			{ TRACK_10,	+PUMP_COL_SPACING*4.5f+4, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-PUMP_COL_SPACING*4.5f-4, NULL },
+		{ TRACK_2,	-PUMP_COL_SPACING*3.5f-4, NULL },
+		{ TRACK_3,	-PUMP_COL_SPACING*2.5f-4, NULL },
+		{ TRACK_4,	-PUMP_COL_SPACING*1.5f-4, NULL },
+		{ TRACK_5,	-PUMP_COL_SPACING*0.5f-4, NULL },
+		{ TRACK_6,	+PUMP_COL_SPACING*0.5f+4, NULL },
+		{ TRACK_7,	+PUMP_COL_SPACING*1.5f+4, NULL },
+		{ TRACK_8,	+PUMP_COL_SPACING*2.5f+4, NULL },
+		{ TRACK_9,	+PUMP_COL_SPACING*3.5f+4, NULL },
+		{ TRACK_10,	+PUMP_COL_SPACING*4.5f+4, NULL },
+		
 	},
 	{
 	  // m_iInputColumn[NUM_GameController][NUM_GameButton]
@@ -490,16 +490,16 @@ static const Style g_Style_KB7_Single = {
 	StepsType_kb7_single,		// m_StepsType
 	StyleType_OnePlayerOneSide,		// m_StyleType
 	7,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,    -KB7_COL_SPACING*3.0f, NULL },
-            		{ TRACK_2,    -KB7_COL_SPACING*2.0f, NULL },
-            		{ TRACK_3,    -KB7_COL_SPACING*1.0f, NULL },
-            		{ TRACK_4,    +KB7_COL_SPACING*0.0f, NULL },
-            		{ TRACK_5,    +KB7_COL_SPACING*1.0f, NULL },
-            		{ TRACK_6,    +KB7_COL_SPACING*2.0f, NULL },
-            		{ TRACK_7,    +KB7_COL_SPACING*3.0f, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,    -KB7_COL_SPACING*3.0f, NULL },
+            	{ TRACK_2,    -KB7_COL_SPACING*2.0f, NULL },
+            	{ TRACK_3,    -KB7_COL_SPACING*1.0f, NULL },
+            	{ TRACK_4,    +KB7_COL_SPACING*0.0f, NULL },
+            	{ TRACK_5,    +KB7_COL_SPACING*1.0f, NULL },
+            	{ TRACK_6,    +KB7_COL_SPACING*2.0f, NULL },
+            	{ TRACK_7,    +KB7_COL_SPACING*3.0f, NULL },
+		
 	},
 	{
 	  // m_iInputColumn[NUM_GameController][NUM_GameButton]
@@ -577,14 +577,14 @@ static const Style g_Style_Ez2_Single = {
 	StepsType_ez2_single,		// m_StepsType
 	StyleType_OnePlayerOneSide,		// m_StyleType
 	5,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-EZ2_COL_SPACING*2.0f, NULL },
-			{ TRACK_2,	-EZ2_COL_SPACING*1.0f, NULL },
-			{ TRACK_3,	+EZ2_COL_SPACING*0.0f, NULL },
-			{ TRACK_4,	+EZ2_COL_SPACING*1.0f, NULL },
-			{ TRACK_5,	+EZ2_COL_SPACING*2.0f, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-EZ2_COL_SPACING*2.0f, NULL },
+		{ TRACK_2,	-EZ2_COL_SPACING*1.0f, NULL },
+		{ TRACK_3,	+EZ2_COL_SPACING*0.0f, NULL },
+		{ TRACK_4,	+EZ2_COL_SPACING*1.0f, NULL },
+		{ TRACK_5,	+EZ2_COL_SPACING*2.0f, NULL },
+		
 	},
 	{
 	  // m_iInputColumn[NUM_GameController][NUM_GameButton]
@@ -614,16 +614,16 @@ static const Style g_Style_Ez2_Real =
 	StepsType_ez2_real,		// m_StepsType
 	StyleType_OnePlayerOneSide,		// m_StyleType
 	7,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-EZ2_REAL_COL_SPACING*2.3f, NULL },
-			{ TRACK_2,	-EZ2_REAL_COL_SPACING*1.6f, NULL },
-			{ TRACK_3,	-EZ2_REAL_COL_SPACING*0.9f, NULL }, 
-			{ TRACK_4,	+EZ2_REAL_COL_SPACING*0.0f, NULL },
-			{ TRACK_5,	+EZ2_REAL_COL_SPACING*0.9f, NULL }, 
-			{ TRACK_6,	+EZ2_REAL_COL_SPACING*1.6f, NULL },
-			{ TRACK_7,	+EZ2_REAL_COL_SPACING*2.3f, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-EZ2_REAL_COL_SPACING*2.3f, NULL },
+		{ TRACK_2,	-EZ2_REAL_COL_SPACING*1.6f, NULL },
+		{ TRACK_3,	-EZ2_REAL_COL_SPACING*0.9f, NULL }, 
+		{ TRACK_4,	+EZ2_REAL_COL_SPACING*0.0f, NULL },
+		{ TRACK_5,	+EZ2_REAL_COL_SPACING*0.9f, NULL }, 
+		{ TRACK_6,	+EZ2_REAL_COL_SPACING*1.6f, NULL },
+		{ TRACK_7,	+EZ2_REAL_COL_SPACING*2.3f, NULL },
+		
 	},
 	{
 	  // m_iInputColumn[NUM_GameController][NUM_GameButton]
@@ -655,19 +655,19 @@ static const Style g_Style_Ez2_Double =
 	StepsType_ez2_double,		// m_StepsType
 	StyleType_OnePlayerTwoSides,		// m_StyleType
 	10,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-EZ2_COL_SPACING*4.5f, NULL },
-			{ TRACK_2,	-EZ2_COL_SPACING*3.5f, NULL },
-			{ TRACK_3,	-EZ2_COL_SPACING*2.5f, NULL },
-			{ TRACK_4,	-EZ2_COL_SPACING*1.5f, NULL },
-			{ TRACK_5,	-EZ2_COL_SPACING*0.5f, NULL },
-			{ TRACK_6,	+EZ2_COL_SPACING*0.5f, NULL },
-			{ TRACK_7,	+EZ2_COL_SPACING*1.5f, NULL },
-			{ TRACK_8,	+EZ2_COL_SPACING*2.5f, NULL },
-			{ TRACK_9,	+EZ2_COL_SPACING*3.5f, NULL },
-			{ TRACK_10,	+EZ2_COL_SPACING*4.5f, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-EZ2_COL_SPACING*4.5f, NULL },
+		{ TRACK_2,	-EZ2_COL_SPACING*3.5f, NULL },
+		{ TRACK_3,	-EZ2_COL_SPACING*2.5f, NULL },
+		{ TRACK_4,	-EZ2_COL_SPACING*1.5f, NULL },
+		{ TRACK_5,	-EZ2_COL_SPACING*0.5f, NULL },
+		{ TRACK_6,	+EZ2_COL_SPACING*0.5f, NULL },
+		{ TRACK_7,	+EZ2_COL_SPACING*1.5f, NULL },
+		{ TRACK_8,	+EZ2_COL_SPACING*2.5f, NULL },
+		{ TRACK_9,	+EZ2_COL_SPACING*3.5f, NULL },
+		{ TRACK_10,	+EZ2_COL_SPACING*4.5f, NULL },
+		
 	},
 	{
 	  // m_iInputColumn[NUM_GameController][NUM_GameButton]
@@ -761,14 +761,14 @@ static const Style g_Style_Para_Single = {
 	StepsType_para_single,		// m_StepsType
 	StyleType_OnePlayerOneSide,		// m_StyleType
 	5,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-PARA_COL_SPACING*2.0f, NULL },
-			{ TRACK_2,	-PARA_COL_SPACING*1.0f, NULL },
-			{ TRACK_3,	+PARA_COL_SPACING*0.0f, NULL },
-			{ TRACK_4,	+PARA_COL_SPACING*1.0f, NULL },
-			{ TRACK_5,	+PARA_COL_SPACING*2.0f, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-PARA_COL_SPACING*2.0f, NULL },
+		{ TRACK_2,	-PARA_COL_SPACING*1.0f, NULL },
+		{ TRACK_3,	+PARA_COL_SPACING*0.0f, NULL },
+		{ TRACK_4,	+PARA_COL_SPACING*1.0f, NULL },
+		{ TRACK_5,	+PARA_COL_SPACING*2.0f, NULL },
+		
 	},
 	{
 	  // m_iInputColumn[NUM_GameController][NUM_GameButton]
@@ -842,17 +842,17 @@ static const Style g_Style_DS3DDX_Single = {
 	StepsType_ds3ddx_single,	// m_StepsType
 	StyleType_OnePlayerOneSide,		// m_StyleType
 	8,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-DS3DDX_COL_SPACING*3.0f, NULL },
-			{ TRACK_2,	-DS3DDX_COL_SPACING*2.0f, NULL },
-			{ TRACK_3,	-DS3DDX_COL_SPACING*1.0f, NULL },
-			{ TRACK_4,	-DS3DDX_COL_SPACING*0.0f, NULL },
-			{ TRACK_5,	+DS3DDX_COL_SPACING*0.0f, NULL },
-			{ TRACK_6,	+DS3DDX_COL_SPACING*1.0f, NULL },
-			{ TRACK_7,	+DS3DDX_COL_SPACING*2.0f, NULL },
-			{ TRACK_8,	+DS3DDX_COL_SPACING*3.0f , NULL},
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-DS3DDX_COL_SPACING*3.0f, NULL },
+		{ TRACK_2,	-DS3DDX_COL_SPACING*2.0f, NULL },
+		{ TRACK_3,	-DS3DDX_COL_SPACING*1.0f, NULL },
+		{ TRACK_4,	-DS3DDX_COL_SPACING*0.0f, NULL },
+		{ TRACK_5,	+DS3DDX_COL_SPACING*0.0f, NULL },
+		{ TRACK_6,	+DS3DDX_COL_SPACING*1.0f, NULL },
+		{ TRACK_7,	+DS3DDX_COL_SPACING*2.0f, NULL },
+		{ TRACK_8,	+DS3DDX_COL_SPACING*3.0f , NULL},
+		
 	},
 	{
 	  // m_iInputColumn[NUM_GameController][NUM_GameButton]
@@ -931,15 +931,15 @@ static const Style g_Style_Beat_Single5 =
 	StepsType_beat_single5,	// m_StepsType
 	StyleType_OnePlayerOneSide,		// m_StyleType
 	6,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-BEAT_COL_SPACING*2.5f, NULL },
-			{ TRACK_2,	-BEAT_COL_SPACING*1.5f, NULL },
-			{ TRACK_3,	-BEAT_COL_SPACING*0.5f, NULL },
-			{ TRACK_4,	+BEAT_COL_SPACING*0.5f, NULL },
-			{ TRACK_5,	+BEAT_COL_SPACING*1.5f, NULL },
-			{ TRACK_6,	+BEAT_COL_SPACING*3.0f, "scratch" },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-BEAT_COL_SPACING*2.5f, NULL },
+		{ TRACK_2,	-BEAT_COL_SPACING*1.5f, NULL },
+		{ TRACK_3,	-BEAT_COL_SPACING*0.5f, NULL },
+		{ TRACK_4,	+BEAT_COL_SPACING*0.5f, NULL },
+		{ TRACK_5,	+BEAT_COL_SPACING*1.5f, NULL },
+		{ TRACK_6,	+BEAT_COL_SPACING*3.0f, "scratch" },
+		
 	},
 	{	// m_iInputColumn[NUM_GameController][NUM_GameButton]
 		{ 0, 1, 2, 3, 4, Style::NO_MAPPING, Style::NO_MAPPING, 5, 5, Style::END_MAPPING },
@@ -962,21 +962,21 @@ static const Style g_Style_Beat_Double5 =
 	StepsType_beat_double5,	// m_StepsType
 	StyleType_OnePlayerTwoSides,		// m_StyleType
 	12,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-BEAT_COL_SPACING*6.0f, NULL },
-			{ TRACK_2,	-BEAT_COL_SPACING*5.0f, NULL },
-			{ TRACK_3,	-BEAT_COL_SPACING*4.0f, NULL },
-			{ TRACK_4,	-BEAT_COL_SPACING*3.0f, NULL },
-			{ TRACK_5,	-BEAT_COL_SPACING*2.0f, NULL },
-			{ TRACK_6,	-BEAT_COL_SPACING*1.5f, "scratch" },
-			{ TRACK_7,	+BEAT_COL_SPACING*0.5f, NULL },
-			{ TRACK_8,	+BEAT_COL_SPACING*1.5f, NULL },
-			{ TRACK_9,	+BEAT_COL_SPACING*2.5f, NULL },
-			{ TRACK_10,	+BEAT_COL_SPACING*3.5f, NULL },
-			{ TRACK_11,	+BEAT_COL_SPACING*4.5f, NULL },
-			{ TRACK_12,	+BEAT_COL_SPACING*6.0f, "scratch" },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-BEAT_COL_SPACING*6.0f, NULL },
+		{ TRACK_2,	-BEAT_COL_SPACING*5.0f, NULL },
+		{ TRACK_3,	-BEAT_COL_SPACING*4.0f, NULL },
+		{ TRACK_4,	-BEAT_COL_SPACING*3.0f, NULL },
+		{ TRACK_5,	-BEAT_COL_SPACING*2.0f, NULL },
+		{ TRACK_6,	-BEAT_COL_SPACING*1.5f, "scratch" },
+		{ TRACK_7,	+BEAT_COL_SPACING*0.5f, NULL },
+		{ TRACK_8,	+BEAT_COL_SPACING*1.5f, NULL },
+		{ TRACK_9,	+BEAT_COL_SPACING*2.5f, NULL },
+		{ TRACK_10,	+BEAT_COL_SPACING*3.5f, NULL },
+		{ TRACK_11,	+BEAT_COL_SPACING*4.5f, NULL },
+		{ TRACK_12,	+BEAT_COL_SPACING*6.0f, "scratch" },
+		
 	},
 	{	// m_iInputColumn[NUM_GameController][NUM_GameButton]
 		{ 0, 1, 2, 3, 4, Style::NO_MAPPING, Style::NO_MAPPING, 5, 5, Style::END_MAPPING },
@@ -999,17 +999,17 @@ static const Style g_Style_Beat_Single7 =
 	StepsType_beat_single7,	// m_StepsType
 	StyleType_OnePlayerOneSide,		// m_StyleType
 	8,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_8,	-BEAT_COL_SPACING*3.5f, "scratch" },
-			{ TRACK_1,	-BEAT_COL_SPACING*2.0f, NULL },
-			{ TRACK_2,	-BEAT_COL_SPACING*1.0f, NULL },
-			{ TRACK_3,	-BEAT_COL_SPACING*0.0f, NULL },
-			{ TRACK_4,	+BEAT_COL_SPACING*1.0f, NULL },
-			{ TRACK_5,	+BEAT_COL_SPACING*2.0f, NULL },
-			{ TRACK_6,	+BEAT_COL_SPACING*3.0f, NULL },
-			{ TRACK_7,	+BEAT_COL_SPACING*4.0f, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_8,	-BEAT_COL_SPACING*3.5f, "scratch" },
+		{ TRACK_1,	-BEAT_COL_SPACING*2.0f, NULL },
+		{ TRACK_2,	-BEAT_COL_SPACING*1.0f, NULL },
+		{ TRACK_3,	-BEAT_COL_SPACING*0.0f, NULL },
+		{ TRACK_4,	+BEAT_COL_SPACING*1.0f, NULL },
+		{ TRACK_5,	+BEAT_COL_SPACING*2.0f, NULL },
+		{ TRACK_6,	+BEAT_COL_SPACING*3.0f, NULL },
+		{ TRACK_7,	+BEAT_COL_SPACING*4.0f, NULL },
+		
 	},
 	{
 	  // m_iInputColumn[NUM_GameController][NUM_GameButton]
@@ -1033,25 +1033,25 @@ static const Style g_Style_Beat_Double7 =
 	StepsType_beat_double7,	// m_StepsType
 	StyleType_OnePlayerTwoSides,		// m_StyleType
 	16,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_8,	-BEAT_COL_SPACING*8.0f, "scratch" },
-			{ TRACK_1,	-BEAT_COL_SPACING*6.5f, NULL },
-			{ TRACK_2,	-BEAT_COL_SPACING*5.5f, NULL },
-			{ TRACK_3,	-BEAT_COL_SPACING*4.5f, NULL },
-			{ TRACK_4,	-BEAT_COL_SPACING*3.5f, NULL },
-			{ TRACK_5,	-BEAT_COL_SPACING*2.5f, NULL },
-			{ TRACK_6,	-BEAT_COL_SPACING*1.5f, NULL },
-			{ TRACK_7,	-BEAT_COL_SPACING*0.5f, NULL },
-			{ TRACK_9,	+BEAT_COL_SPACING*0.5f, NULL },
-			{ TRACK_10,	+BEAT_COL_SPACING*1.5f, NULL },
-			{ TRACK_11,	+BEAT_COL_SPACING*2.5f, NULL },
-			{ TRACK_12,	+BEAT_COL_SPACING*3.5f, NULL },
-			{ TRACK_13,	+BEAT_COL_SPACING*4.5f, NULL },
-			{ TRACK_14,	+BEAT_COL_SPACING*5.5f, NULL },
-			{ TRACK_15,	+BEAT_COL_SPACING*6.5f, NULL },
-			{ TRACK_16,	+BEAT_COL_SPACING*8.0f, "scratch" },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_8,	-BEAT_COL_SPACING*8.0f, "scratch" },
+		{ TRACK_1,	-BEAT_COL_SPACING*6.5f, NULL },
+		{ TRACK_2,	-BEAT_COL_SPACING*5.5f, NULL },
+		{ TRACK_3,	-BEAT_COL_SPACING*4.5f, NULL },
+		{ TRACK_4,	-BEAT_COL_SPACING*3.5f, NULL },
+		{ TRACK_5,	-BEAT_COL_SPACING*2.5f, NULL },
+		{ TRACK_6,	-BEAT_COL_SPACING*1.5f, NULL },
+		{ TRACK_7,	-BEAT_COL_SPACING*0.5f, NULL },
+		{ TRACK_9,	+BEAT_COL_SPACING*0.5f, NULL },
+		{ TRACK_10,	+BEAT_COL_SPACING*1.5f, NULL },
+		{ TRACK_11,	+BEAT_COL_SPACING*2.5f, NULL },
+		{ TRACK_12,	+BEAT_COL_SPACING*3.5f, NULL },
+		{ TRACK_13,	+BEAT_COL_SPACING*4.5f, NULL },
+		{ TRACK_14,	+BEAT_COL_SPACING*5.5f, NULL },
+		{ TRACK_15,	+BEAT_COL_SPACING*6.5f, NULL },
+		{ TRACK_16,	+BEAT_COL_SPACING*8.0f, "scratch" },
+		
 	},
 	{
 	  // m_iInputColumn[NUM_GameController][NUM_GameButton]
@@ -1139,13 +1139,13 @@ static const Style g_Style_Maniax_Single = {
 	StepsType_maniax_single,	// m_StepsType
 	StyleType_OnePlayerOneSide,		// m_StyleType
 	4,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-MANIAX_COL_SPACING*1.5f, NULL },
-			{ TRACK_2,	-MANIAX_COL_SPACING*0.5f, NULL },
-			{ TRACK_3,	+MANIAX_COL_SPACING*0.5f, NULL },
-			{ TRACK_4,	+MANIAX_COL_SPACING*1.5f, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-MANIAX_COL_SPACING*1.5f, NULL },
+		{ TRACK_2,	-MANIAX_COL_SPACING*0.5f, NULL },
+		{ TRACK_3,	+MANIAX_COL_SPACING*0.5f, NULL },
+		{ TRACK_4,	+MANIAX_COL_SPACING*1.5f, NULL },
+		
 	},
 	{
 	  // m_iInputColumn[NUM_GameController][NUM_GameButton]
@@ -1169,17 +1169,17 @@ static const Style g_Style_Maniax_Double =
 	StepsType_maniax_double,	// m_StepsType
 	StyleType_OnePlayerTwoSides,		// m_StyleType
 	8,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-MANIAX_COL_SPACING*3.5f, NULL },
-			{ TRACK_2,	-MANIAX_COL_SPACING*2.5f, NULL },
-			{ TRACK_3,	-MANIAX_COL_SPACING*1.5f, NULL },
-			{ TRACK_4,	-MANIAX_COL_SPACING*0.5f, NULL },
-			{ TRACK_5,	+MANIAX_COL_SPACING*0.5f, NULL },
-			{ TRACK_6,	+MANIAX_COL_SPACING*1.5f, NULL },
-			{ TRACK_7,	+MANIAX_COL_SPACING*2.5f, NULL },
-			{ TRACK_8,	+MANIAX_COL_SPACING*3.5f, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-MANIAX_COL_SPACING*3.5f, NULL },
+		{ TRACK_2,	-MANIAX_COL_SPACING*2.5f, NULL },
+		{ TRACK_3,	-MANIAX_COL_SPACING*1.5f, NULL },
+		{ TRACK_4,	-MANIAX_COL_SPACING*0.5f, NULL },
+		{ TRACK_5,	+MANIAX_COL_SPACING*0.5f, NULL },
+		{ TRACK_6,	+MANIAX_COL_SPACING*1.5f, NULL },
+		{ TRACK_7,	+MANIAX_COL_SPACING*2.5f, NULL },
+		{ TRACK_8,	+MANIAX_COL_SPACING*3.5f, NULL },
+		
 	},
 	{
 	  // m_iInputColumn[NUM_GameController][NUM_GameButton]
@@ -1259,13 +1259,13 @@ static const Style g_Style_Techno_Single4 =
 	StepsType_techno_single4,	// m_StepsType
 	StyleType_OnePlayerOneSide,		// m_StyleType
 	4,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-TECHNO_COL_SPACING*1.5f, NULL },
-			{ TRACK_2,	-TECHNO_COL_SPACING*0.5f, NULL },
-			{ TRACK_3,	+TECHNO_COL_SPACING*0.5f, NULL },
-			{ TRACK_4,	+TECHNO_COL_SPACING*1.5f, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-TECHNO_COL_SPACING*1.5f, NULL },
+		{ TRACK_2,	-TECHNO_COL_SPACING*0.5f, NULL },
+		{ TRACK_3,	+TECHNO_COL_SPACING*0.5f, NULL },
+		{ TRACK_4,	+TECHNO_COL_SPACING*1.5f, NULL },
+		
 	},
 	{
 	  // m_iInputColumn[NUM_GameController][NUM_GameButton]
@@ -1289,14 +1289,14 @@ static const Style g_Style_Techno_Single5 =
 	StepsType_techno_single5,	// m_StepsType
 	StyleType_OnePlayerOneSide,		// m_StyleType
 	5,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-TECHNO_COL_SPACING*2.0f, NULL },
-			{ TRACK_2,	-TECHNO_COL_SPACING*1.0f, NULL },
-			{ TRACK_3,	+TECHNO_COL_SPACING*0.0f, NULL },
-			{ TRACK_4,	+TECHNO_COL_SPACING*1.0f, NULL },
-			{ TRACK_5,	+TECHNO_COL_SPACING*2.0f, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-TECHNO_COL_SPACING*2.0f, NULL },
+		{ TRACK_2,	-TECHNO_COL_SPACING*1.0f, NULL },
+		{ TRACK_3,	+TECHNO_COL_SPACING*0.0f, NULL },
+		{ TRACK_4,	+TECHNO_COL_SPACING*1.0f, NULL },
+		{ TRACK_5,	+TECHNO_COL_SPACING*2.0f, NULL },
+		
 	},
 	{
 	  // m_iInputColumn[NUM_GameController][NUM_GameButton]
@@ -1338,17 +1338,17 @@ static const Style g_Style_Techno_Single8 =
 	StepsType_techno_single8,	// m_StepsType
 	StyleType_OnePlayerOneSide,		// m_StyleType
 	8,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-TECHNO_COL_SPACING*3.5f, NULL },
-			{ TRACK_2,	-TECHNO_COL_SPACING*2.5f, NULL },
-			{ TRACK_3,	-TECHNO_COL_SPACING*1.5f, NULL },
-			{ TRACK_4,	-TECHNO_COL_SPACING*0.5f, NULL },
-			{ TRACK_5,	+TECHNO_COL_SPACING*0.5f, NULL },
-			{ TRACK_6,	+TECHNO_COL_SPACING*1.5f, NULL },
-			{ TRACK_7,	+TECHNO_COL_SPACING*2.5f, NULL },
-			{ TRACK_8,	+TECHNO_COL_SPACING*3.5f, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-TECHNO_COL_SPACING*3.5f, NULL },
+		{ TRACK_2,	-TECHNO_COL_SPACING*2.5f, NULL },
+		{ TRACK_3,	-TECHNO_COL_SPACING*1.5f, NULL },
+		{ TRACK_4,	-TECHNO_COL_SPACING*0.5f, NULL },
+		{ TRACK_5,	+TECHNO_COL_SPACING*0.5f, NULL },
+		{ TRACK_6,	+TECHNO_COL_SPACING*1.5f, NULL },
+		{ TRACK_7,	+TECHNO_COL_SPACING*2.5f, NULL },
+		{ TRACK_8,	+TECHNO_COL_SPACING*3.5f, NULL },
+		
 	},
 	{
 	  // m_iInputColumn[NUM_GameController][NUM_GameButton]
@@ -1372,17 +1372,17 @@ static const Style g_Style_Techno_Double4 =
 	StepsType_techno_double4,	// m_StepsType
 	StyleType_OnePlayerTwoSides,		// m_StyleType
 	8,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-TECHNO_COL_SPACING*3.5f, NULL },
-			{ TRACK_2,	-TECHNO_COL_SPACING*2.5f, NULL },
-			{ TRACK_3,	-TECHNO_COL_SPACING*1.5f, NULL },
-			{ TRACK_4,	-TECHNO_COL_SPACING*0.5f, NULL },
-			{ TRACK_5,	+TECHNO_COL_SPACING*0.5f, NULL },
-			{ TRACK_6,	+TECHNO_COL_SPACING*1.5f, NULL },
-			{ TRACK_7,	+TECHNO_COL_SPACING*2.5f, NULL },
-			{ TRACK_8,	+TECHNO_COL_SPACING*3.5f, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-TECHNO_COL_SPACING*3.5f, NULL },
+		{ TRACK_2,	-TECHNO_COL_SPACING*2.5f, NULL },
+		{ TRACK_3,	-TECHNO_COL_SPACING*1.5f, NULL },
+		{ TRACK_4,	-TECHNO_COL_SPACING*0.5f, NULL },
+		{ TRACK_5,	+TECHNO_COL_SPACING*0.5f, NULL },
+		{ TRACK_6,	+TECHNO_COL_SPACING*1.5f, NULL },
+		{ TRACK_7,	+TECHNO_COL_SPACING*2.5f, NULL },
+		{ TRACK_8,	+TECHNO_COL_SPACING*3.5f, NULL },
+		
 	},
 	{
 	  // m_iInputColumn[NUM_GameController][NUM_GameButton]
@@ -1406,19 +1406,19 @@ static const Style g_Style_Techno_Double5 = {
 	StepsType_techno_double5,	// m_StepsType
 	StyleType_OnePlayerTwoSides,		// m_StyleType
 	10,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-TECHNO_COL_SPACING*4.5f, NULL },
-			{ TRACK_2,	-TECHNO_COL_SPACING*3.5f, NULL },
-			{ TRACK_3,	-TECHNO_COL_SPACING*2.5f, NULL },
-			{ TRACK_4,	-TECHNO_COL_SPACING*1.5f, NULL },
-			{ TRACK_5,	-TECHNO_COL_SPACING*0.5f, NULL },
-			{ TRACK_6,	+TECHNO_COL_SPACING*0.5f, NULL },
-			{ TRACK_7,	+TECHNO_COL_SPACING*1.5f, NULL },
-			{ TRACK_8,	+TECHNO_COL_SPACING*2.5f, NULL },
-			{ TRACK_9,	+TECHNO_COL_SPACING*3.5f, NULL },
-			{ TRACK_10,	+TECHNO_COL_SPACING*4.5f, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-TECHNO_COL_SPACING*4.5f, NULL },
+		{ TRACK_2,	-TECHNO_COL_SPACING*3.5f, NULL },
+		{ TRACK_3,	-TECHNO_COL_SPACING*2.5f, NULL },
+		{ TRACK_4,	-TECHNO_COL_SPACING*1.5f, NULL },
+		{ TRACK_5,	-TECHNO_COL_SPACING*0.5f, NULL },
+		{ TRACK_6,	+TECHNO_COL_SPACING*0.5f, NULL },
+		{ TRACK_7,	+TECHNO_COL_SPACING*1.5f, NULL },
+		{ TRACK_8,	+TECHNO_COL_SPACING*2.5f, NULL },
+		{ TRACK_9,	+TECHNO_COL_SPACING*3.5f, NULL },
+		{ TRACK_10,	+TECHNO_COL_SPACING*4.5f, NULL },
+		
 	},
 	{
 	  // m_iInputColumn[NUM_GameController][NUM_GameButton]
@@ -1459,25 +1459,25 @@ static const Style g_Style_Techno_Double8 = {
 	StepsType_techno_double8,	// m_StepsType
 	StyleType_OnePlayerTwoSides,		// m_StyleType
 	16,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-TECHNO_COL_SPACING*7.5f, NULL },
-			{ TRACK_2,	-TECHNO_COL_SPACING*6.5f, NULL },
-			{ TRACK_3,	-TECHNO_COL_SPACING*5.5f, NULL },
-			{ TRACK_4,	-TECHNO_COL_SPACING*4.5f, NULL },
-			{ TRACK_5,	-TECHNO_COL_SPACING*3.5f, NULL },
-			{ TRACK_6,	-TECHNO_COL_SPACING*2.5f, NULL },
-			{ TRACK_7,	-TECHNO_COL_SPACING*1.5f, NULL },
-			{ TRACK_8,	-TECHNO_COL_SPACING*0.5f, NULL },
-			{ TRACK_9,	+TECHNO_COL_SPACING*0.5f, NULL },
-			{ TRACK_10,	+TECHNO_COL_SPACING*1.5f, NULL },
-			{ TRACK_11,	+TECHNO_COL_SPACING*2.5f, NULL },
-			{ TRACK_12,	+TECHNO_COL_SPACING*3.5f, NULL },
-			{ TRACK_13,	+TECHNO_COL_SPACING*4.5f, NULL },
-			{ TRACK_14,	+TECHNO_COL_SPACING*5.5f, NULL },
-			{ TRACK_15,	+TECHNO_COL_SPACING*6.5f, NULL },
-			{ TRACK_16,	+TECHNO_COL_SPACING*7.5f, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-TECHNO_COL_SPACING*7.5f, NULL },
+		{ TRACK_2,	-TECHNO_COL_SPACING*6.5f, NULL },
+		{ TRACK_3,	-TECHNO_COL_SPACING*5.5f, NULL },
+		{ TRACK_4,	-TECHNO_COL_SPACING*4.5f, NULL },
+		{ TRACK_5,	-TECHNO_COL_SPACING*3.5f, NULL },
+		{ TRACK_6,	-TECHNO_COL_SPACING*2.5f, NULL },
+		{ TRACK_7,	-TECHNO_COL_SPACING*1.5f, NULL },
+		{ TRACK_8,	-TECHNO_COL_SPACING*0.5f, NULL },
+		{ TRACK_9,	+TECHNO_COL_SPACING*0.5f, NULL },
+		{ TRACK_10,	+TECHNO_COL_SPACING*1.5f, NULL },
+		{ TRACK_11,	+TECHNO_COL_SPACING*2.5f, NULL },
+		{ TRACK_12,	+TECHNO_COL_SPACING*3.5f, NULL },
+		{ TRACK_13,	+TECHNO_COL_SPACING*4.5f, NULL },
+		{ TRACK_14,	+TECHNO_COL_SPACING*5.5f, NULL },
+		{ TRACK_15,	+TECHNO_COL_SPACING*6.5f, NULL },
+		{ TRACK_16,	+TECHNO_COL_SPACING*7.5f, NULL },
+		
 	},
 	{
 	  // m_iInputColumn[NUM_GameController][NUM_GameButton]
@@ -1581,14 +1581,14 @@ static const Style g_Style_Popn_Five = {
 	StepsType_popn_five,		// m_StepsType
 	StyleType_OnePlayerOneSide,		// m_StyleType
 	5,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-POPN5_COL_SPACING*2.0f, NULL },
-			{ TRACK_2,	-POPN5_COL_SPACING*1.0f, NULL },
-			{ TRACK_3,	+POPN5_COL_SPACING*0.0f, NULL },
-			{ TRACK_4,	+POPN5_COL_SPACING*1.0f, NULL },
-			{ TRACK_5,	+POPN5_COL_SPACING*2.0f, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-POPN5_COL_SPACING*2.0f, NULL },
+		{ TRACK_2,	-POPN5_COL_SPACING*1.0f, NULL },
+		{ TRACK_3,	+POPN5_COL_SPACING*0.0f, NULL },
+		{ TRACK_4,	+POPN5_COL_SPACING*1.0f, NULL },
+		{ TRACK_5,	+POPN5_COL_SPACING*2.0f, NULL },
+		
 	},
 	{
 	  // m_iInputColumn[NUM_GameController][NUM_GameButton]
@@ -1626,18 +1626,18 @@ static const Style g_Style_Popn_Nine = {
 	StepsType_popn_nine,		// m_StepsType
 	StyleType_OnePlayerOneSide,		// m_StyleType
 	9,				// m_iColsPerPlayer
-	{	// m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
-		{	// PLAYER_1
-			{ TRACK_1,	-POPN9_COL_SPACING*4.0f, NULL },
-			{ TRACK_2,	-POPN9_COL_SPACING*3.0f, NULL },
-			{ TRACK_3,	-POPN9_COL_SPACING*2.0f, NULL },
-			{ TRACK_4,	-POPN9_COL_SPACING*1.0f, NULL },
-			{ TRACK_5,	+POPN9_COL_SPACING*0.0f, NULL },
-			{ TRACK_6,	+POPN9_COL_SPACING*1.0f, NULL },
-			{ TRACK_7,	+POPN9_COL_SPACING*2.0f, NULL },
-			{ TRACK_8,	+POPN9_COL_SPACING*3.0f, NULL },
-			{ TRACK_9,	+POPN9_COL_SPACING*4.0f, NULL },
-		},
+	{	// m_ColumnInfo[MAX_COLS_PER_PLAYER];
+		// PLAYER_1
+		{ TRACK_1,	-POPN9_COL_SPACING*4.0f, NULL },
+		{ TRACK_2,	-POPN9_COL_SPACING*3.0f, NULL },
+		{ TRACK_3,	-POPN9_COL_SPACING*2.0f, NULL },
+		{ TRACK_4,	-POPN9_COL_SPACING*1.0f, NULL },
+		{ TRACK_5,	+POPN9_COL_SPACING*0.0f, NULL },
+		{ TRACK_6,	+POPN9_COL_SPACING*1.0f, NULL },
+		{ TRACK_7,	+POPN9_COL_SPACING*2.0f, NULL },
+		{ TRACK_8,	+POPN9_COL_SPACING*3.0f, NULL },
+		{ TRACK_9,	+POPN9_COL_SPACING*4.0f, NULL },
+		
 	},
 	{
 	  // m_iInputColumn[NUM_GameController][NUM_GameButton]

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -96,7 +96,7 @@ class GameState
 	/** @brief Determine which side is joined.
 	 *
 	 * The left side is player 1, and the right side is player 2. */
-	bool m_bSideIsJoined[NUM_PLAYERS]; // left side, right side
+	bool m_bSideIsJoined; // left side, right side
 	MultiPlayerStatus m_MultiPlayerStatus[NUM_MultiPlayer];
 	BroadcastOnChange<PlayMode>
 	  m_PlayMode; // many screens display different info depending on this value
@@ -178,7 +178,7 @@ class GameState
 	BroadcastOnChange<RString>	m_sPreferredSongGroup;		// GROUP_ALL denotes no preferred group
 	bool		m_bFailTypeWasExplicitlySet;	// true if FailType was changed in the song options screen
 	BroadcastOnChange<StepsType>				m_PreferredStepsType;
-	BroadcastOnChange1D<Difficulty,NUM_PLAYERS>		m_PreferredDifficulty;
+	BroadcastOnChange<Difficulty>		m_PreferredDifficulty;
 	BroadcastOnChange<SortOrder>	m_SortOrder;			// set by MusicWheel
 	SortOrder	m_PreferredSortOrder;		// used by MusicWheel
 
@@ -196,7 +196,7 @@ class GameState
 	 * @brief The number of stages available for the players.
 	 *
 	 * This resets whenever a player joins or continues. */
-	int m_iPlayerStageTokens[NUM_PLAYERS];
+	int m_iPlayerStageTokens;
 	// This is necessary so that IsFinalStageForEveryHumanPlayer knows to
 	// adjust for the current song cost.
 	bool m_AdjustTokensBySongCostForFinalStageCheck;
@@ -229,7 +229,7 @@ class GameState
 	BroadcastOnChangePtr<Song> m_pCurSong;
 	// The last Song that the user manually changed to.
 	Song* m_pPreferredSong;
-	BroadcastOnChangePtr1D<Steps, NUM_PLAYERS> m_pCurSteps;
+	BroadcastOnChangePtr<Steps> m_pCurSteps;
 
 	// Music statistics:
 	SongPosition m_Position;
@@ -284,12 +284,12 @@ class GameState
 	FailType GetPlayerFailType(const PlayerState* pPlayerState) const;
 
 	// character stuff
-	Character* m_pCurCharacters[NUM_PLAYERS];
+	Character* m_pCurCharacters;
 
 	int GetNumSidesJoined() const;
 	// PlayerState
 	/** @brief Allow access to each player's PlayerState. */
-	PlayerState* m_pPlayerState[NUM_PLAYERS];
+	PlayerState* m_pPlayerState;
 	PlayerState* m_pMultiPlayerState[NUM_MultiPlayer];
 
 	int GetNumCols(int pn);

--- a/src/GameplayAssist.cpp
+++ b/src/GameplayAssist.cpp
@@ -37,7 +37,7 @@ GameplayAssist::PlayTicks(const NoteData& nd, const PlayerState* ps)
 	 * sound early enough for it to come out on time; the actual precise timing
 	 * is handled by SetStartTime. */
 	SongPosition& position =
-	  GAMESTATE->m_pPlayerState[ps->m_PlayerNumber]->m_Position;
+	  GAMESTATE->m_pPlayerState->m_Position;
 	float fPositionSeconds = position.m_fMusicSeconds;
 
 	// float fPositionSeconds = GAMESTATE->m_Position.m_fMusicSeconds;
@@ -45,7 +45,7 @@ GameplayAssist::PlayTicks(const NoteData& nd, const PlayerState* ps)
 						static_cast<float>(CommonMetrics::TICK_EARLY_SECONDS) +
 						0.250f;
 	const TimingData& timing =
-	  *GAMESTATE->m_pCurSteps[ps->m_PlayerNumber]->GetTimingData();
+	  *GAMESTATE->m_pCurSteps->GetTimingData();
 	const float fSongBeat =
 	  timing.GetBeatFromElapsedTimeNoOffset(fPositionSeconds);
 

--- a/src/HighScore.cpp
+++ b/src/HighScore.cpp
@@ -1622,7 +1622,7 @@ class LunaHighScore : public Luna<HighScore>
 	{
 		bool bIsFillInMarker = false;
 		bIsFillInMarker |=
-		  p->GetName() == RANKING_TO_FILL_IN_MARKER[PLAYER_1];
+		  p->GetName() == RANKING_TO_FILL_IN_MARKER;
 		lua_pushboolean(L, static_cast<int>(bIsFillInMarker));
 		return 1;
 	}

--- a/src/ModIconRow.cpp
+++ b/src/ModIconRow.cpp
@@ -141,7 +141,7 @@ ModIconRow::SetFromGameState()
 	PlayerNumber pn = m_pn;
 
 	RString sOptions =
-	  GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.GetStage().GetString();
+	  GAMESTATE->m_pPlayerState->m_PlayerOptions.GetStage().GetString();
 	vector<RString> vsOptions;
 	split(sOptions, ", ", vsOptions, true);
 

--- a/src/MusicWheel.cpp
+++ b/src/MusicWheel.cpp
@@ -379,8 +379,8 @@ MusicWheel::GetSongList(vector<Song*>& arraySongs, SortOrder so)
 			break;
 		case SORT_POPULARITY:
 			// todo: make this work -poco
-			//apAllSongs = SONGMAN->GetPopularSongs();
-			//break;
+			// apAllSongs = SONGMAN->GetPopularSongs();
+			// break;
 		case SORT_GROUP:
 			// if we're not using sections with a preferred song group, and
 			// there is a group to load, only load those songs. -aj
@@ -601,7 +601,7 @@ MusicWheel::FilterBySkillsets(vector<Song*>& inv)
 				if (lb > 0.f || ub > 0.f) { // if either bound is active,
 											// continue to evaluation
 					float currate = FILTERMAN->MaxFilterRate + 0.1f;
-					float minrate = FILTERMAN->m_pPlayerState[0]->wtFFF;
+					float minrate = FILTERMAN->m_pPlayerState->wtFFF;
 					do {
 						currate = currate - 0.1f;
 						if (FILTERMAN->HighestSkillsetsOnly)
@@ -655,7 +655,7 @@ MusicWheel::FilterBySkillsets(vector<Song*>& inv)
 				if (lb > 0.f || ub > 0.f) {
 					bool localaddsong;
 					float currate = FILTERMAN->MaxFilterRate + 0.1f;
-					float minrate = FILTERMAN->m_pPlayerState[0]->wtFFF;
+					float minrate = FILTERMAN->m_pPlayerState->wtFFF;
 					bool toiletpaper = false;
 					do {
 						localaddsong = true;
@@ -1080,8 +1080,6 @@ MusicWheel::FilterWheelItemDatas(vector<MusicWheelItemData*>& aUnFilteredDatas,
 		--filteredSize;
 	}
 
-	
-
 	// If we've filtered all items, insert a dummy.
 	if (aFilteredData.empty())
 		aFilteredData.emplace_back(new MusicWheelItemData(
@@ -1122,7 +1120,7 @@ MusicWheel::UpdateSwitch()
 				  GAMESTATE->m_SortOrder, st, dc)) {
 				ASSERT(dc != Difficulty_Invalid);
 				if (GAMESTATE->IsPlayerEnabled(PLAYER_1))
-				  GAMESTATE->m_PreferredDifficulty[PLAYER_1].Set(dc);
+					GAMESTATE->m_PreferredDifficulty.Set(dc);
 			}
 
 			SCREENMAN->PostMessageToTopScreen(SM_SongChanged, 0);
@@ -1532,20 +1530,21 @@ MusicWheel::GetPreferredSelectionForRandomOrPortal()
 	// probe to find a song that has the preferred
 	// difficulties of each player
 	vector<Difficulty> vDifficultiesToRequire;
-	FOREACH_HumanPlayer(p)
-	{
-		if (GAMESTATE->m_PreferredDifficulty[p] == Difficulty_Invalid)
-			continue; // skip
 
-		// TRICKY: Don't require that edits be present if perferred
-		// difficulty is Difficulty_Edit.  Otherwise, players could use this
-		// to set up a 100% chance of getting a particular locked song by
-		// having a single edit for a locked song.
-		if (GAMESTATE->m_PreferredDifficulty[p] == Difficulty_Edit)
-			continue; // skip
+	if (GAMESTATE->m_PreferredDifficulty == Difficulty_Invalid) {
+	// skip
+	}
 
-		vDifficultiesToRequire.emplace_back(
-		  GAMESTATE->m_PreferredDifficulty[p]);
+	// TRICKY: Don't require that edits be present if perferred
+	// difficulty is Difficulty_Edit.  Otherwise, players could use this
+	// to set up a 100% chance of getting a particular locked song by
+	// having a single edit for a locked song.
+	else if (GAMESTATE->m_PreferredDifficulty == Difficulty_Edit) {
+		// skip
+	}
+	else {
+
+	vDifficultiesToRequire.emplace_back(GAMESTATE->m_PreferredDifficulty);
 	}
 
 	RString sPreferredGroup = m_sExpandedSectionName;
@@ -1573,8 +1572,6 @@ MusicWheel::GetPreferredSelectionForRandomOrPortal()
 		if (!sPreferredGroup.empty() &&
 			wid[iSelection]->m_sText != sPreferredGroup)
 			continue;
-
-
 
 		FOREACH(Difficulty, vDifficultiesToRequire, d)
 		{

--- a/src/MusicWheelItem.cpp
+++ b/src/MusicWheelItem.cpp
@@ -89,11 +89,11 @@ MusicWheelItem::MusicWheelItem(RString sType)
 	m_pTextSectionCount->PlayCommand("On");
 	this->AddChild(m_pTextSectionCount);
 
-	m_pGradeDisplay[PLAYER_1].Load(THEME->GetPathG(sType, "grades"));
-	m_pGradeDisplay[PLAYER_1]->SetName(
+	m_pGradeDisplay.Load(THEME->GetPathG(sType, "grades"));
+	m_pGradeDisplay->SetName(
 		ssprintf("GradeP%d", static_cast<int>(PLAYER_1 + 1)));
-	this->AddChild(m_pGradeDisplay[PLAYER_1]);
-	LOAD_ALL_COMMANDS_AND_SET_XY(m_pGradeDisplay[PLAYER_1]);
+	this->AddChild(m_pGradeDisplay);
+	LOAD_ALL_COMMANDS_AND_SET_XY(m_pGradeDisplay);
 
 	this->SubscribeToMessage(Message_CurrentStepsP1Changed);
 	this->SubscribeToMessage(Message_CurrentStepsP2Changed);
@@ -135,8 +135,8 @@ MusicWheelItem::MusicWheelItem(const MusicWheelItem& cpy)
 	m_pTextSectionCount = new BitmapText(*cpy.m_pTextSectionCount);
 	this->AddChild(m_pTextSectionCount);
 
-	m_pGradeDisplay[PLAYER_1] = cpy.m_pGradeDisplay[PLAYER_1];
-	this->AddChild(m_pGradeDisplay[PLAYER_1]);
+	m_pGradeDisplay = cpy.m_pGradeDisplay;
+	this->AddChild(m_pGradeDisplay);
 	
 }
 
@@ -168,7 +168,7 @@ MusicWheelItem::LoadFromWheelItemData(const WheelItemBaseData* pData,
 	if (m_pText[i])
 		m_pText[i]->SetVisible(false);
 	m_pTextSectionCount->SetVisible(false);
-	m_pGradeDisplay[PLAYER_1]->SetVisible(false);
+	m_pGradeDisplay->SetVisible(false);
 
 	// Fill these in below
 	RString sDisplayName, sTranslitName;
@@ -268,16 +268,16 @@ MusicWheelItem::RefreshGrades()
 		return; // LoadFromWheelItemData() hasn't been called yet.
 	FOREACH_HumanPlayer(p)
 	{
-		m_pGradeDisplay[p]->SetVisible(false);
+		m_pGradeDisplay->SetVisible(false);
 
 		if (pWID->m_pSong == NULL)
 			continue;
 
 		Difficulty dc;
-		if (GAMESTATE->m_pCurSteps[p])
-			dc = GAMESTATE->m_pCurSteps[p]->GetDifficulty();
+		if (GAMESTATE->m_pCurSteps)
+			dc = GAMESTATE->m_pCurSteps->GetDifficulty();
 		else
-			dc = GAMESTATE->m_PreferredDifficulty[p];
+			dc = GAMESTATE->m_PreferredDifficulty;
 
 		ProfileSlot ps;
 		if (PROFILEMAN->IsPersistentProfile(p))
@@ -286,12 +286,12 @@ MusicWheelItem::RefreshGrades()
 			continue;
 
 		StepsType st;
-		if (GAMESTATE->m_pCurSteps[p])
-			st = GAMESTATE->m_pCurSteps[p]->m_StepsType;
+		if (GAMESTATE->m_pCurSteps)
+			st = GAMESTATE->m_pCurSteps->m_StepsType;
 		else
 			st = GAMESTATE->GetCurrentStyle(PLAYER_INVALID)->m_StepsType;
 
-		m_pGradeDisplay[p]->SetVisible(true);
+		m_pGradeDisplay->SetVisible(true);
 
 		HighScoreList* BestpHSL = NULL;
 		Grade gradeBest = Grade_Invalid;
@@ -346,7 +346,7 @@ MusicWheelItem::RefreshGrades()
 			msg.SetParam("Difficulty", DifficultyToString(dcBest));
 			msg.SetParam("NumTimesPlayed", 0);
 		}
-		m_pGradeDisplay[p]->HandleMessage(msg);
+		m_pGradeDisplay->HandleMessage(msg);
 	}
 }
 

--- a/src/MusicWheelItem.h
+++ b/src/MusicWheelItem.h
@@ -53,7 +53,7 @@ class MusicWheelItem : public WheelItemBase
 	TextBanner m_TextBanner; // used by Type_Song instead of m_pText
 	BitmapText* m_pText[NUM_MusicWheelItemType];
 	BitmapText* m_pTextSectionCount;
-	AutoActor m_pGradeDisplay[NUM_PLAYERS];
+	AutoActor m_pGradeDisplay;
 };
 
 struct MusicWheelItemData : public WheelItemBaseData

--- a/src/NetworkSyncManager.cpp
+++ b/src/NetworkSyncManager.cpp
@@ -1239,8 +1239,8 @@ ETTProtocol::ReportHighScore(HighScore* hs, PlayerStageStats& pss)
 	payload["ng"] = hs->GetHoldNoteScore(HNS_Missed);
 	payload["chartkey"] = hs->GetChartKey();
 	payload["rate"] = hs->GetMusicRate();
-	if (GAMESTATE->m_pPlayerState[PLAYER_1] != nullptr)
-		payload["options"] = GAMESTATE->m_pPlayerState[PLAYER_1]
+	if (GAMESTATE->m_pPlayerState != nullptr)
+		payload["options"] = GAMESTATE->m_pPlayerState
 							   ->m_PlayerOptions.GetCurrent()
 							   .GetString();
 	auto chart = SONGMAN->GetStepsByChartkey(hs->GetChartKey());
@@ -1386,8 +1386,8 @@ ETTProtocol::SelectUserSong(NetworkSyncManager* n, Song* song)
 		return;
 	if (song == n->song) {
 		if (GAMESTATE->m_pCurSong == nullptr ||
-			GAMESTATE->m_pCurSteps[PLAYER_1] == nullptr ||
-			GAMESTATE->m_pPlayerState[PLAYER_1] == nullptr)
+			GAMESTATE->m_pCurSteps == nullptr ||
+			GAMESTATE->m_pPlayerState == nullptr)
 			return;
 		json startChart;
 		startChart["type"] = ettClientMessageMap[ettpc_startchart];
@@ -1397,10 +1397,10 @@ ETTProtocol::SelectUserSong(NetworkSyncManager* n, Song* song)
 		payload["artist"] = GAMESTATE->m_pCurSong->m_sArtist;
 		payload["filehash"] = GAMESTATE->m_pCurSong->GetFileHash();
 		payload["difficulty"] =
-		  DifficultyToString(GAMESTATE->m_pCurSteps[PLAYER_1]->GetDifficulty());
-		payload["meter"] = GAMESTATE->m_pCurSteps[PLAYER_1]->GetMeter();
-		payload["chartkey"] = GAMESTATE->m_pCurSteps[PLAYER_1]->GetChartKey();
-		payload["options"] = GAMESTATE->m_pPlayerState[PLAYER_1]
+		  DifficultyToString(GAMESTATE->m_pCurSteps->GetDifficulty());
+		payload["meter"] = GAMESTATE->m_pCurSteps->GetMeter();
+		payload["chartkey"] = GAMESTATE->m_pCurSteps->GetChartKey();
+		payload["options"] = GAMESTATE->m_pPlayerState
 							   ->m_PlayerOptions.GetCurrent()
 							   .GetString();
 		payload["rate"] = static_cast<int>(
@@ -1408,7 +1408,7 @@ ETTProtocol::SelectUserSong(NetworkSyncManager* n, Song* song)
 		startChart["id"] = msgId++;
 		Send(startChart);
 	} else {
-		if (GAMESTATE->m_pCurSteps[PLAYER_1] == nullptr)
+		if (GAMESTATE->m_pCurSteps == nullptr)
 			return;
 		json selectChart;
 		selectChart["type"] = ettClientMessageMap[ettpc_selectchart];
@@ -1418,11 +1418,11 @@ ETTProtocol::SelectUserSong(NetworkSyncManager* n, Song* song)
 		payload["artist"] = n->m_sArtist.c_str();
 		payload["filehash"] = song->GetFileHash().c_str();
 		payload["chartkey"] =
-		  GAMESTATE->m_pCurSteps[PLAYER_1]->GetChartKey().c_str();
+		  GAMESTATE->m_pCurSteps->GetChartKey().c_str();
 		payload["difficulty"] =
-		  DifficultyToString(GAMESTATE->m_pCurSteps[PLAYER_1]->GetDifficulty());
-		payload["meter"] = GAMESTATE->m_pCurSteps[PLAYER_1]->GetMeter();
-		payload["options"] = GAMESTATE->m_pPlayerState[PLAYER_1]
+		  DifficultyToString(GAMESTATE->m_pCurSteps->GetDifficulty());
+		payload["meter"] = GAMESTATE->m_pCurSteps->GetMeter();
+		payload["options"] = GAMESTATE->m_pPlayerState
 							   ->m_PlayerOptions.GetCurrent()
 							   .GetString();
 		payload["rate"] = static_cast<int>(

--- a/src/NoteField.cpp
+++ b/src/NoteField.cpp
@@ -181,7 +181,7 @@ NoteField::CacheAllUsedNoteSkins()
 
 	FOREACH_EnabledPlayer(pn)
 	{
-		RString sNoteSkinLower = GAMESTATE->m_pPlayerState[pn]
+		RString sNoteSkinLower = GAMESTATE->m_pPlayerState
 								   ->m_PlayerOptions.GetCurrent()
 								   .m_sNoteSkin;
 		NOTESKIN->ValidateNoteSkinName(sNoteSkinLower);
@@ -282,14 +282,14 @@ NoteField::ensure_note_displays_have_skin()
 	memset(m_pDisplays, 0, sizeof(m_pDisplays));
 	FOREACH_EnabledPlayer(pn)
 	{
-		sNoteSkinLower = GAMESTATE->m_pPlayerState[pn]
+		sNoteSkinLower = GAMESTATE->m_pPlayerState
 						   ->m_PlayerOptions.GetCurrent()
 						   .m_sNoteSkin;
 
 		// XXX: Re-setup sNoteSkinLower. Unsure if inserting the skin again is
 		// needed.
 		if (sNoteSkinLower.empty()) {
-			sNoteSkinLower = GAMESTATE->m_pPlayerState[pn]
+			sNoteSkinLower = GAMESTATE->m_pPlayerState
 							   ->m_PlayerOptions.GetPreferred()
 							   .m_sNoteSkin;
 

--- a/src/OptionRow.cpp
+++ b/src/OptionRow.cpp
@@ -43,7 +43,7 @@ OptionRow::OptionRow(const OptionRowType* pSource)
 	m_pHand = NULL;
 
 	m_textTitle = NULL;
-	ZERO(m_ModIcons);
+	m_ModIcons = false;
 
 	Clear();
 	this->AddChild(&m_Frame);
@@ -61,11 +61,11 @@ OptionRow::Clear()
 {
 	ActorFrame::RemoveAllChildren();
 
-	m_vbSelected[PLAYER_1].clear();
+	m_vbSelected.clear();
 
 	m_Frame.DeleteAllChildren();
 	m_textItems.clear();
-	m_Underline[PLAYER_1].clear();
+	m_Underline.clear();
 
 	if (m_pHand != NULL) {
 		FOREACH_CONST(RString, m_pHand->m_vsReloadRowMessages, m)
@@ -74,8 +74,8 @@ OptionRow::Clear()
 	SAFE_DELETE(m_pHand);
 
 	m_bFirstItemGoesDown = false;
-	ZERO(m_bRowHasFocus);
-	ZERO(m_iChoiceInRowWithFocus);
+	m_bRowHasFocus = false;
+	m_iChoiceInRowWithFocus = false;
 }
 
 void
@@ -104,7 +104,7 @@ OptionRowType::Load(const RString& sMetricsGroup, Actor* pParent)
 	ActorUtil::LoadAllCommands(m_textItem, sMetricsGroup);
 
 	if (SHOW_UNDERLINES) {
-		m_Underline[PLAYER_1].Load(
+		m_Underline.Load(
 		  "OptionsUnderline" + PlayerNumberToString(PLAYER_1), false);
 	}
 
@@ -164,10 +164,10 @@ OptionRow::ChoicesChanged(RowType type, bool reset_focus)
 	// Remove the NextRow marker before reloading choices
 	if (m_pHand->m_Def.m_vsChoices[0] == NEXT_ROW_NAME) {
 		m_pHand->m_Def.m_vsChoices.erase(m_pHand->m_Def.m_vsChoices.begin());
-		m_vbSelected[PLAYER_1].erase(m_vbSelected[PLAYER_1].begin());
+		m_vbSelected.erase(m_vbSelected.begin());
 	}
 
-	vector<bool>& vbSelected = m_vbSelected[PLAYER_1];
+	vector<bool>& vbSelected = m_vbSelected;
 	vbSelected.resize(0);
 	vbSelected.resize(m_pHand->m_Def.m_vsChoices.size(), false);
 
@@ -179,7 +179,7 @@ OptionRow::ChoicesChanged(RowType type, bool reset_focus)
 	if (m_bFirstItemGoesDown) {
 		m_pHand->m_Def.m_vsChoices.insert(m_pHand->m_Def.m_vsChoices.begin(),
 										  NEXT_ROW_NAME);
-		m_vbSelected[PLAYER_1].insert(m_vbSelected[PLAYER_1].begin(), false);
+		m_vbSelected.insert(m_vbSelected.begin(), false);
 	}
 
 	InitText(type);
@@ -234,7 +234,7 @@ OptionRow::InitText(RowType type)
 	 * options. Delete the old ones. */
 	m_Frame.DeleteAllChildren();
 	m_textItems.clear();
-	m_Underline[PLAYER_1].clear();
+	m_Underline.clear();
 
 	m_textTitle = new BitmapText(m_pParentType->m_textTitle);
 	m_Frame.AddChild(m_textTitle);
@@ -247,11 +247,11 @@ OptionRow::InitText(RowType type)
 		switch (m_RowType) {
 			case RowType_Normal:
 			{
-				m_ModIcons[PLAYER_1] = new ModIcon(m_pParentType->m_ModIcon);
-				m_ModIcons[PLAYER_1]->SetDrawOrder(-1); // under title
-				m_ModIcons[PLAYER_1]->PlayCommand("On");
+				m_ModIcons = new ModIcon(m_pParentType->m_ModIcon);
+				m_ModIcons->SetDrawOrder(-1); // under title
+				m_ModIcons->PlayCommand("On");
 
-				m_Frame.AddChild(m_ModIcons[PLAYER_1]);
+				m_Frame.AddChild(m_ModIcons);
 
 				GameCommand gc;
 				SetModIcon(PLAYER_1, "", gc);
@@ -315,8 +315,8 @@ OptionRow::InitText(RowType type)
 			if (m_pParentType->SHOW_UNDERLINES &&
 				GetRowType() != OptionRow::RowType_Exit) {
 				OptionsCursor* pCursor =
-					new OptionsCursor(m_pParentType->m_Underline[PLAYER_1]);
-				m_Underline[PLAYER_1].push_back(pCursor);
+					new OptionsCursor(m_pParentType->m_Underline);
+				m_Underline.push_back(pCursor);
 
 				int iWidth, iX, iY;
 				GetWidthXY(PLAYER_1, 0, iWidth, iX, iY);
@@ -346,8 +346,8 @@ OptionRow::InitText(RowType type)
 				// init underlines
 				if (m_pParentType->SHOW_UNDERLINES) {
 					OptionsCursor* ul =
-						new OptionsCursor(m_pParentType->m_Underline[PLAYER_1]);
-					m_Underline[PLAYER_1].push_back(ul);
+						new OptionsCursor(m_pParentType->m_Underline);
+					m_Underline.push_back(ul);
 					ul->SetX(fX);
 					ul->SetBarWidth(static_cast<int>(fItemWidth));
 				}
@@ -363,8 +363,8 @@ OptionRow::InitText(RowType type)
 
 	for (unsigned c = 0; c < m_textItems.size(); c++)
 		m_Frame.AddChild(m_textItems[c]);
-	for (unsigned c = 0; c < m_Underline[PLAYER_1].size(); c++)
-	  m_Frame.AddChild(m_Underline[PLAYER_1][c]);
+	for (unsigned c = 0; c < m_Underline.size(); c++)
+	  m_Frame.AddChild(m_Underline[c]);
 
 	// This is set in OptionRow::AfterImportOptions, so if we're reused with a
 	// different song selected, SHOW_BPM_IN_SPEED_TITLE will show the new BPM.
@@ -390,8 +390,8 @@ OptionRow::AfterImportOptions(PlayerNumber pn)
 
 	// Hide underlines for disabled players.
 	if (!GAMESTATE->IsHumanPlayer(pn))
-		for (unsigned c = 0; c < m_Underline[pn].size(); c++)
-			m_Underline[pn][c]->SetVisible(false);
+		for (unsigned c = 0; c < m_Underline.size(); c++)
+			m_Underline[c]->SetVisible(false);
 
 	// Make all selections the same if bOneChoiceForAllPlayers.
 	// Hack: we only import active players, so if only player 2 is imported,
@@ -400,7 +400,7 @@ OptionRow::AfterImportOptions(PlayerNumber pn)
 		PlayerNumber pnCopyFrom = GAMESTATE->GetMasterPlayerNumber();
 		if (GAMESTATE->GetMasterPlayerNumber() == PLAYER_INVALID)
 			pnCopyFrom = PLAYER_1;
-		m_vbSelected[PLAYER_1] = m_vbSelected[pnCopyFrom];
+		m_vbSelected = m_vbSelected; // haha this doesnt do anything -poco
 	}
 
 	switch (m_pHand->m_Def.m_selectType) {
@@ -408,8 +408,8 @@ OptionRow::AfterImportOptions(PlayerNumber pn)
 			// Make sure the row actually has a selection.
 			int iSelection = GetOneSelection(pn, true);
 			if (iSelection == -1) {
-				ASSERT(!m_vbSelected[pn].empty());
-				m_vbSelected[pn][0] = true;
+				ASSERT(!m_vbSelected.empty());
+				m_vbSelected[0] = true;
 			}
 		}
 		default:
@@ -424,7 +424,7 @@ OptionRow::AfterImportOptions(PlayerNumber pn)
 void
 OptionRow::PositionUnderlines(PlayerNumber pn)
 {
-	vector<OptionsCursor*>& vpUnderlines = m_Underline[pn];
+	vector<OptionsCursor*>& vpUnderlines = m_Underline;
 	if (vpUnderlines.empty())
 		return;
 
@@ -445,7 +445,7 @@ OptionRow::PositionUnderlines(PlayerNumber pn)
 							   m_pHand->m_Def.m_vEnabledForPlayers.end();
 
 			if (!m_pHand->m_Def.m_bOneChoiceForAllPlayers) {
-				if (m_bRowHasFocus[pn])
+				if (m_bRowHasFocus)
 					fAlpha = m_pParentType->COLOR_SELECTED.GetValue().a;
 				else if (bRowEnabled)
 					fAlpha = m_pParentType->COLOR_NOT_SELECTED.GetValue().a;
@@ -463,12 +463,12 @@ OptionRow::PositionUnderlines(PlayerNumber pn)
 		// only set alpha, in case a theme tries to color underlines. -aj
 		ul.SetDiffuseAlpha(fAlpha);
 
-		ASSERT(m_vbSelected[pnTakeSelectedFrom].size() ==
+		ASSERT(m_vbSelected.size() ==
 			   m_pHand->m_Def.m_vsChoices.size());
 
 		bool bSelected = (iChoiceWithFocus == -1)
 						   ? false
-						   : m_vbSelected[pnTakeSelectedFrom][iChoiceWithFocus];
+						   : m_vbSelected[iChoiceWithFocus];
 		bool bVisible = bSelected && GAMESTATE->IsHumanPlayer(pn);
 
 		ul.BeginTweening(m_pParentType->TWEEN_SECONDS);
@@ -480,7 +480,7 @@ OptionRow::PositionUnderlines(PlayerNumber pn)
 void
 OptionRow::PositionIcons(PlayerNumber pn)
 {
-	ModIcon* pIcon = m_ModIcons[pn];
+	ModIcon* pIcon = m_ModIcons;
 	if (pIcon == NULL)
 		return;
 
@@ -494,7 +494,7 @@ OptionRow::UpdateText(PlayerNumber p)
 	switch (m_pHand->m_Def.m_layoutType) {
 		case LAYOUT_SHOW_ONE_IN_ROW: {
 			unsigned pn = m_pHand->m_Def.m_bOneChoiceForAllPlayers ? 0 : p;
-			int iChoiceWithFocus = m_iChoiceInRowWithFocus[pn];
+			int iChoiceWithFocus = m_iChoiceInRowWithFocus;
 			if (iChoiceWithFocus == -1)
 				break;
 
@@ -515,7 +515,7 @@ OptionRow::UpdateText(PlayerNumber p)
 void
 OptionRow::SetRowHasFocus(PlayerNumber pn, bool bRowHasFocus)
 {
-	m_bRowHasFocus[pn] = bRowHasFocus;
+	m_bRowHasFocus = bRowHasFocus;
 }
 
 void
@@ -533,12 +533,10 @@ void
 OptionRow::UpdateEnabledDisabled()
 {
 	bool bThisRowHasFocusByAny = false;
-	FOREACH_HumanPlayer(p) bThisRowHasFocusByAny |=
-	  static_cast<int>(m_bRowHasFocus[p]);
+	bThisRowHasFocusByAny |= static_cast<int>(m_bRowHasFocus);
 
 	bool bThisRowHasFocusByAll = true;
-	FOREACH_HumanPlayer(p) bThisRowHasFocusByAll &=
-	  static_cast<int>(m_bRowHasFocus[p]);
+	bThisRowHasFocusByAll &= static_cast<int>(m_bRowHasFocus);
 
 	bool bRowEnabled = !m_pHand->m_Def.m_vEnabledForPlayers.empty();
 
@@ -564,13 +562,10 @@ OptionRow::UpdateEnabledDisabled()
 
 	for (unsigned j = 0; j < m_textItems.size(); j++) {
 		bool bThisItemHasFocusByAny = false;
-		FOREACH_HumanPlayer(p)
-		{
-			if (m_bRowHasFocus[p]) {
-				if ((int)j == GetChoiceInRowWithFocus(p)) {
-					bThisItemHasFocusByAny = true;
-					break;
-				}
+		if (m_bRowHasFocus) {
+			if ((int)j == GetChoiceInRowWithFocus(PLAYER_1)) {
+				bThisItemHasFocusByAny = true;
+				break;
 			}
 		}
 
@@ -599,7 +594,7 @@ OptionRow::UpdateEnabledDisabled()
 							  m_pHand->m_Def.m_vEnabledForPlayers.end();
 
 				if (!m_pHand->m_Def.m_bOneChoiceForAllPlayers) {
-					if (m_bRowHasFocus[pn])
+					if (m_bRowHasFocus)
 						color = m_pParentType->COLOR_SELECTED;
 					else if (bRowEnabled)
 						color = m_pParentType->COLOR_NOT_SELECTED;
@@ -636,8 +631,8 @@ OptionRow::SetModIcon(PlayerNumber pn, const RString& sText, GameCommand& gc)
 	msg.SetParam("GameCommand", &gc);
 	msg.SetParam("Text", sText);
 	m_sprFrame->HandleMessage(msg);
-	if (m_ModIcons[pn] != NULL)
-		m_ModIcons[pn]->Set(sText);
+	if (m_ModIcons != NULL)
+		m_ModIcons->Set(sText);
 }
 
 const BitmapText&
@@ -682,8 +677,8 @@ OptionRow::GetWidthXY(PlayerNumber pn,
 int
 OptionRow::GetOneSelection(PlayerNumber pn, bool bAllowFail) const
 {
-	for (unsigned i = 0; i < m_vbSelected[pn].size(); i++)
-		if (m_vbSelected[pn][i])
+	for (unsigned i = 0; i < m_vbSelected.size(); i++)
+		if (m_vbSelected[i])
 			return i;
 
 	ASSERT(
@@ -700,7 +695,7 @@ OptionRow::GetOneSharedSelection(bool bAllowFail) const
 void
 OptionRow::SetOneSelection(PlayerNumber pn, int iChoice)
 {
-	vector<bool>& vb = m_vbSelected[pn];
+	vector<bool>& vb = m_vbSelected;
 	if (vb.empty())
 		return;
 	FOREACH(bool, vb, b)
@@ -733,7 +728,7 @@ OptionRow::GetChoiceInRowWithFocus(PlayerNumber pn) const
 		pn = PLAYER_1;
 	if (m_pHand->m_Def.m_vsChoices.empty())
 		return -1;
-	int iChoice = m_iChoiceInRowWithFocus[pn];
+	int iChoice = m_iChoiceInRowWithFocus;
 	return iChoice;
 }
 
@@ -749,7 +744,7 @@ OptionRow::SetChoiceInRowWithFocus(PlayerNumber pn, int iChoice)
 	if (m_pHand->m_Def.m_bOneChoiceForAllPlayers)
 		pn = PLAYER_1;
 	ASSERT(iChoice >= 0 && iChoice < (int)m_pHand->m_Def.m_vsChoices.size());
-	m_iChoiceInRowWithFocus[pn] = iChoice;
+	m_iChoiceInRowWithFocus = iChoice;
 
 	UpdateText(pn);
 	// PositionUnderlines( pn );
@@ -780,7 +775,7 @@ OptionRow::GetSelected(PlayerNumber pn, int iChoice) const
 {
 	if (m_pHand->m_Def.m_bOneChoiceForAllPlayers)
 		pn = PLAYER_1;
-	return m_vbSelected[pn][iChoice];
+	return m_vbSelected[iChoice];
 }
 
 const OptionRowDefinition&
@@ -800,7 +795,7 @@ OptionRow::SetSelected(PlayerNumber pn, int iChoice, bool b)
 {
 	if (m_pHand->m_Def.m_bOneChoiceForAllPlayers)
 		pn = PLAYER_1;
-	m_vbSelected[pn][iChoice] = b;
+	m_vbSelected[iChoice] = b;
 	return NotifyHandlerOfSelection(pn, iChoice);
 }
 
@@ -840,7 +835,7 @@ OptionRow::Reload()
 	/*
 	if( m_pHand->m_Def.m_bExportOnChange )
 	{
-		bool bRowHasFocus[NUM_PLAYERS];
+		bool bRowHasFocus;
 		ZERO( bRowHasFocus );
 		ExportOptions( vpns, bRowHasFocus );
 	}
@@ -870,7 +865,7 @@ OptionRow::Reload()
 	/*
 	if( m_pHand->m_Def.m_bExportOnChange )
 	{
-		bool bRowHasFocus[NUM_PLAYERS];
+		bool bRowHasFocus;
 		ZERO( bRowHasFocus );
 		ExportOptions( vpns, bRowHasFocus );
 	}
@@ -910,11 +905,11 @@ OptionRow::ImportOptions(const vector<PlayerNumber>& vpns)
 	{
 		PlayerNumber p = *iter;
 
-		FOREACH(bool, m_vbSelected[p], b)
+		FOREACH(bool, m_vbSelected, b)
 		*b = false;
 
-		ASSERT(m_vbSelected[p].size() == m_pHand->m_Def.m_vsChoices.size());
-		ERASE_ONE_BOOL_AT_FRONT_IF_NEEDED(m_vbSelected[p]);
+		ASSERT(m_vbSelected.size() == m_pHand->m_Def.m_vsChoices.size());
+		ERASE_ONE_BOOL_AT_FRONT_IF_NEEDED(m_vbSelected);
 	}
 
 	m_pHand->ImportOption(this, vpns, m_vbSelected);
@@ -923,15 +918,15 @@ OptionRow::ImportOptions(const vector<PlayerNumber>& vpns)
 	{
 		PlayerNumber p = *iter;
 
-		INSERT_ONE_BOOL_AT_FRONT_IF_NEEDED(m_vbSelected[p]);
+		INSERT_ONE_BOOL_AT_FRONT_IF_NEEDED(m_vbSelected);
 		VerifySelected(
-		  m_pHand->m_Def.m_selectType, m_vbSelected[p], m_pHand->m_Def.m_sName);
+		  m_pHand->m_Def.m_selectType, m_vbSelected, m_pHand->m_Def.m_sName);
 	}
 }
 
 int
 OptionRow::ExportOptions(const vector<PlayerNumber>& vpns,
-						 bool bRowHasFocus[NUM_PLAYERS])
+						 bool bRowHasFocus)
 {
 	ASSERT(m_pHand->m_Def.m_vsChoices.size() > 0);
 
@@ -940,18 +935,18 @@ OptionRow::ExportOptions(const vector<PlayerNumber>& vpns,
 	FOREACH_CONST(PlayerNumber, vpns, iter)
 	{
 		PlayerNumber p = *iter;
-		bool bFocus = bRowHasFocus[p];
+		bool bFocus = bRowHasFocus;
 
 		VerifySelected(
-		  m_pHand->m_Def.m_selectType, m_vbSelected[p], m_pHand->m_Def.m_sName);
-		ASSERT(m_vbSelected[p].size() == m_pHand->m_Def.m_vsChoices.size());
-		ERASE_ONE_BOOL_AT_FRONT_IF_NEEDED(m_vbSelected[p]);
+		  m_pHand->m_Def.m_selectType, m_vbSelected, m_pHand->m_Def.m_sName);
+		ASSERT(m_vbSelected.size() == m_pHand->m_Def.m_vsChoices.size());
+		ERASE_ONE_BOOL_AT_FRONT_IF_NEEDED(m_vbSelected);
 
 		// SELECT_NONE rows get exported if they have focus when the user
 		// presses Start.
 		int iChoice = GetChoiceInRowWithFocus(p);
 		if (m_pHand->m_Def.m_selectType == SELECT_NONE && bFocus)
-			m_vbSelected[p][iChoice] = true;
+			m_vbSelected[iChoice] = true;
 	}
 
 	iChangeMask |= m_pHand->ExportOption(vpns, m_vbSelected);
@@ -959,13 +954,13 @@ OptionRow::ExportOptions(const vector<PlayerNumber>& vpns,
 	FOREACH_CONST(PlayerNumber, vpns, iter)
 	{
 		PlayerNumber p = *iter;
-		bool bFocus = bRowHasFocus[p];
+		bool bFocus = bRowHasFocus;
 
 		int iChoice = GetChoiceInRowWithFocus(p);
 		if (m_pHand->m_Def.m_selectType == SELECT_NONE && bFocus)
-			m_vbSelected[p][iChoice] = false;
+			m_vbSelected[iChoice] = false;
 
-		INSERT_ONE_BOOL_AT_FRONT_IF_NEEDED(m_vbSelected[p]);
+		INSERT_ONE_BOOL_AT_FRONT_IF_NEEDED(m_vbSelected);
 	}
 
 	return iChangeMask;

--- a/src/OptionRow.h
+++ b/src/OptionRow.h
@@ -1,4 +1,4 @@
-﻿/* OptionRow - One line in ScreenOptions. */
+/* OptionRow - One line in ScreenOptions. */
 
 #ifndef OptionRow_H
 #define OptionRow_H
@@ -28,7 +28,7 @@ class OptionRowType
 	RString m_sMetricsGroup;
 
 	BitmapText m_textItem;
-	OptionsCursor m_Underline[NUM_PLAYERS];
+	OptionsCursor m_Underline;
 	AutoActor m_sprFrame;
 	BitmapText m_textTitle;
 	ModIcon m_ModIcon;
@@ -66,7 +66,7 @@ class OptionRow : public ActorFrame
 
 	void ImportOptions(const vector<PlayerNumber>& vpns);
 	int ExportOptions(const vector<PlayerNumber>& vpns,
-					  bool bRowHasFocus[NUM_PLAYERS]);
+					  bool bRowHasFocus);
 
 	enum RowType
 	{
@@ -83,7 +83,7 @@ class OptionRow : public ActorFrame
 	void PositionUnderlines(PlayerNumber pn);
 	void PositionIcons(PlayerNumber pn);
 	void UpdateText(PlayerNumber pn);
-	bool GetRowHasFocus(PlayerNumber pn) const { return m_bRowHasFocus[pn]; }
+	bool GetRowHasFocus(PlayerNumber pn) const { return m_bRowHasFocus; }
 	void SetRowHasFocus(PlayerNumber pn, bool bRowHasFocus);
 	void UpdateEnabledDisabled();
 
@@ -144,21 +144,21 @@ class OptionRow : public ActorFrame
 
 	vector<BitmapText*>
 	  m_textItems; // size depends on m_bRowIsLong and which players are joined
-	vector<OptionsCursor*> m_Underline[NUM_PLAYERS]; // size depends on
+	vector<OptionsCursor*> m_Underline; // size depends on
 													 // m_bRowIsLong and which
 													 // players are joined
 
 	Actor* m_sprFrame;
 	BitmapText* m_textTitle;
-	ModIcon* m_ModIcons[NUM_PLAYERS];
+	ModIcon* m_ModIcons;
 
 	bool m_bFirstItemGoesDown;
-	bool m_bRowHasFocus[NUM_PLAYERS];
+	bool m_bRowHasFocus;
 
-	int m_iChoiceInRowWithFocus[NUM_PLAYERS]; // this choice has input focus
+	int m_iChoiceInRowWithFocus; // this choice has input focus
 	// Only one will true at a time if m_pHand->m_Def.bMultiSelect
 	vector<bool>
-	  m_vbSelected[NUM_PLAYERS];	   // size = m_pHand->m_Def.choices.size()
+	  m_vbSelected;	   // size = m_pHand->m_Def.choices.size()
 	Actor::TweenState m_tsDestination; // this should approach m_tsDestination.
 
   public:

--- a/src/OptionRow.h
+++ b/src/OptionRow.h
@@ -64,8 +64,8 @@ class OptionRow : public ActorFrame
 
 	void SetModIcon(PlayerNumber pn, const RString& sText, GameCommand& gc);
 
-	void ImportOptions(const vector<PlayerNumber>& vpns);
-	int ExportOptions(const vector<PlayerNumber>& vpns,
+	void ImportOptions(const PlayerNumber& vpns);
+	int ExportOptions(const PlayerNumber& vpns,
 					  bool bRowHasFocus);
 
 	enum RowType

--- a/src/OptionRowHandler.cpp
+++ b/src/OptionRowHandler.cpp
@@ -1,4 +1,4 @@
-﻿#include "global.h"
+#include "global.h"
 #include "Character.h"
 #include "CharacterManager.h"
 #include "CommonMetrics.h"
@@ -264,12 +264,12 @@ class OptionRowHandlerList : public OptionRowHandler
 	}
 	void ImportOption(OptionRow* pRow,
 					  const vector<PlayerNumber>& vpns,
-					  vector<bool> vbSelectedOut[NUM_PLAYERS]) const override
+					  vector<bool> vbSelectedOut) const override
 	{
 		FOREACH_CONST(PlayerNumber, vpns, pn)
 		{
 			PlayerNumber p = *pn;
-			vector<bool>& vbSelOut = vbSelectedOut[p];
+			vector<bool>& vbSelOut = vbSelectedOut;
 
 			bool bUseFallbackOption = true;
 
@@ -326,12 +326,12 @@ class OptionRowHandlerList : public OptionRowHandler
 	}
 
 	int ExportOption(const vector<PlayerNumber>& vpns,
-					 const vector<bool> vbSelected[NUM_PLAYERS]) const override
+					 const vector<bool> vbSelected) const override
 	{
 		FOREACH_CONST(PlayerNumber, vpns, pn)
 		{
 			PlayerNumber p = *pn;
-			const vector<bool>& vbSel = vbSelected[p];
+			const vector<bool>& vbSel = vbSelected;
 
 			m_Default.Apply(p);
 			for (unsigned i = 0; i < vbSel.size(); i++) {
@@ -525,14 +525,14 @@ class OptionRowHandlerSteps : public OptionRowHandler
 		CHECK_BLANK_ARG;
 
 		if (sParam == "EditSteps") {
-			m_ppStepsToFill = &GAMESTATE->m_pCurSteps[0];
-			m_pDifficultyToFill = &GAMESTATE->m_PreferredDifficulty[0];
+			m_ppStepsToFill = &GAMESTATE->m_pCurSteps;
+			m_pDifficultyToFill = &GAMESTATE->m_PreferredDifficulty;
 			m_vsReloadRowMessages.push_back(
 			  MessageIDToString(Message_EditStepsTypeChanged));
 		} else if (sParam == "EditSourceSteps") {
 			m_vsReloadRowMessages.push_back(
 			  MessageIDToString(Message_EditSourceStepsTypeChanged));
-			if (GAMESTATE->m_pCurSteps[0].Get() != NULL)
+			if (GAMESTATE->m_pCurSteps.Get() != NULL)
 				m_Def.m_vEnabledForPlayers.clear(); // hide row
 		} else {
 			ROW_INVALID_IF(
@@ -595,12 +595,12 @@ class OptionRowHandlerSteps : public OptionRowHandler
 	}
 	void ImportOption(OptionRow* pRow,
 					  const vector<PlayerNumber>& vpns,
-					  vector<bool> vbSelectedOut[NUM_PLAYERS]) const override
+					  vector<bool> vbSelectedOut) const override
 	{
 		FOREACH_CONST(PlayerNumber, vpns, pn)
 		{
 			PlayerNumber p = *pn;
-			vector<bool>& vbSelOut = vbSelectedOut[p];
+			vector<bool>& vbSelOut = vbSelectedOut;
 
 			ASSERT(m_vSteps.size() == vbSelOut.size());
 
@@ -618,7 +618,7 @@ class OptionRowHandlerSteps : public OptionRowHandler
 				FOREACH_CONST(Difficulty, m_vDifficulties, d)
 				{
 					unsigned i = d - m_vDifficulties.begin();
-					if (*d == GAMESTATE->m_PreferredDifficulty[p]) {
+					if (*d == GAMESTATE->m_PreferredDifficulty) {
 						vbSelOut[i] = true;
 						matched = true;
 						vector<PlayerNumber> v;
@@ -635,12 +635,12 @@ class OptionRowHandlerSteps : public OptionRowHandler
 		}
 	}
 	int ExportOption(const vector<PlayerNumber>& vpns,
-					 const vector<bool> vbSelected[NUM_PLAYERS]) const override
+					 const vector<bool> vbSelected) const override
 	{
 		FOREACH_CONST(PlayerNumber, vpns, pn)
 		{
 			PlayerNumber p = *pn;
-			const vector<bool>& vbSel = vbSelected[p];
+			const vector<bool>& vbSel = vbSelected;
 
 			int index = OptionRowHandlerUtil::GetOneSelection(vbSel);
 			Difficulty dc = m_vDifficulties[index];
@@ -1097,7 +1097,7 @@ class OptionRowHandlerLua : public OptionRowHandler
 
 	void ImportOption(OptionRow* pRow,
 					  const vector<PlayerNumber>& vpns,
-					  vector<bool> vbSelectedOut[NUM_PLAYERS]) const override
+					  vector<bool> vbSelectedOut) const override
 	{
 		if (!m_TableIsSane) {
 			return;
@@ -1109,7 +1109,7 @@ class OptionRowHandlerLua : public OptionRowHandler
 		FOREACH_CONST(PlayerNumber, vpns, pn)
 		{
 			PlayerNumber p = *pn;
-			vector<bool>& vbSelOut = vbSelectedOut[p];
+			vector<bool>& vbSelOut = vbSelectedOut;
 
 			/* Evaluate the LoadSelections(self,array,pn) function, where
 			 * array is a table representing vbSelectedOut. */
@@ -1156,7 +1156,7 @@ class OptionRowHandlerLua : public OptionRowHandler
 		LUA->Release(L);
 	}
 	int ExportOption(const vector<PlayerNumber>& vpns,
-					 const vector<bool> vbSelected[NUM_PLAYERS]) const override
+					 const vector<bool> vbSelected) const override
 	{
 		if (!m_TableIsSane) {
 			return 0;
@@ -1168,7 +1168,7 @@ class OptionRowHandlerLua : public OptionRowHandler
 		FOREACH_CONST(PlayerNumber, vpns, pn)
 		{
 			PlayerNumber p = *pn;
-			const vector<bool>& vbSel = vbSelected[p];
+			const vector<bool>& vbSel = vbSelected;
 
 			/* Evaluate SaveSelections(self,array,pn) function, where array is
 			 * a table representing vbSelectedOut. */
@@ -1293,26 +1293,26 @@ class OptionRowHandlerConfig : public OptionRowHandler
 	}
 	void ImportOption(OptionRow*,
 					  const vector<PlayerNumber>& vpns,
-					  vector<bool> vbSelectedOut[NUM_PLAYERS]) const override
+					  vector<bool> vbSelectedOut) const override
 	{
 		FOREACH_CONST(PlayerNumber, vpns, pn)
 		{
 			PlayerNumber p = *pn;
-			vector<bool>& vbSelOut = vbSelectedOut[p];
+			vector<bool>& vbSelOut = vbSelectedOut;
 
 			int iSelection = m_pOpt->Get();
 			OptionRowHandlerUtil::SelectExactlyOne(iSelection, vbSelOut);
 		}
 	}
 	int ExportOption(const vector<PlayerNumber>& vpns,
-					 const vector<bool> vbSelected[NUM_PLAYERS]) const override
+					 const vector<bool> vbSelected) const override
 	{
 		bool bChanged = false;
 
 		FOREACH_CONST(PlayerNumber, vpns, pn)
 		{
 			PlayerNumber p = *pn;
-			const vector<bool>& vbSel = vbSelected[p];
+			const vector<bool>& vbSel = vbSelected;
 
 			int iSel = OptionRowHandlerUtil::GetOneSelection(vbSel);
 
@@ -1361,7 +1361,7 @@ class OptionRowHandlerStepsType : public OptionRowHandler
 			  MessageIDToString(Message_CurrentStepsP1Changed));
 			m_vsReloadRowMessages.push_back(
 			  MessageIDToString(Message_EditStepsTypeChanged));
-			if (GAMESTATE->m_pCurSteps[0].Get() != NULL)
+			if (GAMESTATE->m_pCurSteps.Get() != NULL)
 				m_Def.m_vEnabledForPlayers.clear(); // hide row
 		} else {
 			ROW_INVALID_IF(
@@ -1391,15 +1391,15 @@ class OptionRowHandlerStepsType : public OptionRowHandler
 
 	void ImportOption(OptionRow* pRow,
 					  const vector<PlayerNumber>& vpns,
-					  vector<bool> vbSelectedOut[NUM_PLAYERS]) const override
+					  vector<bool> vbSelectedOut) const override
 	{
 		FOREACH_CONST(PlayerNumber, vpns, pn)
 		{
 			PlayerNumber p = *pn;
-			vector<bool>& vbSelOut = vbSelectedOut[p];
+			vector<bool>& vbSelOut = vbSelectedOut;
 
-			if (GAMESTATE->m_pCurSteps[0]) {
-				StepsType st = GAMESTATE->m_pCurSteps[0]->m_StepsType;
+			if (GAMESTATE->m_pCurSteps) {
+				StepsType st = GAMESTATE->m_pCurSteps->m_StepsType;
 				vector<StepsType>::const_iterator iter = find(
 				  m_vStepsTypesToShow.begin(), m_vStepsTypesToShow.end(), st);
 				if (iter != m_vStepsTypesToShow.end()) {
@@ -1412,12 +1412,12 @@ class OptionRowHandlerStepsType : public OptionRowHandler
 		}
 	}
 	int ExportOption(const vector<PlayerNumber>& vpns,
-					 const vector<bool> vbSelected[NUM_PLAYERS]) const override
+					 const vector<bool> vbSelected) const override
 	{
 		FOREACH_CONST(PlayerNumber, vpns, pn)
 		{
 			PlayerNumber p = *pn;
-			const vector<bool>& vbSel = vbSelected[p];
+			const vector<bool>& vbSel = vbSelected;
 
 			int index = OptionRowHandlerUtil::GetOneSelection(vbSel);
 			m_pstToFill->Set(m_vStepsTypesToShow[index]);
@@ -1458,13 +1458,13 @@ class OptionRowHandlerGameCommand : public OptionRowHandler
 	}
 	void ImportOption(OptionRow* pRow,
 					  const vector<PlayerNumber>& vpns,
-					  vector<bool> vbSelectedOut[NUM_PLAYERS]) const override
+					  vector<bool> vbSelectedOut) const override
 	{
 	}
 	int ExportOption(const vector<PlayerNumber>& vpns,
-					 const vector<bool> vbSelected[NUM_PLAYERS]) const override
+					 const vector<bool> vbSelected) const override
 	{
-		if( vbSelected[PLAYER_1][0] )
+		if( vbSelected[0] )
 			m_gc.ApplyToAllPlayers();
 		return 0;
 	}

--- a/src/OptionRowHandler.h
+++ b/src/OptionRowHandler.h
@@ -217,12 +217,12 @@ class OptionRowHandler
 	virtual int GetDefaultOption() const { return -1; }
 	virtual void ImportOption(OptionRow*,
 							  const vector<PlayerNumber>&,
-							  vector<bool> vbSelectedOut[NUM_PLAYERS]) const
+							  vector<bool> vbSelectedOut) const
 	{
 	}
 	// Returns an OPT mask.
 	virtual int ExportOption(const vector<PlayerNumber>&,
-							 const vector<bool> vbSelected[NUM_PLAYERS]) const
+							 const vector<bool> vbSelected) const
 	{
 		return 0;
 	}

--- a/src/OptionRowHandler.h
+++ b/src/OptionRowHandler.h
@@ -216,13 +216,13 @@ class OptionRowHandler
 
 	virtual int GetDefaultOption() const { return -1; }
 	virtual void ImportOption(OptionRow*,
-							  const vector<PlayerNumber>&,
-							  vector<bool> vbSelectedOut) const
+							  const PlayerNumber&,
+							  vector<bool>& vbSelectedOut) const
 	{
 	}
 	// Returns an OPT mask.
-	virtual int ExportOption(const vector<PlayerNumber>&,
-							 const vector<bool> vbSelected) const
+	virtual int ExportOption(const PlayerNumber&,
+							 const vector<bool>& vbSelected) const
 	{
 		return 0;
 	}

--- a/src/OptionsList.cpp
+++ b/src/OptionsList.cpp
@@ -523,11 +523,9 @@ void
 OptionsList::ImportRow(const RString& sRow)
 {
 	vector<bool> aSelections;
-	vector<PlayerNumber> vpns;
-	vpns.push_back(m_pn);
 	OptionRowHandler* pHandler = m_Rows[sRow];
 	aSelections.resize(pHandler->m_Def.m_vsChoices.size());
-	pHandler->ImportOption(NULL, vpns, aSelections);
+	pHandler->ImportOption(NULL, m_pn, aSelections);
 	m_bSelections[sRow] = aSelections;
 
 	if (m_setTopMenus.find(sRow) != m_setTopMenus.end())
@@ -543,10 +541,7 @@ OptionsList::ExportRow(const RString& sRow)
 	vector<bool> aSelections;
 	aSelections = m_bSelections[sRow];
 
-	vector<PlayerNumber> vpns;
-	vpns.push_back(m_pn);
-
-	m_Rows[sRow]->ExportOption(vpns, aSelections);
+	m_Rows[sRow]->ExportOption(m_pn, aSelections);
 }
 
 void

--- a/src/OptionsList.cpp
+++ b/src/OptionsList.cpp
@@ -1,4 +1,4 @@
-﻿#include "global.h"
+#include "global.h"
 #include "GameState.h"
 #include "InputEventPlus.h"
 #include "InputMapper.h"
@@ -522,13 +522,13 @@ OptionsList::TweenOnCurrentRow(bool bForward)
 void
 OptionsList::ImportRow(const RString& sRow)
 {
-	vector<bool> aSelections[NUM_PLAYERS];
+	vector<bool> aSelections;
 	vector<PlayerNumber> vpns;
 	vpns.push_back(m_pn);
 	OptionRowHandler* pHandler = m_Rows[sRow];
-	aSelections[m_pn].resize(pHandler->m_Def.m_vsChoices.size());
+	aSelections.resize(pHandler->m_Def.m_vsChoices.size());
 	pHandler->ImportOption(NULL, vpns, aSelections);
-	m_bSelections[sRow] = aSelections[m_pn];
+	m_bSelections[sRow] = aSelections;
 
 	if (m_setTopMenus.find(sRow) != m_setTopMenus.end())
 		fill(m_bSelections[sRow].begin(), m_bSelections[sRow].end(), false);
@@ -540,8 +540,8 @@ OptionsList::ExportRow(const RString& sRow)
 	if (m_setTopMenus.find(sRow) != m_setTopMenus.end())
 		return;
 
-	vector<bool> aSelections[NUM_PLAYERS];
-	aSelections[m_pn] = m_bSelections[sRow];
+	vector<bool> aSelections;
+	aSelections = m_bSelections[sRow];
 
 	vector<PlayerNumber> vpns;
 	vpns.push_back(m_pn);
@@ -683,7 +683,7 @@ OptionsList::Start()
 		pHandler->GetIconTextAndGameCommand(
 		  m_iMenuStackSelection, sIconText, gc);
 		if (gc.m_sName == RESET_ROW) {
-			GAMESTATE->m_pPlayerState[m_pn]->ResetToDefaultPlayerOptions(
+			GAMESTATE->m_pPlayerState->ResetToDefaultPlayerOptions(
 			  ModsLevel_Preferred);
 			GAMESTATE->ResetToDefaultSongOptions(ModsLevel_Preferred);
 

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -630,7 +630,7 @@ Player::Load()
 	//		m_pScore->Init( pn );
 
 	// Mina garbage - Mina
-	m_Timing = GAMESTATE->m_pCurSteps[pn]->GetTimingData();
+	m_Timing = GAMESTATE->m_pCurSteps->GetTimingData();
 	m_Timing->NegStopAndBPMCheck();
 	int lastRow = m_NoteData.GetLastRow();
 	m_Timing->BuildAndGetEtar(lastRow);
@@ -649,11 +649,11 @@ Player::Load()
 		m_pPlayerStageStats->filehadnegbpms = true;
 
 	// check before nomines transform
-	if (GAMESTATE->m_pCurSteps[pn]->GetRadarValues()[RadarCategory_Mines] > 0)
+	if (GAMESTATE->m_pCurSteps->GetRadarValues()[RadarCategory_Mines] > 0)
 		m_pPlayerStageStats->filegotmines = true;
 
-	if (GAMESTATE->m_pCurSteps[pn]->GetRadarValues()[RadarCategory_Holds] > 0 ||
-		GAMESTATE->m_pCurSteps[pn]->GetRadarValues()[RadarCategory_Rolls] > 0)
+	if (GAMESTATE->m_pCurSteps->GetRadarValues()[RadarCategory_Holds] > 0 ||
+		GAMESTATE->m_pCurSteps->GetRadarValues()[RadarCategory_Rolls] > 0)
 		m_pPlayerStageStats->filegotholds = true;
 
 	// check for lua script load (technically this is redundant a little with
@@ -662,7 +662,7 @@ Player::Load()
 		m_pPlayerStageStats->luascriptwasloaded = true;
 
 	const HighScore* pb = SCOREMAN->GetChartPBAt(
-	  GAMESTATE->m_pCurSteps[pn]->GetChartKey(),
+	  GAMESTATE->m_pCurSteps->GetChartKey(),
 	  GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate);
 	if (pb != nullptr)
 		wifescorepersonalbest = pb->GetWifeScore();
@@ -1997,7 +1997,7 @@ Player::Step(int col,
 
 	float fSongBeat = m_pPlayerState->m_Position.m_fSongBeat;
 
-	if (GAMESTATE->m_pCurSteps[m_pPlayerState->m_PlayerNumber])
+	if (GAMESTATE->m_pCurSteps)
 		fSongBeat = m_Timing->GetBeatFromElapsedTime(fPositionSeconds);
 
 	const int iSongRow = row == -1 ? BeatToNoteRow(fSongBeat) : row;
@@ -2521,7 +2521,7 @@ Player::StepReplay(int col,
 
 	float fSongBeat = m_pPlayerState->m_Position.m_fSongBeat;
 
-	if (GAMESTATE->m_pCurSteps[m_pPlayerState->m_PlayerNumber])
+	if (GAMESTATE->m_pCurSteps)
 		fSongBeat = m_Timing->GetBeatFromElapsedTime(fPositionSeconds);
 
 	const int iSongRow = row == -1 ? BeatToNoteRow(fSongBeat) : row;

--- a/src/PlayerStageStats.cpp
+++ b/src/PlayerStageStats.cpp
@@ -363,7 +363,7 @@ PlayerStageStats::GetMaxWifeScore() const
 vector<float>
 PlayerStageStats::CalcSSR(float ssrpercent) const
 {
-	Steps* steps = GAMESTATE->m_pCurSteps[PLAYER_1];
+	Steps* steps = GAMESTATE->m_pCurSteps;
 	float musicrate = GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate;
 	return MinaSDCalc(serializednd,
 					  steps->GetNoteData().GetNumTracks(),

--- a/src/PlayerState.cpp
+++ b/src/PlayerState.cpp
@@ -1,4 +1,4 @@
-﻿#include "global.h"
+#include "global.h"
 #include "GameState.h"
 #include "PlayerState.h"
 #include "RadarValues.h"
@@ -64,7 +64,7 @@ PlayerState::GetDisplayedPosition() const
 const TimingData&
 PlayerState::GetDisplayedTiming() const
 {
-	Steps* steps = GAMESTATE->m_pCurSteps[m_PlayerNumber];
+	Steps* steps = GAMESTATE->m_pCurSteps;
 	if (steps == NULL)
 		return GAMESTATE->m_pCurSong->m_SongTiming;
 	return *steps->GetTimingData();

--- a/src/Profile.cpp
+++ b/src/Profile.cpp
@@ -1783,8 +1783,8 @@ class LunaProfile : public Luna<Profile>
 	{
 		bool o = false;
 
-		if (GAMESTATE->m_pCurSteps[PLAYER_1]) {
-			const string& ck = GAMESTATE->m_pCurSteps[PLAYER_1]->GetChartKey();
+		if (GAMESTATE->m_pCurSteps) {
+			const string& ck = GAMESTATE->m_pCurSteps->GetChartKey();
 
 			if (p->PermaMirrorCharts.count(ck))
 				o = true;

--- a/src/ProfileManager.h
+++ b/src/ProfileManager.h
@@ -74,7 +74,7 @@ class ProfileManager
 
 	bool IsPersistentProfile(PlayerNumber pn) const
 	{
-		return !m_sProfileDir[pn].empty();
+		return !m_sProfileDir.empty();
 	}
 	bool IsPersistentProfile(ProfileSlot slot) const;
 
@@ -121,22 +121,21 @@ class ProfileManager
 
 	// Directory that contains the profile.  Either on local machine or
 	// on a memory card.
-	RString m_sProfileDir[NUM_PLAYERS];
+	RString m_sProfileDir;
 
 	RString m_stats_prefix;
 	Profile* dummy;
-	bool m_bLastLoadWasTamperedOrCorrupt[NUM_PLAYERS]; // true if Stats.xml was
+	bool m_bLastLoadWasTamperedOrCorrupt; // true if Stats.xml was
 													   // present, but failed to
 													   // load (probably because
 													   // of a signature
 													   // failure)
-	bool m_bLastLoadWasFromLastGood
-	  [NUM_PLAYERS]; // if true, then
+	bool m_bLastLoadWasFromLastGood; // if true, then
 					 // m_bLastLoadWasTamperedOrCorrupt
 					 // is also true
-	mutable bool m_bNeedToBackUpLastLoad[NUM_PLAYERS]; // if true, back up
+	mutable bool m_bNeedToBackUpLastLoad; // if true, back up
 													   // profile on next save
-	bool m_bNewProfile[NUM_PLAYERS];
+	bool m_bNewProfile;
 };
 
 extern ProfileManager*

--- a/src/ReceptorArrowRow.cpp
+++ b/src/ReceptorArrowRow.cpp
@@ -90,9 +90,9 @@ ReceptorArrowRow::Update(float fDeltaTime)
 			const Style* style =
 			  GAMESTATE->GetCurrentStyle(m_pPlayerState->m_PlayerNumber);
 			m_ReceptorArrow[c]->SetX(
-			  style->m_ColumnInfo[m_pPlayerState->m_PlayerNumber][c].fXOffset);
+			  style->m_ColumnInfo[c].fXOffset);
 			m_OverlayReceptorArrow[c]->SetX(
-			  style->m_ColumnInfo[m_pPlayerState->m_PlayerNumber][c].fXOffset);
+			  style->m_ColumnInfo[c].fXOffset);
 		}
 	}
 }

--- a/src/ScoreKeeperNormal.cpp
+++ b/src/ScoreKeeperNormal.cpp
@@ -465,7 +465,7 @@ ScoreKeeperNormal::HandleTapNoteScoreInternal(const NoteData& nd,
 
 	// update judged row totals. Respect Combo segments here.
 	TimingData& td =
-	  *GAMESTATE->m_pCurSteps[m_pPlayerState->m_PlayerNumber]->GetTimingData();
+	  *GAMESTATE->m_pCurSteps->GetTimingData();
 	ComboSegment* cs = td.GetComboSegmentAtRow(row);
 	if (tns == TNS_CheckpointHit || tns >= m_MinScoreToContinueCombo) {
 		m_pPlayerStageStats->m_iTapNoteScores[tns] += cs->GetCombo();
@@ -493,7 +493,7 @@ ScoreKeeperNormal::HandleComboInternal(int iNumHitContinueCombo,
 		m_pPlayerStageStats->m_iCurMissCombo = 0;
 	}
 	TimingData& td =
-	  *GAMESTATE->m_pCurSteps[m_pPlayerState->m_PlayerNumber]->GetTimingData();
+	  *GAMESTATE->m_pCurSteps->GetTimingData();
 	if (iNumBreakCombo == 0) {
 		int multiplier =
 		  (iRow == -1 ? 1 : td.GetComboSegmentAtRow(iRow)->GetCombo());
@@ -516,7 +516,7 @@ ScoreKeeperNormal::HandleRowComboInternal(TapNoteScore tns,
 		iNumTapsInRow = min(iNumTapsInRow, 1);
 	}
 	TimingData& td =
-	  *GAMESTATE->m_pCurSteps[m_pPlayerState->m_PlayerNumber]->GetTimingData();
+	  *GAMESTATE->m_pCurSteps->GetTimingData();
 	if (tns >= m_MinScoreToContinueCombo) {
 		m_pPlayerStageStats->m_iCurMissCombo = 0;
 		int multiplier =

--- a/src/ScreenDebugOverlay.cpp
+++ b/src/ScreenDebugOverlay.cpp
@@ -652,7 +652,7 @@ class DebugLineAutoplay : public IDebugLine
 	{
 		ASSERT(GAMESTATE->GetMasterPlayerNumber() != PLAYER_INVALID);
 		PlayerController pc =
-		  GAMESTATE->m_pPlayerState[GAMESTATE->GetMasterPlayerNumber()]
+		  GAMESTATE->m_pPlayerState
 			->m_PlayerController;
 		bool bHoldingShift =
 		  INPUTFILTER->IsBeingPressed(
@@ -664,7 +664,7 @@ class DebugLineAutoplay : public IDebugLine
 			pc = (pc == PC_AUTOPLAY) ? PC_HUMAN : PC_AUTOPLAY;
 		if (GamePreferences::m_AutoPlay != PC_REPLAY)
 			GamePreferences::m_AutoPlay.Set(pc);
-		FOREACH_HumanPlayer(p) GAMESTATE->m_pPlayerState[p]
+		GAMESTATE->m_pPlayerState
 		  ->m_PlayerController = GamePreferences::m_AutoPlay;
 		FOREACH_MultiPlayer(p) GAMESTATE->m_pMultiPlayerState[p]
 		  ->m_PlayerController = GamePreferences::m_AutoPlay;

--- a/src/ScreenEvaluation.cpp
+++ b/src/ScreenEvaluation.cpp
@@ -77,11 +77,11 @@ ScreenEvaluation::Init()
 		ss.m_vpPlayedSongs.push_back(GAMESTATE->m_pCurSong);
 		ss.m_vpPossibleSongs.push_back(GAMESTATE->m_pCurSong);
 		GAMESTATE->m_iCurrentStageIndex = 0;
-		GAMESTATE->m_iPlayerStageTokens[PLAYER_1] = 1;
+		GAMESTATE->m_iPlayerStageTokens = 1;
 
-		ss.m_player[PLAYER_1].m_pStyle = GAMESTATE->GetCurrentStyle(PLAYER_1);
+		ss.m_player.m_pStyle = GAMESTATE->GetCurrentStyle(PLAYER_1);
 		if (RandomInt(2))
-			PO_GROUP_ASSIGN_N(GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions,
+			PO_GROUP_ASSIGN_N(GAMESTATE->m_pPlayerState->m_PlayerOptions,
 								ModsLevel_Stage,
 								m_bTransforms,
 								PlayerOptions::TRANSFORM_ECHO,
@@ -90,61 +90,61 @@ ScreenEvaluation::Init()
 			GAMESTATE->m_SongOptions, ModsLevel_Stage, m_fMusicRate, 1.1f);
 
 		GAMESTATE->JoinPlayer(PLAYER_1);
-		GAMESTATE->m_pCurSteps[PLAYER_1].Set(
+		GAMESTATE->m_pCurSteps.Set(
 			GAMESTATE->m_pCurSong->GetAllSteps()[0]);
-		ss.m_player[PLAYER_1].m_vpPossibleSteps.push_back(
-			GAMESTATE->m_pCurSteps[PLAYER_1]);
-		ss.m_player[PLAYER_1].m_iStepsPlayed = 1;
+		ss.m_player.m_vpPossibleSteps.push_back(
+			GAMESTATE->m_pCurSteps);
+		ss.m_player.m_iStepsPlayed = 1;
 
-		PO_GROUP_ASSIGN(GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions,
+		PO_GROUP_ASSIGN(GAMESTATE->m_pPlayerState->m_PlayerOptions,
 						ModsLevel_Stage,
 						m_fScrollSpeed,
 						2.0f);
-		PO_GROUP_CALL(GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions,
+		PO_GROUP_CALL(GAMESTATE->m_pPlayerState->m_PlayerOptions,
 						ModsLevel_Stage,
 						ChooseRandomModifiers);
 
 		for( float f = 0; f < 100.0f; f += 1.0f )
 		{
 			float fP1 = fmodf(f/100*4+.3f,1);
-			ss.m_player[PLAYER_1].SetLifeRecordAt( fP1, f );
+			ss.m_player.SetLifeRecordAt( fP1, f );
 		}
 		float fSeconds = GAMESTATE->m_pCurSong->GetStepsSeconds();
-		ss.m_player[PLAYER_1].m_iActualDancePoints = RandomInt(3);
-		ss.m_player[PLAYER_1].m_iPossibleDancePoints = 2;
+		ss.m_player.m_iActualDancePoints = RandomInt(3);
+		ss.m_player.m_iPossibleDancePoints = 2;
 		if (RandomInt(2))
-			ss.m_player[PLAYER_1].m_iCurCombo = RandomInt(15000);
+			ss.m_player.m_iCurCombo = RandomInt(15000);
 		else
-			ss.m_player[PLAYER_1].m_iCurCombo = 0;
-		ss.m_player[PLAYER_1].UpdateComboList(0, true);
+			ss.m_player.m_iCurCombo = 0;
+		ss.m_player.UpdateComboList(0, true);
 
-		ss.m_player[PLAYER_1].m_iCurCombo += 50;
-		ss.m_player[PLAYER_1].UpdateComboList(0.10f * fSeconds, false);
+		ss.m_player.m_iCurCombo += 50;
+		ss.m_player.UpdateComboList(0.10f * fSeconds, false);
 
-		ss.m_player[PLAYER_1].m_iCurCombo = 0;
-		ss.m_player[PLAYER_1].UpdateComboList(0.15f * fSeconds, false);
-		ss.m_player[PLAYER_1].m_iCurCombo = 1;
-		ss.m_player[PLAYER_1].UpdateComboList(0.25f * fSeconds, false);
-		ss.m_player[PLAYER_1].m_iCurCombo = 50;
-		ss.m_player[PLAYER_1].UpdateComboList(0.35f * fSeconds, false);
-		ss.m_player[PLAYER_1].m_iCurCombo = 0;
-		ss.m_player[PLAYER_1].UpdateComboList(0.45f * fSeconds, false);
-		ss.m_player[PLAYER_1].m_iCurCombo = 1;
-		ss.m_player[PLAYER_1].UpdateComboList(0.50f * fSeconds, false);
-		ss.m_player[PLAYER_1].m_iCurCombo = 100;
-		ss.m_player[PLAYER_1].UpdateComboList(1.00f * fSeconds, false);
+		ss.m_player.m_iCurCombo = 0;
+		ss.m_player.UpdateComboList(0.15f * fSeconds, false);
+		ss.m_player.m_iCurCombo = 1;
+		ss.m_player.UpdateComboList(0.25f * fSeconds, false);
+		ss.m_player.m_iCurCombo = 50;
+		ss.m_player.UpdateComboList(0.35f * fSeconds, false);
+		ss.m_player.m_iCurCombo = 0;
+		ss.m_player.UpdateComboList(0.45f * fSeconds, false);
+		ss.m_player.m_iCurCombo = 1;
+		ss.m_player.UpdateComboList(0.50f * fSeconds, false);
+		ss.m_player.m_iCurCombo = 100;
+		ss.m_player.UpdateComboList(1.00f * fSeconds, false);
 		if (RandomInt(5) == 0) {
-			ss.m_player[PLAYER_1].m_bFailed = true;
+			ss.m_player.m_bFailed = true;
 		}
-		ss.m_player[PLAYER_1].m_iTapNoteScores[TNS_W1] = RandomInt(3);
-		ss.m_player[PLAYER_1].m_iTapNoteScores[TNS_W2] = RandomInt(3);
-		ss.m_player[PLAYER_1].m_iTapNoteScores[TNS_W3] = RandomInt(3);
-		ss.m_player[PLAYER_1].m_iPossibleGradePoints =
+		ss.m_player.m_iTapNoteScores[TNS_W1] = RandomInt(3);
+		ss.m_player.m_iTapNoteScores[TNS_W2] = RandomInt(3);
+		ss.m_player.m_iTapNoteScores[TNS_W3] = RandomInt(3);
+		ss.m_player.m_iPossibleGradePoints =
 			4 * ScoreKeeperNormal::TapNoteScoreToGradePoints(TNS_W1, false);
-		ss.m_player[PLAYER_1].m_fLifeRemainingSeconds = randomf(90, 580);
-		ss.m_player[PLAYER_1].m_iScore = random_up_to(900 * 1000 * 1000);
-		ss.m_player[PLAYER_1].m_iPersonalHighScoreIndex = (random_up_to(3)) - 1;
-		ss.m_player[PLAYER_1].m_iMachineHighScoreIndex = (random_up_to(3)) - 1;
+		ss.m_player.m_fLifeRemainingSeconds = randomf(90, 580);
+		ss.m_player.m_iScore = random_up_to(900 * 1000 * 1000);
+		ss.m_player.m_iPersonalHighScoreIndex = (random_up_to(3)) - 1;
+		ss.m_player.m_iMachineHighScoreIndex = (random_up_to(3)) - 1;
 
 		FOREACH_ENUM(RadarCategory, rc)
 		{
@@ -157,10 +157,10 @@ ScreenEvaluation::Init()
 				case RadarCategory_Rolls:
 				case RadarCategory_Lifts:
 				case RadarCategory_Fakes:
-					ss.m_player[PLAYER_1].m_radarPossible[rc] =
+					ss.m_player.m_radarPossible[rc] =
 						1 + (random_up_to(200));
-					ss.m_player[PLAYER_1].m_radarActual[rc] = random_up_to(
-						static_cast<int>(ss.m_player[PLAYER_1].m_radarPossible[rc]));
+					ss.m_player.m_radarActual[rc] = random_up_to(
+						static_cast<int>(ss.m_player.m_radarPossible[rc]));
 					break;
 				default:
 					break;
@@ -179,14 +179,14 @@ ScreenEvaluation::Init()
 	}
 	m_pStageStats = &STATSMAN->m_vPlayedStageStats.back();
 
-	ZERO(m_bSavedScreenshot);
+	m_bSavedScreenshot = false;
 
 
 
 	// update persistent statistics
 	if (GamePreferences::m_AutoPlay == PC_REPLAY) {
-		m_pStageStats->m_player[PLAYER_1].m_HighScore.SetRadarValues(
-		  m_pStageStats->m_player[PLAYER_1].m_radarActual);
+		m_pStageStats->m_player.m_HighScore.SetRadarValues(
+		  m_pStageStats->m_player.m_radarActual);
 	} else if (GamePreferences::m_AutoPlay != PC_REPLAY) {
 		m_pStageStats->FinalizeScores(true);
 	}
@@ -195,9 +195,9 @@ ScreenEvaluation::Init()
 	ScreenWithMenuElements::Init();
 
 	// Calculate grades
-	Grade grade[NUM_PLAYERS];
+	Grade grade;
 
-	grade[PLAYER_1] = Grade_Failed;
+	grade = Grade_Failed;
 
 	// load sounds
 	m_soundStart.Load(THEME->GetPathS(m_sName, "start"));
@@ -209,26 +209,26 @@ ScreenEvaluation::Init()
 	bool bOneHasFullW3Combo = false;
 	bool bOneHasFullW4Combo = false;
 	if (GAMESTATE->IsPlayerEnabled(PLAYER_1)) {
-		if ((m_pStageStats->m_player[PLAYER_1].m_iMachineHighScoreIndex == 0 ||
-				m_pStageStats->m_player[PLAYER_1].m_iPersonalHighScoreIndex == 0)) {
+		if ((m_pStageStats->m_player.m_iMachineHighScoreIndex == 0 ||
+				m_pStageStats->m_player.m_iPersonalHighScoreIndex == 0)) {
 			bOneHasNewTopRecord = true;
 		}
 
-		if (m_pStageStats->m_player[PLAYER_1].FullComboOfScore(TNS_W4))
+		if (m_pStageStats->m_player.FullComboOfScore(TNS_W4))
 			bOneHasFullW4Combo = true;
 
-		if (m_pStageStats->m_player[PLAYER_1].FullComboOfScore(TNS_W3))
+		if (m_pStageStats->m_player.FullComboOfScore(TNS_W3))
 			bOneHasFullW3Combo = true;
 
-		if (m_pStageStats->m_player[PLAYER_1].FullComboOfScore(TNS_W2))
+		if (m_pStageStats->m_player.FullComboOfScore(TNS_W2))
 			bOneHasFullW2Combo = true;
 
-		if (m_pStageStats->m_player[PLAYER_1].FullComboOfScore(TNS_W1))
+		if (m_pStageStats->m_player.FullComboOfScore(TNS_W1))
 			bOneHasFullW1Combo = true;
 	}
 
 	Grade best_grade = Grade_NoData;
-	best_grade = min(best_grade, grade[PLAYER_1]);
+	best_grade = min(best_grade, grade);
 
 	if (bOneHasNewTopRecord &&
 		ANNOUNCER->HasSoundsFor("evaluation new record")) {
@@ -277,7 +277,7 @@ ScreenEvaluation::Input(const InputEventPlus& input)
 			// Otherwise, you can tap away at the screenshot button without
 			// holding shift.
 			if (bHoldingShift && PROFILEMAN->IsPersistentProfile(pn)) {
-				if (!m_bSavedScreenshot[pn]) {
+				if (!m_bSavedScreenshot) {
 					Profile* pProfile = PROFILEMAN->GetProfile(pn);
 					sDir = PROFILEMAN->GetProfileDir((ProfileSlot)pn) +
 						   "Screenshots/";
@@ -287,7 +287,7 @@ ScreenEvaluation::Input(const InputEventPlus& input)
 						RString sPath = sDir + sFileName;
 
 						const HighScore& hs =
-						  m_pStageStats->m_player[pn].m_HighScore;
+						  m_pStageStats->m_player.m_HighScore;
 						Screenshot screenshot;
 						screenshot.sFileName = sFileName;
 						screenshot.sMD5 =
@@ -295,7 +295,7 @@ ScreenEvaluation::Input(const InputEventPlus& input)
 						screenshot.highScore = hs;
 						pProfile->AddScreenshot(screenshot);
 					}
-					m_bSavedScreenshot[pn] = true;
+					m_bSavedScreenshot = true;
 				}
 			} else {
 				sDir = "Screenshots/";
@@ -341,28 +341,28 @@ void
 ScreenEvaluation::HandleMenuStart()
 {
 	StepsID stepsid;
-	stepsid.FromSteps(GAMESTATE->m_pCurSteps[PLAYER_1]);
+	stepsid.FromSteps(GAMESTATE->m_pCurSteps);
 	SongID songid;
 	songid.FromSong(GAMESTATE->m_pCurSong);
 	if (GAMEMAN->m_bResetModifiers) {
 		float oldRate = GAMEMAN->m_fPreviousRate;
 		const RString mods = GAMEMAN->m_sModsToReset;
 		/* // Reset mods
-		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetSong().FromString("clearall");
-		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetCurrent().FromString("clearall");
-		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetPreferred().FromString("clearall");
-		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetSong().FromString(mods);
-		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetCurrent().FromString(mods);
-		GAMESTATE->m_pPlayerState[PLAYER_1]->m_PlayerOptions.GetPreferred().FromString(mods);
+		GAMESTATE->m_pPlayerState->m_PlayerOptions.GetSong().FromString("clearall");
+		GAMESTATE->m_pPlayerState->m_PlayerOptions.GetCurrent().FromString("clearall");
+		GAMESTATE->m_pPlayerState->m_PlayerOptions.GetPreferred().FromString("clearall");
+		GAMESTATE->m_pPlayerState->m_PlayerOptions.GetSong().FromString(mods);
+		GAMESTATE->m_pPlayerState->m_PlayerOptions.GetCurrent().FromString(mods);
+		GAMESTATE->m_pPlayerState->m_PlayerOptions.GetPreferred().FromString(mods);
 		*/
 		FailType failreset = GAMEMAN->m_iPreviousFail;
-		GAMESTATE->m_pPlayerState[PLAYER_1]
+		GAMESTATE->m_pPlayerState
 		  ->m_PlayerOptions.GetSong()
 		  .m_FailType = failreset;
-		GAMESTATE->m_pPlayerState[PLAYER_1]
+		GAMESTATE->m_pPlayerState
 		  ->m_PlayerOptions.GetCurrent()
 		  .m_FailType = failreset;
-		GAMESTATE->m_pPlayerState[PLAYER_1]
+		GAMESTATE->m_pPlayerState
 		  ->m_PlayerOptions.GetPreferred()
 		  .m_FailType = failreset;
 		GAMESTATE->m_SongOptions.GetSong().m_fMusicRate = oldRate;
@@ -372,13 +372,13 @@ ScreenEvaluation::HandleMenuStart()
 		
 		const vector<RString> oldturns = GAMEMAN->m_vTurnsToReset;
 		if (GAMEMAN->m_bResetTurns) {
-			GAMESTATE->m_pPlayerState[PLAYER_1]
+			GAMESTATE->m_pPlayerState
 			  ->m_PlayerOptions.GetSong()
 			  .ResetModsToStringVector(oldturns);
-			GAMESTATE->m_pPlayerState[PLAYER_1]
+			GAMESTATE->m_pPlayerState
 			  ->m_PlayerOptions.GetCurrent()
 			  .ResetModsToStringVector(oldturns);
-			GAMESTATE->m_pPlayerState[PLAYER_1]
+			GAMESTATE->m_pPlayerState
 			  ->m_PlayerOptions.GetPreferred()
 			  .ResetModsToStringVector(oldturns);
 			GAMEMAN->m_bResetTurns = false;

--- a/src/ScreenEvaluation.h
+++ b/src/ScreenEvaluation.h
@@ -41,7 +41,7 @@ class ScreenEvaluation : public ScreenWithMenuElements
 	RageSound m_soundStart; // sound played if the player passes or fails
 
 	/** @brief Did a player save a screenshot of their score? */
-	bool m_bSavedScreenshot[NUM_PLAYERS];
+	bool m_bSavedScreenshot;
 };
 
 #endif

--- a/src/ScreenGameplaySyncMachine.cpp
+++ b/src/ScreenGameplaySyncMachine.cpp
@@ -45,7 +45,7 @@ ScreenGameplaySyncMachine::Init()
 	ASSERT_M(vpSteps.size() > 0,
 			 "No playable steps for ScreenGameplaySyncMachine");
 	Steps* pSteps = vpSteps[0];
-	GAMESTATE->m_pCurSteps[GAMESTATE->GetFirstHumanPlayer()].Set(pSteps);
+	GAMESTATE->m_pCurSteps.Set(pSteps);
 
 	GamePreferences::m_AutoPlay.Set(PC_HUMAN);
 
@@ -105,7 +105,7 @@ ScreenGameplaySyncMachine::HandleScreenMessage(const ScreenMessage SM)
 	ScreenGameplayNormal::HandleScreenMessage(SM);
 
 	if (SM == SM_GoToPrevScreen || SM == SM_GoToNextScreen) {
-		GAMESTATE->m_pCurSteps[PLAYER_1].Set(NULL);
+		GAMESTATE->m_pCurSteps.Set(NULL);
 		GAMESTATE->m_PlayMode.Set(PlayMode_Invalid);
 		GAMESTATE->SetCurrentStyle(NULL, PLAYER_INVALID);
 		GAMESTATE->m_pCurSong.Set(NULL);

--- a/src/ScreenMiniMenu.cpp
+++ b/src/ScreenMiniMenu.cpp
@@ -110,10 +110,8 @@ ScreenMiniMenu::AfterChangeValueOrRow(PlayerNumber pn)
 {
 	ScreenOptions::AfterChangeValueOrRow(pn);
 
-	vector<PlayerNumber> vpns;
-	vpns.push_back(PLAYER_1);
 	for (unsigned i = 0; i < m_pRows.size(); i++)
-		ExportOptions(i, vpns);
+		ExportOptions(i, PLAYER_1);
 
 	// Changing one option can affect whether other options are available.
 	for (unsigned i = 0; i < m_pRows.size(); i++) {
@@ -130,7 +128,7 @@ ScreenMiniMenu::AfterChangeValueOrRow(PlayerNumber pn)
 }
 
 void
-ScreenMiniMenu::ImportOptions(int r, const vector<PlayerNumber>& vpns)
+ScreenMiniMenu::ImportOptions(int r, const PlayerNumber& vpns)
 {
 	OptionRow& optrow = *m_pRows[r];
 	const MenuRowDef& mr = m_vMenuRows[r];
@@ -139,7 +137,7 @@ ScreenMiniMenu::ImportOptions(int r, const vector<PlayerNumber>& vpns)
 }
 
 void
-ScreenMiniMenu::ExportOptions(int r, const vector<PlayerNumber>& vpns)
+ScreenMiniMenu::ExportOptions(int r, const PlayerNumber& vpns)
 {
 	if (r == GetCurrentRow())
 		s_iLastRowCode = m_vMenuRows[r].iRowCode;

--- a/src/ScreenMiniMenu.h
+++ b/src/ScreenMiniMenu.h
@@ -337,8 +337,8 @@ class ScreenMiniMenu : public ScreenOptions
 
   protected:
 	void AfterChangeValueOrRow(PlayerNumber pn) override;
-	void ImportOptions(int iRow, const vector<PlayerNumber>& vpns) override;
-	void ExportOptions(int iRow, const vector<PlayerNumber>& vpns) override;
+	void ImportOptions(int iRow, const PlayerNumber& vpns) override;
+	void ExportOptions(int iRow, const PlayerNumber& vpns) override;
 
 	bool FocusedItemEndsScreen(PlayerNumber pn) const override;
 

--- a/src/ScreenNetSelectMusic.cpp
+++ b/src/ScreenNetSelectMusic.cpp
@@ -98,8 +98,8 @@ SelectSongUsingNSMAN(ScreenNetSelectMusic* s, bool start)
 	if (NSMAN->song != nullptr) {
 		GAMESTATE->m_pCurSong.Set(NSMAN->song);
 		if (NSMAN->steps != nullptr) {
-			GAMESTATE->m_pCurSteps[PLAYER_1].Set(NSMAN->steps);
-			GAMESTATE->m_PreferredDifficulty[PLAYER_1].Set(
+			GAMESTATE->m_pCurSteps.Set(NSMAN->steps);
+			GAMESTATE->m_PreferredDifficulty.Set(
 			  NSMAN->steps->GetDifficulty());
 		}
 		if (!m_MusicWheel.SelectSong(NSMAN->song)) {
@@ -137,8 +137,8 @@ ScreenNetSelectMusic::HandleScreenMessage(const ScreenMessage SM)
 		if (NSMAN->song != nullptr) {
 			GAMESTATE->m_pCurSong.Set(NSMAN->song);
 			if (NSMAN->steps != nullptr) {
-				GAMESTATE->m_pCurSteps[PLAYER_1].Set(NSMAN->steps);
-				GAMESTATE->m_PreferredDifficulty[PLAYER_1].Set(
+				GAMESTATE->m_pCurSteps.Set(NSMAN->steps);
+				GAMESTATE->m_PreferredDifficulty.Set(
 				  NSMAN->steps->GetDifficulty());
 			}
 			if (!m_MusicWheel.SelectSong(NSMAN->song)) {
@@ -265,12 +265,12 @@ ScreenNetSelectMusic::SelectCurrent()
 
 	if (pSong == NULL)
 		return false;
-	if (static_cast<int>(m_vpSteps.size()) <= m_iSelection[PLAYER_1])
+	if (static_cast<int>(m_vpSteps.size()) <= m_iSelection)
 		return false;
 	GAMESTATE->m_pCurSong.Set(pSong);
-	Steps* pSteps = m_vpSteps[m_iSelection[PLAYER_1]];
-	GAMESTATE->m_pCurSteps[PLAYER_1].Set(pSteps);
-	GAMESTATE->m_PreferredDifficulty[PLAYER_1].Set(pSteps->GetDifficulty());
+	Steps* pSteps = m_vpSteps[m_iSelection];
+	GAMESTATE->m_pCurSteps.Set(pSteps);
+	GAMESTATE->m_PreferredDifficulty.Set(pSteps->GetDifficulty());
 
 	if (NSMAN->useSMserver) {
 		NSMAN->m_sArtist = pSong->GetTranslitArtist();

--- a/src/ScreenNetworkOptions.cpp
+++ b/src/ScreenNetworkOptions.cpp
@@ -159,12 +159,12 @@ ScreenNetworkOptions::MenuStart(const InputEventPlus& input)
 
 void
 ScreenNetworkOptions::ImportOptions(int /* iRow */,
-									const vector<PlayerNumber>& /* vpns */)
+									const PlayerNumber& /* vpns */)
 {
 }
 void
 ScreenNetworkOptions::ExportOptions(int /* iRow */,
-									const vector<PlayerNumber>& /* vpns */)
+									const PlayerNumber& /* vpns */)
 {
 }
 

--- a/src/ScreenNetworkOptions.h
+++ b/src/ScreenNetworkOptions.h
@@ -1,4 +1,4 @@
-﻿#ifndef SCREEN_NETWORK_OPTIONS_H
+#ifndef SCREEN_NETWORK_OPTIONS_H
 #define SCREEN_NETWORK_OPTIONS_H
 
 #include "ScreenOptions.h"
@@ -13,8 +13,8 @@ class ScreenNetworkOptions : public ScreenOptions
 	bool MenuStart(const InputEventPlus& input) override;
 
   private:
-	void ImportOptions(int iRow, const vector<PlayerNumber>& vpns) override;
-	void ExportOptions(int iRow, const vector<PlayerNumber>& vpns) override;
+	void ImportOptions(int iRow, const PlayerNumber& vpns) override;
+	void ExportOptions(int iRow, const PlayerNumber& vpns) override;
 	// vector<NetServerInfo> AllServers;
 
 	void UpdateConnectStatus();

--- a/src/ScreenOptions.cpp
+++ b/src/ScreenOptions.cpp
@@ -255,15 +255,13 @@ void
 ScreenOptions::RestartOptions()
 {
 	m_exprRowPositionTransformFunction.ClearCache();
-	vector<PlayerNumber> vpns;
-	FOREACH_HumanPlayer(p) vpns.push_back(p);
 
 	for (unsigned r = 0; r < m_pRows.size(); r++) // foreach row
 	{
 		OptionRow* pRow = m_pRows[r];
 		pRow->Reload();
 
-		this->ImportOptions(r, vpns);
+		this->ImportOptions(r, PLAYER_1);
 
 		// HACK: Process disabled players, too, to hide inactive underlines.
 		pRow->AfterImportOptions(PLAYER_1);
@@ -565,13 +563,11 @@ ScreenOptions::HandleScreenMessage(const ScreenMessage SM)
 
 		StartTransitioningScreen(SM_ExportOptions);
 	} else if (SM == SM_ExportOptions) {
-		vector<PlayerNumber> vpns;
-		FOREACH_HumanPlayer(p) vpns.push_back(p);
 		for (unsigned r = 0; r < m_pRows.size(); r++) // foreach row
 		{
 			if (m_pRows[r]->GetRowType() == OptionRow::RowType_Exit)
 				continue;
-			this->ExportOptions(r, vpns);
+			this->ExportOptions(r, PLAYER_1);
 		}
 
 		this->HandleScreenMessage(SM_GoToNextScreen);
@@ -834,9 +830,7 @@ ScreenOptions::ProcessMenuStart(const InputEventPlus& input)
 		/* In NAV_THREE_KEY_MENU mode, if a row doesn't set a screen, it does
 		 * something.  Apply it now, and don't go to the next screen. */
 		if (!FocusedItemEndsScreen(input.pn)) {
-			vector<PlayerNumber> vpns;
-			vpns.push_back(input.pn);
-			ExportOptions(iCurRow, vpns);
+			ExportOptions(iCurRow, input.pn);
 			return;
 		}
 	}
@@ -1139,9 +1133,7 @@ ScreenOptions::ChangeValueInRowRelative(int iRow,
 		m_SoundChangeCol.Play(true);
 
 	if (row.GetRowDef().m_bExportOnChange) {
-		vector<PlayerNumber> vpns;
-		FOREACH_HumanPlayer(p) vpns.push_back(p);
-		ExportOptions(iRow, vpns);
+		ExportOptions(iRow, PLAYER_1);
 	}
 
 	this->AfterChangeValueInRow(iRow, pn);

--- a/src/ScreenOptions.cpp
+++ b/src/ScreenOptions.cpp
@@ -138,30 +138,30 @@ ScreenOptions::Init()
 	m_frameContainer.AddChild(m_sprPage);
 
 	// init line highlights
-	m_sprLineHighlight[PLAYER_1].Load(
+	m_sprLineHighlight.Load(
 	  THEME->GetPathG(m_sName, ssprintf("LineHighlight P%d", PLAYER_1 + 1)));
-	m_sprLineHighlight[PLAYER_1]->SetName(
+	m_sprLineHighlight->SetName(
 	  ssprintf("LineHighlightP%d", PLAYER_1 + 1));
-	m_sprLineHighlight[PLAYER_1]->SetX(LINE_HIGHLIGHT_X);
-	LOAD_ALL_COMMANDS(m_sprLineHighlight[PLAYER_1]);
-	m_frameContainer.AddChild(m_sprLineHighlight[PLAYER_1]);
+	m_sprLineHighlight->SetX(LINE_HIGHLIGHT_X);
+	LOAD_ALL_COMMANDS(m_sprLineHighlight);
+	m_frameContainer.AddChild(m_sprLineHighlight);
 
 	// init cursors
-	m_Cursor[PLAYER_1].Load("OptionsCursor" + PlayerNumberToString(PLAYER_1),
+	m_Cursor.Load("OptionsCursor" + PlayerNumberToString(PLAYER_1),
 							true);
-	m_Cursor[PLAYER_1].SetName("Cursor");
-	LOAD_ALL_COMMANDS(m_Cursor[PLAYER_1]);
-	m_frameContainer.AddChild(&m_Cursor[PLAYER_1]);
+	m_Cursor.SetName("Cursor");
+	LOAD_ALL_COMMANDS(m_Cursor);
+	m_frameContainer.AddChild(&m_Cursor);
 
 	switch (m_InputMode) {
 		case INPUTMODE_INDIVIDUAL:
-			m_textExplanation[PLAYER_1].LoadFromFont(
+			m_textExplanation.LoadFromFont(
 			  THEME->GetPathF(m_sName, "explanation"));
-			m_textExplanation[PLAYER_1].SetDrawOrder(2);
-			m_textExplanation[PLAYER_1].SetName("Explanation" +
+			m_textExplanation.SetDrawOrder(2);
+			m_textExplanation.SetName("Explanation" +
 												PlayerNumberToString(PLAYER_1));
-			LOAD_ALL_COMMANDS_AND_SET_XY(m_textExplanation[PLAYER_1]);
-			m_frameContainer.AddChild(&m_textExplanation[PLAYER_1]);
+			LOAD_ALL_COMMANDS_AND_SET_XY(m_textExplanation);
+			m_frameContainer.AddChild(&m_textExplanation);
 			break;
 		case INPUTMODE_SHARE_CURSOR:
 			m_textExplanationTogether.LoadFromFont(
@@ -269,22 +269,22 @@ ScreenOptions::RestartOptions()
 		pRow->AfterImportOptions(PLAYER_1);
 	}
 
-	m_iCurrentRow[PLAYER_1] = -1;
-	m_iFocusX[PLAYER_1] = -1;
-	m_bWasOnExit[PLAYER_1] = false;
+	m_iCurrentRow = -1;
+	m_iFocusX = -1;
+	m_bWasOnExit = false;
 
 	// put focus on the first enabled row
 	for (unsigned r = 0; r < m_pRows.size(); r++) {
 		const OptionRow& row = *m_pRows[r];
 		if (row.GetRowDef().IsEnabledForPlayer(PLAYER_1)) {
-			m_iCurrentRow[PLAYER_1] = r;
+			m_iCurrentRow = r;
 			break;
 		}
 	}
 
 	// Hide the highlight if no rows are enabled.
-	m_sprLineHighlight[PLAYER_1]->SetVisible(
-	  m_iCurrentRow[PLAYER_1] != -1 && GAMESTATE->IsHumanPlayer(PLAYER_1));
+	m_sprLineHighlight->SetVisible(
+	  m_iCurrentRow != -1 && GAMESTATE->IsHumanPlayer(PLAYER_1));
 
 	CHECKPOINT_M("About to get the rows positioned right.");
 
@@ -308,12 +308,12 @@ ScreenOptions::BeginScreen()
 
 	RestartOptions();
 
-	m_bGotAtLeastOneStartPressed[PLAYER_1] = false;
+	m_bGotAtLeastOneStartPressed = false;
 
 	ON_COMMAND(m_frameContainer);
 
-	m_Cursor[PLAYER_1].SetVisible(GAMESTATE->IsHumanPlayer(PLAYER_1));
-	ON_COMMAND(m_Cursor[PLAYER_1]);
+	m_Cursor.SetVisible(GAMESTATE->IsHumanPlayer(PLAYER_1));
+	ON_COMMAND(m_Cursor);
 
 	this->SortByDrawOrder();
 }
@@ -415,7 +415,7 @@ ScreenOptions::PositionCursor(PlayerNumber pn)
 {
 	// Set the position of the cursor showing the current option the user is
 	// changing.
-	const int iRow = m_iCurrentRow[pn];
+	const int iRow = m_iCurrentRow;
 	if (iRow == -1)
 		return;
 
@@ -430,7 +430,7 @@ ScreenOptions::PositionCursor(PlayerNumber pn)
 	int iWidth, iX, iY;
 	GetWidthXY(pn, iRow, iChoiceWithFocus, iWidth, iX, iY);
 
-	OptionsCursor& cursor = m_Cursor[pn];
+	OptionsCursor& cursor = m_Cursor;
 	cursor.SetBarWidth(iWidth);
 	cursor.SetXY(static_cast<float>(iX), static_cast<float>(iY));
 	bool bCanGoLeft = iChoiceWithFocus > 0;
@@ -445,7 +445,7 @@ ScreenOptions::TweenCursor(PlayerNumber pn)
 {
 	// Set the position of the cursor showing the current option the user is
 	// changing.
-	const int iRow = m_iCurrentRow[pn];
+	const int iRow = m_iCurrentRow;
 	ASSERT_M(iRow >= 0 && iRow < (int)m_pRows.size(),
 			 ssprintf("%i < %i", iRow, (int)m_pRows.size()));
 
@@ -455,7 +455,7 @@ ScreenOptions::TweenCursor(PlayerNumber pn)
 	int iWidth, iX, iY;
 	GetWidthXY(pn, iRow, iChoiceWithFocus, iWidth, iX, iY);
 
-	OptionsCursor& cursor = m_Cursor[pn];
+	OptionsCursor& cursor = m_Cursor;
 	if (cursor.GetDestX() != static_cast<float>(iX) ||
 		cursor.GetDestY() != static_cast<float>(iY) ||
 		cursor.GetBarWidth() != iWidth) {
@@ -486,7 +486,7 @@ ScreenOptions::TweenCursor(PlayerNumber pn)
 		if (row.GetRowType() == OptionRow::RowType_Exit)
 			COMMAND(m_sprLineHighlight[pn], "ChangeToExit");
 
-		m_sprLineHighlight[pn]->SetY(static_cast<float>(iY));
+		m_sprLineHighlight->SetY(static_cast<float>(iY));
 	}
 }
 
@@ -589,7 +589,7 @@ ScreenOptions::PositionRows(bool bTween)
 	int first_start, first_end, second_start, second_end;
 
 	// Choices for the player.
-	int P1Choice = m_iCurrentRow[PLAYER_1];
+	int P1Choice = m_iCurrentRow;
 
 	vector<OptionRow*> Rows(m_pRows);
 	OptionRow* pSeparateExitRow = NULL;
@@ -699,7 +699,7 @@ ScreenOptions::AfterChangeValueOrRow(PlayerNumber pn)
 	if (!GAMESTATE->IsHumanPlayer(pn))
 		return;
 
-	const int iCurRow = m_iCurrentRow[pn];
+	const int iCurRow = m_iCurrentRow;
 
 	if (iCurRow == -1)
 		return;
@@ -733,8 +733,8 @@ ScreenOptions::AfterChangeValueOrRow(PlayerNumber pn)
 	const bool bExitSelected = row.GetRowType() == OptionRow::RowType_Exit;
 	if (GAMESTATE->GetNumHumanPlayers() != 1 && PLAYER_1 != pn)
 		return;
-	if (m_bWasOnExit[PLAYER_1] != bExitSelected) {
-		m_bWasOnExit[PLAYER_1] = bExitSelected;
+	if (m_bWasOnExit != bExitSelected) {
+		m_bWasOnExit = bExitSelected;
 		COMMAND(m_sprMore,
 				ssprintf("Exit%sP%i",
 						 bExitSelected ? "Selected" : "Unselected",
@@ -746,7 +746,7 @@ ScreenOptions::AfterChangeValueOrRow(PlayerNumber pn)
 	BitmapText* pText = NULL;
 	switch (m_InputMode) {
 		case INPUTMODE_INDIVIDUAL:
-			pText = &m_textExplanation[pn];
+			pText = &m_textExplanation;
 			break;
 		default:
 			// case INPUTMODE_SHARE_CURSOR:
@@ -770,11 +770,8 @@ ScreenOptions::MenuBack(const InputEventPlus&)
 bool
 ScreenOptions::AllAreOnLastRow() const
 {
-	FOREACH_HumanPlayer(p)
-	{
-		if (m_iCurrentRow[p] != (int)(m_pRows.size() - 1))
-			return false;
-	}
+	if (m_iCurrentRow != (int)(m_pRows.size() - 1))
+		return false;
 	return true;
 }
 
@@ -784,12 +781,12 @@ ScreenOptions::MenuStart(const InputEventPlus& input)
 	PlayerNumber pn = input.pn;
 	switch (input.type) {
 		case IET_FIRST_PRESS:
-			m_bGotAtLeastOneStartPressed[pn] = true;
+			m_bGotAtLeastOneStartPressed = true;
 			break;
 		case IET_RELEASE:
 			return false; // ignore
 		default:		  // repeat type
-			if (!m_bGotAtLeastOneStartPressed[pn])
+			if (!m_bGotAtLeastOneStartPressed)
 				return false; // don't allow repeat
 			break;
 	}
@@ -821,7 +818,7 @@ ScreenOptions::ProcessMenuStart(const InputEventPlus& input)
 {
 	PlayerNumber pn = input.pn;
 
-	int iCurRow = m_iCurrentRow[pn];
+	int iCurRow = m_iCurrentRow;
 
 	if (iCurRow < 0) {
 		// this shouldn't be happening, but it is, so we need to bail out. -aj
@@ -908,7 +905,7 @@ ScreenOptions::ProcessMenuStart(const InputEventPlus& input)
 
 		if (row.GetFirstItemGoesDown() && row.GoToFirstOnStart()) {
 			// move to the first choice in the row
-			ChangeValueInRowRelative(m_iCurrentRow[pn],
+			ChangeValueInRowRelative(m_iCurrentRow,
 									 pn,
 									 -row.GetChoiceInRowWithFocus(pn),
 									 input.type != IET_FIRST_PRESS);
@@ -923,7 +920,7 @@ ScreenOptions::ProcessMenuStart(const InputEventPlus& input)
 				MenuDown(input);
 				break;
 			case NAV_THREE_KEY_ALT:
-				ChangeValueInRowRelative(m_iCurrentRow[input.pn],
+				ChangeValueInRowRelative(m_iCurrentRow,
 										 input.pn,
 										 +1,
 										 input.type != IET_FIRST_PRESS);
@@ -939,14 +936,14 @@ ScreenOptions::ProcessMenuStart(const InputEventPlus& input)
 
 				if (row.GetFirstItemGoesDown())
 					ChangeValueInRowRelative(
-					  m_iCurrentRow[pn],
+					  m_iCurrentRow,
 					  pn,
 					  -row.GetChoiceInRowWithFocus(pn),
 					  input.type !=
 						IET_FIRST_PRESS); // move to the first choice
 				else
 					ChangeValueInRowRelative(
-					  m_iCurrentRow[pn], pn, 0, input.type != IET_FIRST_PRESS);
+					  m_iCurrentRow, pn, 0, input.type != IET_FIRST_PRESS);
 				break;
 			}
 			case NAV_THREE_KEY_MENU:
@@ -967,22 +964,22 @@ void
 ScreenOptions::StoreFocus(PlayerNumber pn)
 {
 	// Long rows always put us in the center, so don't update the focus.
-	int iCurrentRow = m_iCurrentRow[pn];
+	int iCurrentRow = m_iCurrentRow;
 	const OptionRow& row = *m_pRows[iCurrentRow];
 	if (row.GetRowDef().m_layoutType == LAYOUT_SHOW_ONE_IN_ROW)
 		return;
 
 	int iWidth, iY;
 	GetWidthXY(pn,
-			   m_iCurrentRow[pn],
+			   m_iCurrentRow,
 			   row.GetChoiceInRowWithFocus(pn),
 			   iWidth,
-			   m_iFocusX[pn],
+			   m_iFocusX,
 			   iY);
 	LOG->Trace("cur selection %ix%i @ %i",
-			   m_iCurrentRow[pn],
+			   m_iCurrentRow,
 			   row.GetChoiceInRowWithFocus(pn),
-			   m_iFocusX[pn]);
+			   m_iFocusX);
 }
 
 bool
@@ -1167,7 +1164,7 @@ ScreenOptions::MoveRowRelative(PlayerNumber pn, int iDir, bool bRepeat)
 	ASSERT(m_pRows.size() != 0);
 	for (int r = 1; r < (int)m_pRows.size(); r++) {
 		int iDelta = r * iDir;
-		iDest = m_iCurrentRow[pn] + iDelta;
+		iDest = m_iCurrentRow + iDelta;
 		wrap(iDest, m_pRows.size());
 
 		OptionRow& row = *m_pRows[iDest];
@@ -1181,9 +1178,9 @@ ScreenOptions::MoveRowRelative(PlayerNumber pn, int iDir, bool bRepeat)
 		return false;
 	if (bRepeat) {
 		// Don't wrap on repeating inputs.
-		if (iDir > 0 && iDest < m_iCurrentRow[pn])
+		if (iDir > 0 && iDest < m_iCurrentRow)
 			return false;
-		if (iDir < 0 && iDest > m_iCurrentRow[pn])
+		if (iDir < 0 && iDest > m_iCurrentRow)
 			return false;
 	}
 
@@ -1193,7 +1190,7 @@ ScreenOptions::MoveRowRelative(PlayerNumber pn, int iDir, bool bRepeat)
 void
 ScreenOptions::AfterChangeRow(PlayerNumber pn)
 {
-	const int iRow = m_iCurrentRow[pn];
+	const int iRow = m_iCurrentRow;
 	if (iRow != -1) {
 		// In FIVE_KEY, keep the selection in the row near the focus.
 		OptionRow& row = *m_pRows[iRow];
@@ -1203,8 +1200,8 @@ ScreenOptions::AfterChangeRow(PlayerNumber pn)
 					int iSelectionDist = -1;
 					for (unsigned i = 0; i < row.GetTextItemsSize(); ++i) {
 						int iWidth, iX, iY;
-						GetWidthXY(pn, m_iCurrentRow[pn], i, iWidth, iX, iY);
-						const int iDist = abs(iX - m_iFocusX[pn]);
+						GetWidthXY(pn, m_iCurrentRow, i, iWidth, iX, iY);
+						const int iDist = abs(iX - m_iFocusX);
 						if (iSelectionDist == -1 || iDist < iSelectionDist) {
 							iSelectionDist = iDist;
 							row.SetChoiceInRowWithFocus(pn, i);
@@ -1233,14 +1230,14 @@ ScreenOptions::MoveRowAbsolute(PlayerNumber pn, int iRow)
 	bool bChanged = false;
 	if (m_InputMode == INPUTMODE_INDIVIDUAL && PLAYER_1 != pn) {
 	} // skip
-	else if (m_iCurrentRow[PLAYER_1] == iRow)
+	else if (m_iCurrentRow == iRow)
 	{
 		// also skip
 	}
 	else
 	{
 
-		m_iCurrentRow[PLAYER_1] = iRow;
+		m_iCurrentRow = iRow;
 
 		AfterChangeRow(PLAYER_1);
 		bChanged = true;
@@ -1263,7 +1260,7 @@ ScreenOptions::MenuLeft(const InputEventPlus& input)
 		MenuUpDown(input, -1);
 	else
 		ChangeValueInRowRelative(
-		  m_iCurrentRow[input.pn], input.pn, -1, input.type != IET_FIRST_PRESS);
+		  m_iCurrentRow, input.pn, -1, input.type != IET_FIRST_PRESS);
 
 	PlayerNumber pn = input.pn;
 	MESSAGEMAN->Broadcast(static_cast<MessageID>(Message_MenuLeftP1 + pn));
@@ -1277,7 +1274,7 @@ ScreenOptions::MenuRight(const InputEventPlus& input)
 		MenuUpDown(input, +1);
 	else
 		ChangeValueInRowRelative(
-		  m_iCurrentRow[input.pn], input.pn, +1, input.type != IET_FIRST_PRESS);
+		  m_iCurrentRow, input.pn, +1, input.type != IET_FIRST_PRESS);
 
 	PlayerNumber pn = input.pn;
 	MESSAGEMAN->Broadcast(static_cast<MessageID>(Message_MenuRightP1 + pn));

--- a/src/ScreenOptions.h
+++ b/src/ScreenOptions.h
@@ -54,8 +54,8 @@ class ScreenOptions : public ScreenWithMenuElements
 	friend class LunaScreenOptions;
 
   protected:
-	virtual void ImportOptions(int iRow, const vector<PlayerNumber>& vpns) = 0;
-	virtual void ExportOptions(int iRow, const vector<PlayerNumber>& vpns) = 0;
+	virtual void ImportOptions(int iRow, const PlayerNumber& vpns) = 0;
+	virtual void ExportOptions(int iRow, const PlayerNumber& vpns) = 0;
 
 	void RestartOptions();
 	void GetWidthXY(PlayerNumber pn,

--- a/src/ScreenOptions.h
+++ b/src/ScreenOptions.h
@@ -110,7 +110,7 @@ class ScreenOptions : public ScreenWithMenuElements
 
 	int GetCurrentRow(PlayerNumber pn = PLAYER_1) const
 	{
-		return m_iCurrentRow[pn];
+		return m_iCurrentRow;
 	}
 	bool AllAreOnLastRow() const;
 	OptionRow* GetRow(int iRow) const { return m_pRows[iRow]; }
@@ -133,7 +133,7 @@ class ScreenOptions : public ScreenWithMenuElements
 	/** @brief Map menu lines to m_OptionRow entries. */
 	vector<OptionRow*> m_pRows;
 	/** @brief The current row each player is on. */
-	int m_iCurrentRow[NUM_PLAYERS];
+	int m_iCurrentRow;
 
 	OptionRowType m_OptionRowTypeNormal;
 	OptionRowType m_OptionRowTypeExit;
@@ -141,8 +141,8 @@ class ScreenOptions : public ScreenWithMenuElements
 	Navigation m_OptionsNavigation;
 	InputMode m_InputMode;
 
-	int m_iFocusX[NUM_PLAYERS];
-	bool m_bWasOnExit[NUM_PLAYERS];
+	int m_iFocusX;
+	bool m_bWasOnExit;
 
 	/** @brief True if at least one player pressed Start after selecting the
 	 * song.
@@ -150,16 +150,16 @@ class ScreenOptions : public ScreenWithMenuElements
 	 * TRICKY: People hold Start to get to PlayerOptions, then the repeat events
 	 * cause them to zip to the bottom. So, ignore Start repeat events until
 	 * we've seen one first pressed event. */
-	bool m_bGotAtLeastOneStartPressed[NUM_PLAYERS];
+	bool m_bGotAtLeastOneStartPressed;
 
 	// actors
 	ActorFrame m_frameContainer;
 	AutoActor m_sprPage;
 
-	OptionsCursor m_Cursor[NUM_PLAYERS];
-	AutoActor m_sprLineHighlight[NUM_PLAYERS];
+	OptionsCursor m_Cursor;
+	AutoActor m_sprLineHighlight;
 
-	BitmapText m_textExplanation[NUM_PLAYERS];
+	BitmapText m_textExplanation;
 	BitmapText m_textExplanationTogether;
 	DualScrollBar m_ScrollBar;
 	AutoActor m_sprMore;

--- a/src/ScreenOptionsEditProfile.cpp
+++ b/src/ScreenOptionsEditProfile.cpp
@@ -63,7 +63,7 @@ ScreenOptionsEditProfile::~ScreenOptionsEditProfile() = default;
 
 void
 ScreenOptionsEditProfile::ImportOptions(int iRow,
-										const vector<PlayerNumber>& vpns)
+										const PlayerNumber& vpns)
 {
 	Profile* pProfile =
 	  PROFILEMAN->GetLocalProfile(GAMESTATE->m_sEditLocalProfileID);
@@ -79,7 +79,7 @@ ScreenOptionsEditProfile::ImportOptions(int iRow,
 
 void
 ScreenOptionsEditProfile::ExportOptions(int iRow,
-										const vector<PlayerNumber>& vpns)
+										const PlayerNumber& vpns)
 {
 	Profile* pProfile =
 	  PROFILEMAN->GetLocalProfile(GAMESTATE->m_sEditLocalProfileID);

--- a/src/ScreenOptionsEditProfile.h
+++ b/src/ScreenOptionsEditProfile.h
@@ -14,8 +14,8 @@ class ScreenOptionsEditProfile : public ScreenOptions
 
   protected:
   private:
-	void ImportOptions(int row, const vector<PlayerNumber>& vpns) override;
-	void ExportOptions(int row, const vector<PlayerNumber>& vpns) override;
+	void ImportOptions(int row, const PlayerNumber& vpns) override;
+	void ExportOptions(int row, const PlayerNumber& vpns) override;
 
 	virtual void GoToNextScreen();
 	virtual void GoToPrevScreen();

--- a/src/ScreenOptionsManageProfiles.cpp
+++ b/src/ScreenOptionsManageProfiles.cpp
@@ -187,7 +187,7 @@ void
 ScreenOptionsManageProfiles::HandleScreenMessage(const ScreenMessage SM)
 {
 	if (SM == SM_GoToNextScreen) {
-		int iCurRow = m_iCurrentRow[GAMESTATE->GetMasterPlayerNumber()];
+		int iCurRow = m_iCurrentRow;
 		OptionRow& row = *m_pRows[iCurRow];
 		if (row.GetRowType() == OptionRow::RowType_Exit) {
 			this->HandleScreenMessage(SM_GoToPrevScreen);
@@ -376,7 +376,7 @@ ScreenOptionsManageProfiles::ProcessMenuStart(const InputEventPlus&)
 	if (IsTransitioning())
 		return;
 
-	int iCurRow = m_iCurrentRow[GAMESTATE->GetMasterPlayerNumber()];
+	int iCurRow = m_iCurrentRow;
 	OptionRow& row = *m_pRows[iCurRow];
 
 	if (SHOW_CREATE_NEW && iCurRow == 0) // "create new"
@@ -435,7 +435,7 @@ ScreenOptionsManageProfiles::ExportOptions(
 int
 ScreenOptionsManageProfiles::GetLocalProfileIndexWithFocus() const
 {
-	int iCurRow = m_iCurrentRow[GAMESTATE->GetMasterPlayerNumber()];
+	int iCurRow = m_iCurrentRow;
 	OptionRow& row = *m_pRows[iCurRow];
 
 	if (SHOW_CREATE_NEW && iCurRow == 0) // "create new"

--- a/src/ScreenOptionsManageProfiles.cpp
+++ b/src/ScreenOptionsManageProfiles.cpp
@@ -421,14 +421,14 @@ ScreenOptionsManageProfiles::ProcessMenuStart(const InputEventPlus&)
 void
 ScreenOptionsManageProfiles::ImportOptions(
   int /* iRow */,
-  const vector<PlayerNumber>& /* vpns */)
+  const PlayerNumber& /* vpns */)
 {
 }
 
 void
 ScreenOptionsManageProfiles::ExportOptions(
   int /* iRow */,
-  const vector<PlayerNumber>& /* vpns */)
+  const PlayerNumber& /* vpns */)
 {
 }
 

--- a/src/ScreenOptionsManageProfiles.h
+++ b/src/ScreenOptionsManageProfiles.h
@@ -13,8 +13,8 @@ class ScreenOptionsManageProfiles : public ScreenOptions
 	void HandleScreenMessage(ScreenMessage SM) override;
 
   protected:
-	void ImportOptions(int iRow, const vector<PlayerNumber>& vpns) override;
-	void ExportOptions(int iRow, const vector<PlayerNumber>& vpns) override;
+	void ImportOptions(int iRow, const PlayerNumber& vpns) override;
+	void ExportOptions(int iRow, const PlayerNumber& vpns) override;
 
 	void AfterChangeRow(PlayerNumber pn) override;
 	void ProcessMenuStart(const InputEventPlus& input) override;

--- a/src/ScreenOptionsMaster.cpp
+++ b/src/ScreenOptionsMaster.cpp
@@ -89,13 +89,9 @@ ScreenOptionsMaster::ExportOptions(int r, const vector<PlayerNumber>& vpns)
 	CHECKPOINT_M(ssprintf("%i/%i", r, static_cast<int>(m_pRows.size())));
 
 	OptionRow& row = *m_pRows[r];
-	bool bRowHasFocus[NUM_PLAYERS];
-	ZERO(bRowHasFocus);
-	FOREACH_CONST(PlayerNumber, vpns, p)
-	{
-		int iCurRow = m_iCurrentRow[*p];
-		bRowHasFocus[*p] = iCurRow == r;
-	}
+	bool bRowHasFocus = false;
+	int iCurRow = m_iCurrentRow;
+	bRowHasFocus = iCurRow == r;
 	m_iChangeMask |= row.ExportOptions(vpns, bRowHasFocus);
 }
 

--- a/src/ScreenOptionsMaster.cpp
+++ b/src/ScreenOptionsMaster.cpp
@@ -75,16 +75,15 @@ ScreenOptionsMaster::Init()
 }
 
 void
-ScreenOptionsMaster::ImportOptions(int r, const vector<PlayerNumber>& vpns)
+ScreenOptionsMaster::ImportOptions(int r, const PlayerNumber& vpns)
 {
-	FOREACH_CONST(PlayerNumber, vpns, pn)
-	ASSERT(GAMESTATE->IsHumanPlayer(*pn));
+	ASSERT(GAMESTATE->IsHumanPlayer(vpns));
 	OptionRow& row = *m_pRows[r];
 	row.ImportOptions(vpns);
 }
 
 void
-ScreenOptionsMaster::ExportOptions(int r, const vector<PlayerNumber>& vpns)
+ScreenOptionsMaster::ExportOptions(int r, const PlayerNumber& vpns)
 {
 	CHECKPOINT_M(ssprintf("%i/%i", r, static_cast<int>(m_pRows.size())));
 
@@ -104,10 +103,8 @@ ScreenOptionsMaster::HandleScreenMessage(const ScreenMessage SM)
 
 		CHECKPOINT_M("Starting the export handling.");
 
-		vector<PlayerNumber> vpns;
-		FOREACH_OptionsPlayer(p) vpns.push_back(p);
 		for (unsigned r = 0; r < m_pRows.size(); r++) // foreach row
-			ExportOptions(r, vpns);
+			ExportOptions(r, PLAYER_1);
 
 		if ((m_iChangeMask & OPT_APPLY_ASPECT_RATIO) != 0) {
 			THEME->UpdateLuaGlobals(); // This needs to be done before resetting

--- a/src/ScreenOptionsMaster.h
+++ b/src/ScreenOptionsMaster.h
@@ -1,4 +1,4 @@
-﻿#ifndef SCREEN_OPTIONS_MASTER_H
+#ifndef SCREEN_OPTIONS_MASTER_H
 #define SCREEN_OPTIONS_MASTER_H
 
 #include "ScreenOptions.h"
@@ -16,8 +16,8 @@ class ScreenOptionsMaster : public ScreenOptions
   protected:
 	void HandleScreenMessage(ScreenMessage SM) override;
 
-	void ImportOptions(int iRow, const vector<PlayerNumber>& vpns) override;
-	void ExportOptions(int iRow, const vector<PlayerNumber>& vpns) override;
+	void ImportOptions(int iRow, const PlayerNumber& vpns) override;
+	void ExportOptions(int iRow, const PlayerNumber& vpns) override;
 };
 
 #endif

--- a/src/ScreenPlayerOptions.cpp
+++ b/src/ScreenPlayerOptions.cpp
@@ -20,13 +20,13 @@ void
 ScreenPlayerOptions::Init()
 {
 	ScreenOptionsMaster::Init();
-	m_sprDisqualify[PLAYER_1].Load(THEME->GetPathG(m_sName, "disqualify"));
-	m_sprDisqualify[PLAYER_1]->SetName(ssprintf("DisqualifyP%i", PLAYER_1 + 1));
-	LOAD_ALL_COMMANDS_AND_SET_XY(m_sprDisqualify[PLAYER_1]);
-	m_sprDisqualify[PLAYER_1]->SetVisible(
+	m_sprDisqualify.Load(THEME->GetPathG(m_sName, "disqualify"));
+	m_sprDisqualify->SetName(ssprintf("DisqualifyP%i", PLAYER_1 + 1));
+	LOAD_ALL_COMMANDS_AND_SET_XY(m_sprDisqualify);
+	m_sprDisqualify->SetVisible(
 		false); // unhide later if handicapping options are discovered
-	m_sprDisqualify[PLAYER_1]->SetDrawOrder(2);
-	m_frameContainer.AddChild(m_sprDisqualify[PLAYER_1]);
+	m_sprDisqualify->SetDrawOrder(2);
+	m_frameContainer.AddChild(m_sprDisqualify);
 
 	m_bAskOptionsMessage = PREFSMAN->m_ShowSongOptions == Maybe_ASK;
 
@@ -35,7 +35,7 @@ ScreenPlayerOptions::Init()
 
 	SOUND->PlayOnceFromDir(ANNOUNCER->GetPathTo("player options intro"));
 
-	m_bRowCausesDisqualified[PLAYER_1].resize(m_pRows.size(), false);
+	m_bRowCausesDisqualified.resize(m_pRows.size(), false);
 }
 
 void
@@ -72,7 +72,7 @@ ScreenPlayerOptions::Input(const InputEventPlus& input)
 		CodeDetector::EnteredCode(input.GameI.controller,
 								  CODE_CANCEL_ALL_PLAYER_OPTIONS)) {
 		// apply the game default mods, but not the Profile saved mods
-		GAMESTATE->m_pPlayerState[pn]->ResetToDefaultPlayerOptions(
+		GAMESTATE->m_pPlayerState->ResetToDefaultPlayerOptions(
 		  ModsLevel_Preferred);
 
 		MESSAGEMAN->Broadcast(ssprintf("CancelAllP%i", pn + 1));
@@ -93,7 +93,7 @@ ScreenPlayerOptions::Input(const InputEventPlus& input)
 
 	// UGLY: Update m_Disqualified whenever Start is pressed
 	if (GAMESTATE->IsHumanPlayer(pn) && input.MenuI == GAME_BUTTON_START) {
-		int row = m_iCurrentRow[pn];
+		int row = m_iCurrentRow;
 		UpdateDisqualified(row, pn);
 	}
 	return bHandled;
@@ -121,32 +121,32 @@ ScreenPlayerOptions::UpdateDisqualified(int row, PlayerNumber pn)
 
 	// save original player options
 	PlayerOptions poOrig =
-	  GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.GetPreferred();
+	  GAMESTATE->m_pPlayerState->m_PlayerOptions.GetPreferred();
 
 	// Find out if the current row when exported causes disqualification.
 	// Exporting the row will fill GAMESTATE->m_PlayerOptions.
-	PO_GROUP_CALL(GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions,
+	PO_GROUP_CALL(GAMESTATE->m_pPlayerState->m_PlayerOptions,
 				  ModsLevel_Preferred,
 				  Init);
 	vector<PlayerNumber> v;
 	v.push_back(pn);
 	ExportOptions(row, v);
 	bool bRowCausesDisqualified = GAMESTATE->CurrentOptionsDisqualifyPlayer(pn);
-	m_bRowCausesDisqualified[pn][row] = bRowCausesDisqualified;
+	m_bRowCausesDisqualified[row] = bRowCausesDisqualified;
 
 	// Update disqualified graphic
 	bool bDisqualified = false;
-	FOREACH_CONST(bool, m_bRowCausesDisqualified[pn], b)
+	FOREACH_CONST(bool, m_bRowCausesDisqualified, b)
 	{
 		if (*b) {
 			bDisqualified = true;
 			break;
 		}
 	}
-	m_sprDisqualify[pn]->SetVisible(bDisqualified);
+	m_sprDisqualify->SetVisible(bDisqualified);
 
 	// restore previous player options in case the user escapes back after this
-	GAMESTATE->m_pPlayerState[pn]->m_PlayerOptions.Assign(ModsLevel_Preferred,
+	GAMESTATE->m_pPlayerState->m_PlayerOptions.Assign(ModsLevel_Preferred,
 														  poOrig);
 }
 

--- a/src/ScreenPlayerOptions.cpp
+++ b/src/ScreenPlayerOptions.cpp
@@ -41,7 +41,7 @@ ScreenPlayerOptions::Init()
 void
 ScreenPlayerOptions::BeginScreen()
 {
-	ON_COMMAND(m_sprDisqualify[PLAYER_1]);
+	ON_COMMAND(m_sprDisqualify);
 
 	ScreenOptionsMaster::BeginScreen();
 
@@ -78,10 +78,8 @@ ScreenPlayerOptions::Input(const InputEventPlus& input)
 		MESSAGEMAN->Broadcast(ssprintf("CancelAllP%i", pn + 1));
 
 		for (unsigned r = 0; r < m_pRows.size(); r++) {
-			vector<PlayerNumber> v;
-			v.push_back(pn);
 			int iOldFocus = m_pRows[r]->GetChoiceInRowWithFocus(pn);
-			this->ImportOptions(r, v);
+			this->ImportOptions(r, pn);
 			m_pRows[r]->AfterImportOptions(pn);
 			this->UpdateDisqualified(r, pn);
 			m_pRows[r]->SetChoiceInRowWithFocus(pn, iOldFocus);
@@ -128,9 +126,8 @@ ScreenPlayerOptions::UpdateDisqualified(int row, PlayerNumber pn)
 	PO_GROUP_CALL(GAMESTATE->m_pPlayerState->m_PlayerOptions,
 				  ModsLevel_Preferred,
 				  Init);
-	vector<PlayerNumber> v;
-	v.push_back(pn);
-	ExportOptions(row, v);
+
+	ExportOptions(row, pn);
 	bool bRowCausesDisqualified = GAMESTATE->CurrentOptionsDisqualifyPlayer(pn);
 	m_bRowCausesDisqualified[row] = bRowCausesDisqualified;
 
@@ -146,8 +143,7 @@ ScreenPlayerOptions::UpdateDisqualified(int row, PlayerNumber pn)
 	m_sprDisqualify->SetVisible(bDisqualified);
 
 	// restore previous player options in case the user escapes back after this
-	GAMESTATE->m_pPlayerState->m_PlayerOptions.Assign(ModsLevel_Preferred,
-														  poOrig);
+	GAMESTATE->m_pPlayerState->m_PlayerOptions.Assign(ModsLevel_Preferred, poOrig);
 }
 
 // lua start

--- a/src/ScreenPlayerOptions.h
+++ b/src/ScreenPlayerOptions.h
@@ -19,7 +19,7 @@ class ScreenPlayerOptions : public ScreenOptionsMaster
 	void PushSelf(lua_State* L) override;
 
   private:
-	vector<bool> m_bRowCausesDisqualified[NUM_PLAYERS];
+	vector<bool> m_bRowCausesDisqualified;
 	void UpdateDisqualified(int row, PlayerNumber pn);
 
 	bool m_bAcceptedChoices;
@@ -27,7 +27,7 @@ class ScreenPlayerOptions : public ScreenOptionsMaster
 	bool m_bAskOptionsMessage;
 
 	// show if the current selections will disqualify a high score
-	AutoActor m_sprDisqualify[NUM_PLAYERS];
+	AutoActor m_sprDisqualify;
 };
 
 #endif

--- a/src/ScreenSMOnlineLogin.cpp
+++ b/src/ScreenSMOnlineLogin.cpp
@@ -59,7 +59,7 @@ ScreenSMOnlineLogin::Init()
 }
 
 void
-ScreenSMOnlineLogin::ImportOptions(int iRow, const vector<PlayerNumber>& vpns)
+ScreenSMOnlineLogin::ImportOptions(int iRow, const PlayerNumber& vpns)
 {
 	switch (iRow) {
 		case 0: {
@@ -78,7 +78,7 @@ ScreenSMOnlineLogin::ImportOptions(int iRow, const vector<PlayerNumber>& vpns)
 }
 
 void
-ScreenSMOnlineLogin::ExportOptions(int iRow, const vector<PlayerNumber>& vpns)
+ScreenSMOnlineLogin::ExportOptions(int iRow, const PlayerNumber& vpns)
 {
 	switch (iRow) {
 		case 0: {
@@ -163,10 +163,8 @@ ScreenSMOnlineLogin::HandleScreenMessage(const ScreenMessage SM)
 		}
 	} else if (SM == SM_GoToNextScreen) {
 		LOG->Trace("[ScreenSMOnlineLogin::HandleScreenMessage] GoToNextScreen");
-		vector<PlayerNumber> v;
-		v.push_back(GAMESTATE->GetMasterPlayerNumber());
 		for (unsigned r = 0; r < m_pRows.size(); r++)
-			ExportOptions(r, v);
+			ExportOptions(r, GAMESTATE->GetMasterPlayerNumber());
 
 		PREFSMAN->SavePrefsToDisk();
 		FOREACH_EnabledPlayer(pn)

--- a/src/ScreenSMOnlineLogin.h
+++ b/src/ScreenSMOnlineLogin.h
@@ -13,8 +13,8 @@ class ScreenSMOnlineLogin : public ScreenOptions
 	void SendLogin(RString sPassword, RString user);
 
   private:
-	void ImportOptions(int iRow, const vector<PlayerNumber>& vpns) override;
-	void ExportOptions(int iRow, const vector<PlayerNumber>& vpns) override;
+	void ImportOptions(int iRow, const PlayerNumber& vpns) override;
+	void ExportOptions(int iRow, const PlayerNumber& vpns) override;
 	RString GetSelectedProfileID();
 	int m_iPlayer;
 	bool typeUsername{ false };

--- a/src/ScreenSelectMaster.h
+++ b/src/ScreenSelectMaster.h
@@ -110,20 +110,20 @@ class ScreenSelectMaster : public ScreenSelect
 	vector<AutoActor> m_vsprIcon;
 
 	// preview is per-player, per-choice piece
-	vector<AutoActor> m_vsprScroll[NUM_PLAYERS];
+	vector<AutoActor> m_vsprScroll;
 
-	ActorScroller m_Scroller[NUM_PLAYERS];
+	ActorScroller m_Scroller;
 
 	// cursor is the per-player, shared by all choices
-	AutoActor m_sprCursor[NUM_PLAYERS];
+	AutoActor m_sprCursor;
 
 	RageSound m_soundChange;
 	RandomSample m_soundDifficult;
 	RageSound m_soundStart;
 
-	int m_iChoice[NUM_PLAYERS];
-	bool m_bChosen[NUM_PLAYERS];
-	bool m_bDoubleChoice[NUM_PLAYERS];
+	int m_iChoice;
+	bool m_bChosen;
+	bool m_bDoubleChoice;
 	bool m_bDoubleChoiceNoSound;
 
 	GameButton m_TrackingRepeatingInput;

--- a/src/ScreenSelectMusic.h
+++ b/src/ScreenSelectMusic.h
@@ -93,7 +93,7 @@ class ScreenSelectMusic : public ScreenWithMenuElements
 	bool DetectCodes(const InputEventPlus& input);
 
 	vector<Steps*> m_vpSteps;
-	int m_iSelection[NUM_PLAYERS];
+	int m_iSelection;
 
 	RageTimer m_timerIdleComment;
 	ThemeMetric<float> IDLE_COMMENT_SECONDS;
@@ -154,18 +154,17 @@ class ScreenSelectMusic : public ScreenWithMenuElements
 	RString m_sFallbackCDTitlePath;
 
 	MusicWheel m_MusicWheel;
-	OptionsList m_OptionsList[NUM_PLAYERS];
+	OptionsList m_OptionsList;
 
 	SelectionState m_SelectionState;
-	bool
-	  m_bStepsChosen[NUM_PLAYERS]; // only used in SelectionState_SelectingSteps
+	bool m_bStepsChosen; // only used in SelectionState_SelectingSteps
 	bool m_bGoToOptions;
 	RString m_sSampleMusicToPlay;
 	TimingData* m_pSampleMusicTimingData;
 	float m_fSampleStartSeconds, m_fSampleLengthSeconds;
 	bool m_bAllowOptionsMenu, m_bAllowOptionsMenuRepeat;
-	bool m_bSelectIsDown[NUM_PLAYERS];
-	bool m_bAcceptSelectRelease[NUM_PLAYERS];
+	bool m_bSelectIsDown;
+	bool m_bAcceptSelectRelease;
 
 	RageSound m_soundStart;
 	RageSound m_soundDifficultyEasier;

--- a/src/ScreenSelectProfile.cpp
+++ b/src/ScreenSelectProfile.cpp
@@ -11,7 +11,7 @@ void
 ScreenSelectProfile::Init()
 {
 	// no selection initially
-	m_iSelectedProfiles[PLAYER_1] = -1;
+	m_iSelectedProfiles = -1;
 	m_TrackingRepeatingInput = GameButton_Invalid;
 	ScreenWithMenuElements::Init();
 }
@@ -132,11 +132,11 @@ ScreenSelectProfile::SetProfileIndex(PlayerNumber pn, int iProfileIndex)
 	if (iProfileIndex == -2) {
 		// GAMESTATE->UnjoinPlayer takes care of unloading the profile.
 		GAMESTATE->UnjoinPlayer(pn);
-		m_iSelectedProfiles[pn] = -1;
+		m_iSelectedProfiles = -1;
 		return true;
 	}
 
-	m_iSelectedProfiles[pn] = iProfileIndex;
+	m_iSelectedProfiles = iProfileIndex;
 
 	return true;
 }
@@ -149,27 +149,27 @@ ScreenSelectProfile::Finish()
 
 	// if profile indexes are the same for both players
 	if (GAMESTATE->GetNumPlayersEnabled() == 2 &&
-		m_iSelectedProfiles[0] == m_iSelectedProfiles[1] &&
-		m_iSelectedProfiles[0] > 0)
+		m_iSelectedProfiles == m_iSelectedProfiles &&
+		m_iSelectedProfiles > 0)
 		return false;
 
 	int iUsedLocalProfiles = 0;
 	int iUnselectedProfiles = 0;
 
 	// not all players has made their choices
-	if (GAMESTATE->IsHumanPlayer(PLAYER_1) && (m_iSelectedProfiles[PLAYER_1] == -1))
+	if (GAMESTATE->IsHumanPlayer(PLAYER_1) && (m_iSelectedProfiles == -1))
 		iUnselectedProfiles++;
 
 	// card not ready
-	if (m_iSelectedProfiles[PLAYER_1] == 0)
+	if (m_iSelectedProfiles == 0)
 		return false;
 
 	// profile index too big
-	if (m_iSelectedProfiles[PLAYER_1] > PROFILEMAN->GetNumLocalProfiles())
+	if (m_iSelectedProfiles > PROFILEMAN->GetNumLocalProfiles())
 		return false;
 
 	// inc used profile count
-	if (m_iSelectedProfiles[PLAYER_1] > 0)
+	if (m_iSelectedProfiles > 0)
 		iUsedLocalProfiles++;
 
 	// this allows to continue if there is less local profiles than number of
@@ -181,9 +181,9 @@ ScreenSelectProfile::Finish()
 	// all ok - load profiles and go to next screen
 	PROFILEMAN->UnloadProfile(PLAYER_1);
 
-	if (m_iSelectedProfiles[PLAYER_1] > 0) {
+	if (m_iSelectedProfiles > 0) {
 		PROFILEMAN->m_sDefaultLocalProfileID[PLAYER_1].Set(
-			PROFILEMAN->GetLocalProfileIDFromIndex(m_iSelectedProfiles[PLAYER_1] - 1));
+			PROFILEMAN->GetLocalProfileIDFromIndex(m_iSelectedProfiles - 1));
 		PROFILEMAN->LoadLocalProfileFromMachine(PLAYER_1);
 		GAMESTATE->LoadCurrentSettingsFromProfile(PLAYER_1);
 	}

--- a/src/ScreenSelectProfile.h
+++ b/src/ScreenSelectProfile.h
@@ -22,11 +22,11 @@ class ScreenSelectProfile : public ScreenWithMenuElements
 	// Lua
 	void PushSelf(lua_State* L) override;
 	bool SetProfileIndex(PlayerNumber pn, int iProfileIndex);
-	int GetProfileIndex(PlayerNumber pn) { return m_iSelectedProfiles[pn]; }
+	int GetProfileIndex(PlayerNumber pn) { return m_iSelectedProfiles; }
 	bool Finish();
 
   protected:
-	int m_iSelectedProfiles[NUM_PLAYERS];
+	int m_iSelectedProfiles;
 };
 
 #endif

--- a/src/ScreenSongOptions.cpp
+++ b/src/ScreenSongOptions.cpp
@@ -25,7 +25,7 @@ void
 ScreenSongOptions::ExportOptions(int iRow, const vector<PlayerNumber>& vpns)
 {
 	PlayerNumber pn = GAMESTATE->GetMasterPlayerNumber();
-	PlayerState* pPS = GAMESTATE->m_pPlayerState[pn];
+	PlayerState* pPS = GAMESTATE->m_pPlayerState;
 	const FailType ft = pPS->m_PlayerOptions.GetPreferred().m_FailType;
 
 	ScreenOptionsMaster::ExportOptions(iRow, vpns);

--- a/src/ScreenSongOptions.cpp
+++ b/src/ScreenSongOptions.cpp
@@ -22,7 +22,7 @@ ScreenSongOptions::Init()
 }
 
 void
-ScreenSongOptions::ExportOptions(int iRow, const vector<PlayerNumber>& vpns)
+ScreenSongOptions::ExportOptions(int iRow, const PlayerNumber& vpns)
 {
 	PlayerNumber pn = GAMESTATE->GetMasterPlayerNumber();
 	PlayerState* pPS = GAMESTATE->m_pPlayerState;

--- a/src/ScreenSongOptions.h
+++ b/src/ScreenSongOptions.h
@@ -9,7 +9,7 @@ class ScreenSongOptions : public ScreenOptionsMaster
 	void Init() override;
 
   private:
-	void ExportOptions(int iRow, const vector<PlayerNumber>& vpns) override;
+	void ExportOptions(int iRow, const PlayerNumber& vpns) override;
 };
 
 #endif

--- a/src/ScreenSyncOverlay.cpp
+++ b/src/ScreenSyncOverlay.cpp
@@ -213,11 +213,8 @@ ScreenSyncOverlay::Input(const InputEventPlus& input)
 	// Release the lookup tables being used for the timing data because
 	// changing the timing data invalidates them. -Kyz
 	if (a != Action_Invalid) {
-		FOREACH_EnabledPlayer(pn)
-		{
-			if (GAMESTATE->m_pCurSteps[pn]) {
-				GAMESTATE->m_pCurSteps[pn]->GetTimingData()->ReleaseLookup();
-			}
+		if (GAMESTATE->m_pCurSteps) {
+			GAMESTATE->m_pCurSteps->GetTimingData()->ReleaseLookup();
 		}
 	}
 

--- a/src/ScreenSystemLayer.cpp
+++ b/src/ScreenSystemLayer.cpp
@@ -44,7 +44,7 @@ GetCreditsMessage(PlayerNumber pn)
 		SCREENMAN->GetTopScreen()->GetScreenType() == system_menu)
 		bShowCreditsMessage = true;
 	else
-		bShowCreditsMessage = !GAMESTATE->m_bSideIsJoined[pn];
+		bShowCreditsMessage = !GAMESTATE->m_bSideIsJoined;
 
 	if (!bShowCreditsMessage) {
 		const Profile* pProfile = PROFILEMAN->GetProfile(pn);

--- a/src/SongUtil.cpp
+++ b/src/SongUtil.cpp
@@ -854,7 +854,7 @@ bool
 SongUtil::ValidateCurrentEditStepsDescription(const RString& sAnswer,
 											  RString& sErrorOut)
 {
-	Steps* pSteps = GAMESTATE->m_pCurSteps[PLAYER_1];
+	Steps* pSteps = GAMESTATE->m_pCurSteps;
 	Song* pSong = pSteps->m_pSong;
 
 	ASSERT(pSteps->IsAnEdit());
@@ -897,7 +897,7 @@ SongUtil::ValidateCurrentStepsDescription(const RString& sAnswer,
 
 	/* Don't allow duplicate edit names within the same StepsType; edit names
 	 * uniquely identify the edit. */
-	Steps* pSteps = GAMESTATE->m_pCurSteps[PLAYER_1];
+	Steps* pSteps = GAMESTATE->m_pCurSteps;
 
 	// If unchanged:
 	if (pSteps->GetDescription() == sAnswer)
@@ -926,7 +926,7 @@ SongUtil::ValidateCurrentStepsChartName(const RString& answer, RString& error)
 
 	/* Don't allow duplicate title names within the same StepsType.
 	 * We need some way of identifying the unique charts. */
-	Steps* pSteps = GAMESTATE->m_pCurSteps[PLAYER_1];
+	Steps* pSteps = GAMESTATE->m_pCurSteps;
 
 	if (pSteps->GetChartName() == answer)
 		return true;
@@ -949,7 +949,7 @@ SongUtil::ValidateCurrentStepsCredit(const RString& sAnswer, RString& sErrorOut)
 	if (sAnswer.empty())
 		return true;
 
-	Steps* pSteps = GAMESTATE->m_pCurSteps[PLAYER_1];
+	Steps* pSteps = GAMESTATE->m_pCurSteps;
 	// If unchanged:
 	if (pSteps->GetCredit() == sAnswer)
 		return true;
@@ -995,7 +995,7 @@ SongUtil::ValidateCurrentStepsMusic(const RString& answer, RString& error)
 {
 	if (answer.empty())
 		return true;
-	Steps* pSteps = GAMESTATE->m_pCurSteps[PLAYER_1];
+	Steps* pSteps = GAMESTATE->m_pCurSteps;
 	RString real_file = pSteps->GetMusicFile();
 	pSteps->SetMusicFile(answer);
 	RString path = pSteps->GetMusicPath();

--- a/src/StageStats.cpp
+++ b/src/StageStats.cpp
@@ -302,7 +302,7 @@ StageStats::StageStats()
 	m_fGameplaySeconds = 0;
 	m_fStepsSeconds = 0;
 	m_fMusicRate = 1;
-	m_player[PLAYER_1].Init(PLAYER_1);
+	m_player.Init(PLAYER_1);
 	FOREACH_MultiPlayer(pn) { m_multiPlayer[pn].Init(pn); }
 }
 
@@ -317,23 +317,23 @@ StageStats::AssertValid(PlayerNumber pn) const
 {
 	ASSERT(m_vpPlayedSongs.size() != 0);
 	ASSERT(m_vpPossibleSongs.size() != 0);
-	ASSERT(m_player[pn].m_iStepsPlayed > 0);
-	ASSERT(m_player[pn].m_vpPossibleSteps.size() != 0);
-	ASSERT(m_player[pn].m_vpPossibleSteps[0] != NULL);
+	ASSERT(m_player.m_iStepsPlayed > 0);
+	ASSERT(m_player.m_vpPossibleSteps.size() != 0);
+	ASSERT(m_player.m_vpPossibleSteps[0] != NULL);
 	ASSERT_M(m_playMode < NUM_PlayMode, ssprintf("playmode %i", m_playMode));
-	ASSERT_M(m_player[pn].m_vpPossibleSteps[0]->GetDifficulty() <
+	ASSERT_M(m_player.m_vpPossibleSteps[0]->GetDifficulty() <
 			   NUM_Difficulty,
 			 ssprintf("Invalid Difficulty %i",
-					  m_player[pn].m_vpPossibleSteps[0]->GetDifficulty()));
-	ASSERT_M((int)m_vpPlayedSongs.size() == m_player[pn].m_iStepsPlayed,
+					  m_player.m_vpPossibleSteps[0]->GetDifficulty()));
+	ASSERT_M((int)m_vpPlayedSongs.size() == m_player.m_iStepsPlayed,
 			 ssprintf("%i Songs Played != %i Steps Played for player %i",
 					  (int)m_vpPlayedSongs.size(),
-					  (int)m_player[pn].m_iStepsPlayed,
+					  (int)m_player.m_iStepsPlayed,
 					  pn));
-	ASSERT_M(m_vpPossibleSongs.size() == m_player[pn].m_vpPossibleSteps.size(),
+	ASSERT_M(m_vpPossibleSongs.size() == m_player.m_vpPossibleSteps.size(),
 			 ssprintf("%i Possible Songs != %i Possible Steps for player %i",
 					  (int)m_vpPossibleSongs.size(),
-					  (int)m_player[pn].m_vpPossibleSteps.size(),
+					  (int)m_player.m_vpPossibleSteps.size(),
 					  pn));
 }
 
@@ -345,12 +345,12 @@ StageStats::AssertValid(MultiPlayer pn) const
 	ASSERT(m_multiPlayer[pn].m_vpPossibleSteps.size() != 0);
 	ASSERT(m_multiPlayer[pn].m_vpPossibleSteps[0] != NULL);
 	ASSERT_M(m_playMode < NUM_PlayMode, ssprintf("playmode %i", m_playMode));
-	ASSERT_M(m_player[pn].m_vpPossibleSteps[0]->GetDifficulty() <
+	ASSERT_M(m_player.m_vpPossibleSteps[0]->GetDifficulty() <
 			   NUM_Difficulty,
 			 ssprintf("difficulty %i",
-					  m_player[pn].m_vpPossibleSteps[0]->GetDifficulty()));
-	ASSERT((int)m_vpPlayedSongs.size() == m_player[pn].m_iStepsPlayed);
-	ASSERT(m_vpPossibleSongs.size() == m_player[pn].m_vpPossibleSteps.size());
+					  m_player.m_vpPossibleSteps[0]->GetDifficulty()));
+	ASSERT((int)m_vpPlayedSongs.size() == m_player.m_iStepsPlayed);
+	ASSERT(m_vpPossibleSongs.size() == m_player.m_vpPossibleSteps.size());
 }
 
 int
@@ -362,7 +362,7 @@ StageStats::GetAverageMeter(PlayerNumber pn) const
 	int iTotalMeter = 0;
 
 	for (unsigned i = 0; i < m_vpPlayedSongs.size(); i++) {
-		const Steps* pSteps = m_player[pn].m_vpPossibleSteps[i];
+		const Steps* pSteps = m_player.m_vpPossibleSteps[i];
 		iTotalMeter += pSteps->GetMeter();
 	}
 	return iTotalMeter / m_vpPlayedSongs.size(); // round down
@@ -385,20 +385,20 @@ StageStats::AddStats(const StageStats& other)
 	m_fGameplaySeconds += other.m_fGameplaySeconds;
 	m_fStepsSeconds += other.m_fStepsSeconds;
 
-	FOREACH_EnabledPlayer(p) m_player[p].AddStats(other.m_player[p]);
+	m_player.AddStats(other.m_player);
 }
 
 bool
 StageStats::OnePassed() const
 {
-	FOREACH_EnabledPlayer(p) if (!m_player[p].m_bFailed) return true;
+	if (!m_player.m_bFailed) return true;
 	return false;
 }
 
 bool
 StageStats::AllFailed() const
 {
-	FOREACH_EnabledPlayer(p) if (!m_player[p].m_bFailed) return false;
+	if (!m_player.m_bFailed) return false;
 	return true;
 }
 
@@ -418,7 +418,7 @@ DetermineScoreEligibility(const PlayerStageStats& pss, const PlayerState& ps)
 {
 
 	// 4k only
-	if (GAMESTATE->m_pCurSteps[ps.m_PlayerNumber]->m_StepsType !=
+	if (GAMESTATE->m_pCurSteps->m_StepsType !=
 		StepsType_dance_single)
 		return false;
 
@@ -509,7 +509,7 @@ FillInHighScore(const PlayerStageStats& pss,
 	HighScore hs;
 	hs.SetName(sRankingToFillInMarker);
 
-	auto chartKey = GAMESTATE->m_pCurSteps[ps.m_PlayerNumber]->GetChartKey();
+	auto chartKey = GAMESTATE->m_pCurSteps->GetChartKey();
 	hs.SetChartKey(chartKey);
 	hs.SetGrade(pss.GetGrade());
 	hs.SetMachineGuid(getSystemUniqueId());
@@ -604,8 +604,8 @@ StageStats::FinalizeScores(bool bSummary)
 	SCOREMAN->camefromreplay =
 	  false; // if we're viewing an online replay this gets set to true -mina
 	if (PREFSMAN->m_sTestInitialScreen.Get() != "") {
-		m_player[PLAYER_1].m_iPersonalHighScoreIndex = 0;
-		m_player[PLAYER_1].m_iMachineHighScoreIndex = 0;
+		m_player.m_iPersonalHighScoreIndex = 0;
+		m_player.m_iMachineHighScoreIndex = 0;
 	}
 
 	// don't save scores if the player chose not to
@@ -618,16 +618,13 @@ StageStats::FinalizeScores(bool bSummary)
 
 	// whether or not to save scores when the stage was failed depends on if
 	// this is a course or not... it's handled below in the switch.
-	FOREACH_HumanPlayer(p)
-	{
-		RString sPlayerGuid = PROFILEMAN->IsPersistentProfile(p)
-								? PROFILEMAN->GetProfile(p)->m_sGuid
-								: RString("");
-		m_player[p].m_HighScore = FillInHighScore(m_player[p],
-												  *GAMESTATE->m_pPlayerState[p],
-												  RANKING_TO_FILL_IN_MARKER[p],
+	RString sPlayerGuid = PROFILEMAN->IsPersistentProfile(PLAYER_1)
+							? PROFILEMAN->GetProfile(PLAYER_1)->m_sGuid
+							: RString("");
+	m_player.m_HighScore = FillInHighScore(m_player,
+												*GAMESTATE->m_pPlayerState,
+												RANKING_TO_FILL_IN_MARKER,
 												  sPlayerGuid);
-	}
 	FOREACH_EnabledMultiPlayer(mp)
 	{
 		RString sPlayerGuid = "00000000-0000-0000-0000-000000000000"; // FIXME
@@ -638,9 +635,9 @@ StageStats::FinalizeScores(bool bSummary)
 						  sPlayerGuid);
 	}
 
-	HighScore& hs = m_player[PLAYER_1].m_HighScore;
+	HighScore& hs = m_player.m_HighScore;
 
-	const Steps* pSteps = GAMESTATE->m_pCurSteps[PLAYER_1];
+	const Steps* pSteps = GAMESTATE->m_pCurSteps;
 
 	ASSERT(pSteps != NULL);
 	Profile* zzz = PROFILEMAN->GetProfile(PLAYER_1);
@@ -672,20 +669,20 @@ StageStats::FinalizeScores(bool bSummary)
 		auto steps = SONGMAN->GetStepsByChartkey(hs.GetChartKey());
 		auto td = steps->GetTimingData();
 		hs.timeStamps = td->ConvertReplayNoteRowsToTimestamps(
-		  m_player[PLAYER_1].GetNoteRowVector(), hs.GetMusicRate());
+		  m_player.GetNoteRowVector(), hs.GetMusicRate());
 		DLMAN->UploadScoreWithReplayData(&hs);
 		hs.timeStamps.clear();
 		hs.timeStamps.shrink_to_fit();
 	}
 	if (NSMAN->isSMOnline)
-		NSMAN->ReportHighScore(&hs, m_player[PLAYER_1]);
-	if (m_player[PLAYER_1].m_fWifeScore > 0.f) {
+		NSMAN->ReportHighScore(&hs, m_player);
+	if (m_player.m_fWifeScore > 0.f) {
 
 		bool writesuccess = hs.WriteReplayData();
 		if (writesuccess)
 			hs.UnloadReplayData();
 	}
-	zzz->SetAnyAchievedGoals(GAMESTATE->m_pCurSteps[PLAYER_1]->GetChartKey(),
+	zzz->SetAnyAchievedGoals(GAMESTATE->m_pCurSteps->GetChartKey(),
 							 GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate,
 							 hs);
 	mostrecentscorekey = hs.GetScoreKey();
@@ -705,7 +702,7 @@ unsigned int
 StageStats::GetMinimumMissCombo() const
 {
 	unsigned int iMin = INT_MAX;
-	FOREACH_HumanPlayer(p) iMin = min(iMin, m_player[p].m_iCurMissCombo);
+	iMin = min(iMin, m_player.m_iCurMissCombo);
 	return iMin;
 }
 
@@ -718,7 +715,7 @@ class LunaStageStats : public Luna<StageStats>
   public:
 	static int GetPlayerStageStats(T* p, lua_State* L)
 	{
-		p->m_player[PLAYER_1].PushSelf(L);
+		p->m_player.PushSelf(L);
 		return 1;
 	}
 	static int GetMultiPlayerStageStats(T* p, lua_State* L)

--- a/src/StageStats.h
+++ b/src/StageStats.h
@@ -64,7 +64,7 @@ class StageStats
 	// Total number of seconds between first beat and last beat for every song.
 	float GetTotalPossibleStepsSeconds() const;
 
-	PlayerStageStats m_player[NUM_PLAYERS];
+	PlayerStageStats m_player;
 	PlayerStageStats m_multiPlayer[NUM_MultiPlayer];
 
 	void FinalizeScores(bool bSummary);

--- a/src/StatsManager.cpp
+++ b/src/StatsManager.cpp
@@ -75,8 +75,8 @@ AccumPlayedStageStats(const vector<StageStats>& vss)
 	FOREACH_EnabledPlayer(p)
 	{
 		for (int r = 0; r < RadarCategory_TapsAndHolds; r++) {
-			ssreturn.m_player[p].m_radarPossible[r] /= uNumSongs;
-			ssreturn.m_player[p].m_radarActual[r] /= uNumSongs;
+			ssreturn.m_player.m_radarPossible[r] /= uNumSongs;
+			ssreturn.m_player.m_radarActual[r] /= uNumSongs;
 		}
 	}
 	FOREACH_EnabledMultiPlayer(p)
@@ -127,19 +127,19 @@ StatsManager::CommitStatsToProfiles(const StageStats* pSS)
 	FOREACH_HumanPlayer(pn)
 	{
 		int iNumTapsAndHolds =
-		  (int)pSS->m_player[pn].m_radarActual[RadarCategory_TapsAndHolds];
+		  (int)pSS->m_player.m_radarActual[RadarCategory_TapsAndHolds];
 		int iNumJumps =
-		  (int)pSS->m_player[pn].m_radarActual[RadarCategory_Jumps];
+		  (int)pSS->m_player.m_radarActual[RadarCategory_Jumps];
 		int iNumHolds =
-		  (int)pSS->m_player[pn].m_radarActual[RadarCategory_Holds];
+		  (int)pSS->m_player.m_radarActual[RadarCategory_Holds];
 		int iNumRolls =
-		  (int)pSS->m_player[pn].m_radarActual[RadarCategory_Rolls];
+		  (int)pSS->m_player.m_radarActual[RadarCategory_Rolls];
 		int iNumMines =
-		  (int)pSS->m_player[pn].m_radarActual[RadarCategory_Mines];
+		  (int)pSS->m_player.m_radarActual[RadarCategory_Mines];
 		int iNumHands =
-		  (int)pSS->m_player[pn].m_radarActual[RadarCategory_Hands];
+		  (int)pSS->m_player.m_radarActual[RadarCategory_Hands];
 		int iNumLifts =
-		  (int)pSS->m_player[pn].m_radarActual[RadarCategory_Lifts];
+		  (int)pSS->m_player.m_radarActual[RadarCategory_Lifts];
 		PROFILEMAN->AddStepTotals(pn,
 								  iNumTapsAndHolds,
 								  iNumJumps,
@@ -179,12 +179,12 @@ StatsManager::UnjoinPlayer(PlayerNumber pn)
 	 * purge any m_vPlayedStageStats that no longer have any player data because
 	 * all of the players that were playing at the time have been unjoined. */
 	FOREACH(StageStats, m_vPlayedStageStats, ss)
-	ss->m_player[pn] = PlayerStageStats();
+	ss->m_player = PlayerStageStats();
 
 	for (int i = 0; i < (int)m_vPlayedStageStats.size(); ++i) {
 		StageStats& ss = m_vPlayedStageStats[i];
 		bool bIsActive = false;
-		if (ss.m_player[PLAYER_1].m_bJoined) bIsActive = true;
+		if (ss.m_player.m_bJoined) bIsActive = true;
 		FOREACH_MultiPlayer(mp) if (ss.m_multiPlayer[mp].m_bJoined) bIsActive =
 		  true;
 		if (bIsActive)
@@ -199,7 +199,7 @@ void
 StatsManager::GetStepsInUse(set<Steps*>& apInUseOut) const
 {
 	for (int i = 0; i < (int)m_vPlayedStageStats.size(); ++i) {
-		const PlayerStageStats& pss = m_vPlayedStageStats[i].m_player[PLAYER_1];
+		const PlayerStageStats& pss = m_vPlayedStageStats[i].m_player;
 		apInUseOut.insert(pss.m_vpPossibleSteps.begin(),
 							pss.m_vpPossibleSteps.end());
 
@@ -261,7 +261,7 @@ class LunaStatsManager : public Luna<StatsManager>
 		else {
 			StageStats stats;
 			p->GetFinalEvalStageStats(stats);
-			lua_pushnumber(L, stats.m_player[pn].GetGrade());
+			lua_pushnumber(L, stats.m_player.GetGrade());
 		}
 		return 1;
 	}
@@ -275,7 +275,7 @@ class LunaStatsManager : public Luna<StatsManager>
 	{
 		Grade g = NUM_Grade;
 		FOREACH_EnabledPlayer(pn) g =
-		  min(g, STATSMAN->m_CurStageStats.m_player[pn].GetGrade());
+		  min(g, STATSMAN->m_CurStageStats.m_player.GetGrade());
 		lua_pushnumber(L, g);
 		return 1;
 	}
@@ -284,7 +284,7 @@ class LunaStatsManager : public Luna<StatsManager>
 	{
 		Grade g = Grade_Tier01;
 		FOREACH_EnabledPlayer(pn) g =
-		  max(g, STATSMAN->m_CurStageStats.m_player[pn].GetGrade());
+		  max(g, STATSMAN->m_CurStageStats.m_player.GetGrade());
 		lua_pushnumber(L, g);
 		return 1;
 	}
@@ -300,7 +300,7 @@ class LunaStatsManager : public Luna<StatsManager>
 			bool bPlayerFailedOneStage = false;
 			FOREACH_CONST(StageStats, STATSMAN->m_vPlayedStageStats, ss)
 			{
-				if (ss->m_player[p].m_bFailed) {
+				if (ss->m_player.m_bFailed) {
 					bPlayerFailedOneStage = true;
 					break;
 				}
@@ -309,7 +309,7 @@ class LunaStatsManager : public Luna<StatsManager>
 			if (bPlayerFailedOneStage)
 				continue;
 
-			top_grade = min(top_grade, stats.m_player[p].GetGrade());
+			top_grade = min(top_grade, stats.m_player.GetGrade());
 		}
 
 		Enum::Push(L, top_grade);

--- a/src/StepsDisplay.cpp
+++ b/src/StepsDisplay.cpp
@@ -123,12 +123,12 @@ StepsDisplay::Load(const RString& sMetricsGroup,
 void
 StepsDisplay::SetFromGameState(PlayerNumber pn)
 {
-	const Steps* pSteps = GAMESTATE->m_pCurSteps[pn];
+	const Steps* pSteps = GAMESTATE->m_pCurSteps;
 	if (pSteps != nullptr)
 		SetFromSteps(pSteps);
 	else
 		SetFromStepsTypeAndMeterAndDifficultyAndCourseType(
-		  StepsType_Invalid, 0, GAMESTATE->m_PreferredDifficulty[pn]);
+		  StepsType_Invalid, 0, GAMESTATE->m_PreferredDifficulty);
 }
 
 void

--- a/src/Style.cpp
+++ b/src/Style.cpp
@@ -41,7 +41,7 @@ Style::GetTransformedNoteDataForStyle(PlayerNumber pn,
 
 	int iNewToOriginalTrack[MAX_COLS_PER_PLAYER];
 	for (int col = 0; col < m_iColsPerPlayer; col++) {
-		ColumnInfo colInfo = m_ColumnInfo[pn][col];
+		ColumnInfo colInfo = m_ColumnInfo[col];
 		iNewToOriginalTrack[col] = colInfo.track;
 	}
 
@@ -115,8 +115,8 @@ Style::GetMinAndMaxColX(PlayerNumber pn, float& fMixXOut, float& fMaxXOut) const
 	fMixXOut = FLT_MAX;
 	fMaxXOut = FLT_MIN;
 	for (int i = 0; i < m_iColsPerPlayer; i++) {
-		fMixXOut = min(fMixXOut, m_ColumnInfo[pn][i].fXOffset);
-		fMaxXOut = max(fMaxXOut, m_ColumnInfo[pn][i].fXOffset);
+		fMixXOut = min(fMixXOut, m_ColumnInfo[i].fXOffset);
+		fMaxXOut = max(fMaxXOut, m_ColumnInfo[i].fXOffset);
 	}
 }
 
@@ -134,7 +134,7 @@ Style::GetWidth(PlayerNumber pn) const
 RString
 Style::ColToButtonName(int iCol) const
 {
-	const char* pzColumnName = m_ColumnInfo[PLAYER_1][iCol].pzName;
+	const char* pzColumnName = m_ColumnInfo[iCol].pzName;
 	if (pzColumnName != NULL)
 		return pzColumnName;
 
@@ -187,9 +187,9 @@ class LunaStyle : public Luna<Style>
 		}
 
 		LuaTable ret;
-		lua_pushnumber(L, p->m_ColumnInfo[pn][iCol].track + 1);
+		lua_pushnumber(L, p->m_ColumnInfo[iCol].track + 1);
 		ret.Set(L, "Track");
-		lua_pushnumber(L, p->m_ColumnInfo[pn][iCol].fXOffset);
+		lua_pushnumber(L, p->m_ColumnInfo[iCol].fXOffset);
 		ret.Set(L, "XOffset");
 		lua_pushstring(L, p->ColToButtonName(iCol));
 		ret.Set(L, "Name");

--- a/src/Style.h
+++ b/src/Style.h
@@ -64,7 +64,7 @@ class Style
 	};
 
 	/** @brief Map each players' colun to a track in the NoteData. */
-	ColumnInfo m_ColumnInfo[NUM_PLAYERS][MAX_COLS_PER_PLAYER];
+	ColumnInfo m_ColumnInfo[MAX_COLS_PER_PLAYER];
 
 	/* This maps from game inputs to columns. More than one button may map to a
 	 * single column. */

--- a/src/XMLProfile.cpp
+++ b/src/XMLProfile.cpp
@@ -312,7 +312,7 @@ XMLProfile::SaveEttGeneralDataCreateNode(const Profile* profile) const
 		pGeneralDataNode->AppendChild(
 		  "LastDifficulty",
 		  DifficultyToString(
-			GAMESTATE->m_pCurSteps[PLAYER_1]->GetDifficulty()));
+			GAMESTATE->m_pCurSteps->GetDifficulty()));
 	else if (profile->m_LastDifficulty < Difficulty_Invalid)
 		pGeneralDataNode->AppendChild(
 		  "LastDifficulty", DifficultyToString(profile->m_LastDifficulty));


### PR DESCRIPTION
It is not known that this breaks anything on top of what has been fixed by the commits in this pr.

A couple of uses of NUM_PLAYERS still exist. All of these except for 2 are basic uses that can most likely be replaced by a number.
One real use is to determine the size of the array of OPPOSITE_PLAYER, which has essentially no uses (1 use) and could be removed.
One use I couldn't figure out what to do with is its use in ScreenGameplayNormal. Removing this breaks A LOT of macros and I don't want to mess with it.

glhf