### PR TITLE
CPack Update

### DIFF
--- a/CMake/Helpers/CPackSetup.cmake
+++ b/CMake/Helpers/CPackSetup.cmake
@@ -4,25 +4,10 @@ set(CMAKE_PACKAGE_DESCRIPTION "Advanced cross-platform rhythm game focused on ke
 set(CPACK_RESOURCE_FILE_LICENSE ${PROJECT_SOURCE_DIR}/CMake/CPack/license_install.txt)
 set(CPACK_COMPONENT_ETTERNA_REQUIRED TRUE)  # Require Etterna component to be installed
 
-
-# Univeral CMake install lines
-install(DIRECTORY Announcers            COMPONENT Etterna DESTINATION .)
-install(DIRECTORY Assets                COMPONENT Etterna DESTINATION .)
-install(DIRECTORY BackgroundEffects     COMPONENT Etterna DESTINATION .)
-install(DIRECTORY BackgroundTransitions COMPONENT Etterna DESTINATION .)
-install(DIRECTORY BGAnimations          COMPONENT Etterna DESTINATION .)
-install(DIRECTORY Characters            COMPONENT Etterna DESTINATION .)
-install(DIRECTORY Data                  COMPONENT Etterna DESTINATION .)
-install(DIRECTORY NoteSkins             COMPONENT Etterna DESTINATION .)
-install(DIRECTORY Scripts               COMPONENT Etterna DESTINATION .)
-install(DIRECTORY Songs                 COMPONENT Etterna DESTINATION .)
-install(DIRECTORY Themes                COMPONENT Etterna DESTINATION .)
-install(FILES portable.ini              COMPONENT Etterna DESTINATION .)
-
 # Windows Specific CPack
 if(WIN32)
     set(CPACK_GENERATOR "NSIS")
-    SET(CPACK_NSIS_INSTALL_ROOT "C:\\\\Games") # Default install directory
+    set(CPACK_NSIS_INSTALL_ROOT "C:\\\\Games") # Default install directory
     set(CPACK_NSIS_EXECUTABLES_DIRECTORY Program)
     set(CPACK_NSIS_MUI_FINISHPAGE_RUN Etterna.exe)
     set(CPACK_NSIS_MUI_ICON ${PROJECT_SOURCE_DIR}/CMake/CPack/Windows/Install.ico)
@@ -36,6 +21,7 @@ if(WIN32)
     ## Switch the strings below to use backslashes. NSIS requires it for those variables in particular. Copied from original script.
     string(REGEX REPLACE "/" "\\\\\\\\" CPACK_NSIS_MUI_WELCOMEFINISHPAGE_BITMAP "${CPACK_NSIS_MUI_WELCOMEFINISHPAGE_BITMAP}")
 
+    set(INSTALL_DIR ".")
     install(TARGETS Etterna     COMPONENT Etterna DESTINATION Program)
     install(DIRECTORY Program   COMPONENT Etterna DESTINATION .)
     install(FILES CMake/CPack/license_install.txt COMPONENT Etterna DESTINATION Docs)
@@ -46,7 +32,20 @@ elseif(APPLE)
     set(CPACK_GENERATOR DragNDrop)
     set(CPACK_DMG_VOLUME_NAME Etterna)
 
+    set(INSTALL_DIR "Etterna")
     install(TARGETS Etterna COMPONENT Etterna DESTINATION Etterna)
 endif()
 
-
+# Universal Install Directories
+install(DIRECTORY Announcers            COMPONENT Etterna DESTINATION "${INSTALL_DIR}")
+install(DIRECTORY Assets                COMPONENT Etterna DESTINATION "${INSTALL_DIR}")
+install(DIRECTORY BackgroundEffects     COMPONENT Etterna DESTINATION "${INSTALL_DIR}")
+install(DIRECTORY BackgroundTransitions COMPONENT Etterna DESTINATION "${INSTALL_DIR}")
+install(DIRECTORY BGAnimations          COMPONENT Etterna DESTINATION "${INSTALL_DIR}")
+install(DIRECTORY Characters            COMPONENT Etterna DESTINATION "${INSTALL_DIR}")
+install(DIRECTORY Data                  COMPONENT Etterna DESTINATION "${INSTALL_DIR}")
+install(DIRECTORY NoteSkins             COMPONENT Etterna DESTINATION "${INSTALL_DIR}")
+install(DIRECTORY Scripts               COMPONENT Etterna DESTINATION "${INSTALL_DIR}")
+install(DIRECTORY Songs                 COMPONENT Etterna DESTINATION "${INSTALL_DIR}")
+install(DIRECTORY Themes                COMPONENT Etterna DESTINATION "${INSTALL_DIR}")
+install(FILES portable.ini              COMPONENT Etterna DESTINATION "${INSTALL_DIR}")


### PR DESCRIPTION
Due to the way Etterna interacts with the filesystem on Mac and Windows, different install directories are required for Etterna to properly find the necessary resources. This commit will change the install directories to be compatible with the hard-coded filesystem values which Etterna uses to access the filesystem.