### PR TITLE
Fix https://github.com/etternagame/etterna/issues/485

### DIFF
--- a/src/Etterna/Models/Songs/SongPosition.cpp
+++ b/src/Etterna/Models/Songs/SongPosition.cpp
@@ -36,7 +36,7 @@ SongPosition::UpdateSongPosition(float fPositionSeconds,
 	m_fSongBeatNoOffset =
 	  timing.GetBeatFromElapsedTimeNoOffset(fPositionSeconds);
 
-	m_fMusicSecondsVisible = fPositionSeconds - (g_fVisualDelaySeconds.Get()* GAMESTATE->m_SongOptions.GetPreferred().m_fMusicRate);
+	m_fMusicSecondsVisible = fPositionSeconds - (g_fVisualDelaySeconds.Get() * GAMESTATE->m_SongOptions.GetPreferred().m_fMusicRate);
 	beat_info.elapsed_time = m_fMusicSecondsVisible;
 	timing.GetBeatAndBPSFromElapsedTime(beat_info);
 	m_fSongBeatVisible = beat_info.beat;

--- a/src/Etterna/Models/Songs/SongPosition.cpp
+++ b/src/Etterna/Models/Songs/SongPosition.cpp
@@ -1,4 +1,5 @@
 #include "Etterna/Globals/global.h"
+#include "Etterna/Singletons/GameState.h"
 #include "SongPosition.h"
 
 static Preference<float> g_fVisualDelaySeconds("VisualDelaySeconds", 0.0f);
@@ -35,7 +36,7 @@ SongPosition::UpdateSongPosition(float fPositionSeconds,
 	m_fSongBeatNoOffset =
 	  timing.GetBeatFromElapsedTimeNoOffset(fPositionSeconds);
 
-	m_fMusicSecondsVisible = fPositionSeconds - g_fVisualDelaySeconds.Get();
+	m_fMusicSecondsVisible = fPositionSeconds - (g_fVisualDelaySeconds.Get()* GAMESTATE->m_SongOptions.GetPreferred().m_fMusicRate);
 	beat_info.elapsed_time = m_fMusicSecondsVisible;
 	timing.GetBeatAndBPSFromElapsedTime(beat_info);
 	m_fSongBeatVisible = beat_info.beat;


### PR DESCRIPTION
thankfully this was extremely easy to test with autoplay

i don't really like the idea of having to grab music rate from gamestate every update cycle but it doesn't appear to have that much effect, and it would make more sense to me to prevent visual delay from being divided by rate in the first place but it's not immediately obvious how or why that would happen 

