### PR TITLE
Remove redundant header text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# Etterna
-
 <p align="center">
     <img src="Docs/images/etterna-logo-dark.svg" width=250px>
 </p>


### PR DESCRIPTION
This is my ninth PR on this repository.

This PR removes the "Etterna" header from the `README.md`. It is redundant as the first word in the `README.md` is "Etterna", as is the name of the repo.