### PR TITLE
ScreenEvaluation: Tweak Chord Cohesion text and add MA/PA ratio indicator

### DIFF
--- a/Themes/Til Death/BGAnimations/ScreenEvaluation decorations/default.lua
+++ b/Themes/Til Death/BGAnimations/ScreenEvaluation decorations/default.lua
@@ -509,7 +509,8 @@ function scoreBoard(pn, position)
 		LoadFont("Common Large") ..
 			{
 				InitCommand = function(self)
-					self:xy(frameX + 5, frameY + 210):zoom(0.25):halign(0)
+					self:xy(frameX + 3, frameY + 210):zoom(0.25):halign(0)
+					self:maxwidth(capWideScale(get43size(100), 160)/0.25)
 				end,
 				BeginCommand = function(self)
 					self:queuecommand("Set")
@@ -527,13 +528,70 @@ function scoreBoard(pn, position)
 	The following section first adds the ratioText and the maRatio. Then the paRatio is added and positioned. The right
 	values for maRatio and paRatio are then filled in. Finally ratioText and maRatio are aligned to paRatio.
 	--]]
-	local ratioText, maRatio, paRatio
+	local ratioText, maRatio, paRatio, marvelousTaps, perfectTaps, greatTaps
 	t[#t + 1] =
 	LoadFont("Common Large") ..
 		{
 			InitCommand = function(self)
 				ratioText = self
 				self:settext("MA/PA ratio:"):zoom(0.25):halign(1)
+			end
+		}
+	t[#t + 1] =
+	LoadFont("Common Large") ..
+		{
+			InitCommand = function(self)
+				maRatio = self
+				self:zoom(0.25):halign(1):diffuse(byJudgment(judges[1]))
+			end
+		}
+	t[#t + 1] =
+	LoadFont("Common Large") ..
+		{
+			InitCommand = function(self)
+				paRatio = self
+				self:xy(frameWidth + frameX, frameY + 210):zoom(0.25):halign(1):diffuse(byJudgment(judges[2]))
+				marvelousTaps = score:GetTapNoteScore(judges[1])
+				perfectTaps = score:GetTapNoteScore(judges[2])
+				greatTaps = score:GetTapNoteScore(judges[3])
+				self:playcommand("Set")
+			end,
+			SetCommand = function(self)
+				-- Fill in maRatio and paRatio
+				maRatio:settextf("%.1f:1", marvelousTaps / perfectTaps)
+				paRatio:settextf("%.1f:1", perfectTaps / greatTaps)
+
+				-- Align ratioText and maRatio to paRatio (self)
+				maRatioX = paRatio:GetX() - paRatio:GetZoomedWidth() - 10
+				maRatio:xy(maRatioX, paRatio:GetY())
+
+				ratioTextX = maRatioX - maRatio:GetZoomedWidth() - 10
+				ratioText:xy(ratioTextX, paRatio:GetY())
+				if score:GetChordCohesion() == true then
+					maRatio:maxwidth(maRatio:GetZoomedWidth()/0.25)
+					self:maxwidth(self:GetZoomedWidth()/0.25)
+					ratioText:maxwidth(capWideScale(get43size(65), 85)/0.27)
+				end
+			end,
+			CodeMessageCommand = function(self, params)
+				if params.Name == "PrevJudge" or params.Name == "NextJudge" then
+					if enabledCustomWindows then
+						marvelousTaps = getRescoredCustomJudge(dvt, customWindow.judgeWindows, 1)
+						perfectTaps = getRescoredCustomJudge(dvt, customWindow.judgeWindows, 2)
+						greatTaps = getRescoredCustomJudge(dvt, customWindow.judgeWindows, 3)
+					else
+						marvelousTaps = getRescoredJudge(dvt, judge, 1)
+						perfectTaps = getRescoredJudge(dvt, judge, 2)
+						greatTaps = getRescoredJudge(dvt, judge, 3)
+					end
+					self:playcommand("Set")
+				end
+				if params.Name == "ResetJudge" then
+					marvelousTaps = score:GetTapNoteScore(judges[1])
+					perfectTaps = score:GetTapNoteScore(judges[2])
+					greatTaps = score:GetTapNoteScore(judges[3])
+					self:playcommand("Set")
+				end
 			end
 		}
 	t[#t + 1] =

--- a/Themes/Til Death/BGAnimations/ScreenEvaluation decorations/default.lua
+++ b/Themes/Til Death/BGAnimations/ScreenEvaluation decorations/default.lua
@@ -525,6 +525,50 @@ function scoreBoard(pn, position)
 			end
 		}
 
+	--[[
+	The following section first adds the ratioText and the maRatio. Then the paRatio is added and positioned. The right
+	values for maRatio and paRatio are then filled in. Finally ratioText and maRatio are aligned to paRatio.
+	--]]
+	local ratioText, maRatio, paRatio
+	t[#t + 1] =
+	LoadFont("Common Large") ..
+		{
+			InitCommand = function(self)
+				ratioText = self
+				self:settext("MA/PA ratio:"):zoom(0.25):halign(1)
+			end
+		}
+	t[#t + 1] =
+	LoadFont("Common Large") ..
+		{
+			InitCommand = function(self)
+				maRatio = self
+				self:zoom(0.25):halign(1):diffuse(byJudgment(judges[1]))
+			end
+		}
+	t[#t + 1] =
+	LoadFont("Common Large") ..
+		{
+			InitCommand = function(self)
+				paRatio = self
+				self:xy(frameWidth + frameX, frameY + 210):zoom(0.25):halign(1):diffuse(byJudgment(judges[2]))
+
+				marvelousTaps = score:GetTapNoteScore(judges[1])
+				perfectTaps = score:GetTapNoteScore(judges[2])
+				greatTaps = score:GetTapNoteScore(judges[3])
+
+				-- Fill in maRatio and paRatio
+				maRatio:settextf("%.1f:1", marvelousTaps / perfectTaps)
+				paRatio:settextf("%.1f:1", perfectTaps / greatTaps)
+
+				-- Align ratioText and maRatio to paRatio (self)
+				maRatioX = paRatio:GetX() - paRatio:GetZoomedWidth() - 10
+				maRatio:xy(maRatioX, paRatio:GetY())
+				radioTextX = maRatioX - maRatio:GetZoomedWidth() - 10
+				ratioText:xy(ratioTextX, paRatio:GetY())
+			end
+		}
+
 	local fart = {"Holds", "Mines", "Rolls", "Lifts", "Fakes"}
 	t[#t + 1] =
 		Def.Quad {

--- a/Themes/Til Death/BGAnimations/ScreenEvaluation decorations/default.lua
+++ b/Themes/Til Death/BGAnimations/ScreenEvaluation decorations/default.lua
@@ -508,7 +508,7 @@ function scoreBoard(pn, position)
 		LoadFont("Common Large") ..
 		{
 			InitCommand = function(self)
-				self:xy(frameX + 40, frameY * 2.49):zoom(0.25):halign(0)
+				self:xy(frameX + 5, frameY + 210):zoom(0.25):halign(0)
 			end,
 			BeginCommand = function(self)
 				self:queuecommand("Set")

--- a/Themes/Til Death/BGAnimations/ScreenEvaluation decorations/default.lua
+++ b/Themes/Til Death/BGAnimations/ScreenEvaluation decorations/default.lua
@@ -504,26 +504,24 @@ function scoreBoard(pn, position)
 			}
 	end
 
-	t[#t + 1] =
+	if score:GetChordCohesion() == true then
+		t[#t + 1] =
 		LoadFont("Common Large") ..
-		{
-			InitCommand = function(self)
-				self:xy(frameX + 5, frameY + 210):zoom(0.25):halign(0)
-			end,
-			BeginCommand = function(self)
-				self:queuecommand("Set")
-			end,
-			ScoreChangedMessageCommand = function(self)
-				self:queuecommand("Set")
-			end,
-			SetCommand = function(self)
-				if score:GetChordCohesion() == true then
-					self:settext("Chord Cohesion: Yes")
-				else
-					self:settext("Chord Cohesion: No")
+			{
+				InitCommand = function(self)
+					self:xy(frameX + 5, frameY + 210):zoom(0.25):halign(0)
+				end,
+				BeginCommand = function(self)
+					self:queuecommand("Set")
+				end,
+				ScoreChangedMessageCommand = function(self)
+					self:queuecommand("Set")
+				end,
+				SetCommand = function(self)
+					self:settext("Chord Cohesion on")
 				end
-			end
-		}
+			}
+	end
 
 	--[[
 	The following section first adds the ratioText and the maRatio. Then the paRatio is added and positioned. The right

--- a/Themes/Til Death/BGAnimations/ScreenEvaluation decorations/default.lua
+++ b/Themes/Til Death/BGAnimations/ScreenEvaluation decorations/default.lua
@@ -564,7 +564,7 @@ function scoreBoard(pn, position)
 				-- Align ratioText and maRatio to paRatio (self)
 				maRatioX = paRatio:GetX() - paRatio:GetZoomedWidth() - 10
 				maRatio:xy(maRatioX, paRatio:GetY())
-				radioTextX = maRatioX - maRatio:GetZoomedWidth() - 10
+				ratioTextX = maRatioX - maRatio:GetZoomedWidth() - 10
 				ratioText:xy(ratioTextX, paRatio:GetY())
 			end
 		}


### PR DESCRIPTION
This is my first pull request! I added an MA/PA ratio indicator in the evaluation screen and the Chord Cohesion message now only shows when Chord Cohesion is enabled (also, it is aligned to the rest of the text, contrary to how it was before)

That's what it looks like

![Screenshot_20190610_001514](https://user-images.githubusercontent.com/21220820/59164981-d7583600-8b14-11e9-829e-6134798e88b0.png)
