### PR TITLE
Fix https://github.com/etternagame/etterna/issues/537

### DIFF
--- a/src/arch/InputHandler/InputHandler_DirectInput.h
+++ b/src/arch/InputHandler/InputHandler_DirectInput.h
@@ -5,6 +5,8 @@
 #include "RageUtil/Misc/RageThreads.h"
 #include <chrono>
 
+void DInput_ForceJoystickPollingInNextDevicesChangedCall();
+
 struct DIDevice;
 class InputHandler_DInput : public InputHandler
 {

--- a/src/archutils/Win32/GraphicsWindow.cpp
+++ b/src/archutils/Win32/GraphicsWindow.cpp
@@ -182,19 +182,15 @@ GraphicsWindow_WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 			break;
 		}
 		case WM_DEVICECHANGE: {
-			switch (wParam)
-			{
-				case DBT_CONFIGCHANGED:
-				case DBT_DEVICEARRIVAL:
-				case DBT_DEVICEREMOVECOMPLETE:
-				case DBT_DEVNODES_CHANGED:
-				{
+			switch (wParam) {
+				case DBT_DEVICEARRIVAL: {
 					DInput_ForceJoystickPollingInNextDevicesChangedCall();
 					if (INPUTMAN->DevicesChanged()) {
 						INPUTFILTER->Reset();
 						INPUTMAN->LoadDrivers();
 						RString sMessage;
-						if (INPUTMAPPER->CheckForChangedInputDevicesAndRemap(sMessage))
+						if (INPUTMAPPER->CheckForChangedInputDevicesAndRemap(
+							  sMessage))
 							SCREENMAN->SystemMessage(sMessage);
 					}
 					break;


### PR DESCRIPTION
No longer poll for a set amount of seconds/tries for device changes when using direct input (Windows only afaik), instead listen to the WM_DEVICECHANGE windows message and poll once when we get it.