### PR TITLE
Fix ALSA-sw driver not loading

### DIFF
--- a/.changelog/Release_0-66-1.md
+++ b/.changelog/Release_0-66-1.md
@@ -1,7 +1,7 @@
 # Release Changelog
 
 
-## [0.66.1] - 2019-06-10 - Hotfix
+## [0.66.1] - 2019-06-13 - Hotfix
 
 Windows x64, Windows i386, and Mac installer release.
 
@@ -19,8 +19,10 @@ Windows x64, Windows i386, and Mac installer release.
 - ScreenTextEntry's question and answer text needs to be aligned properly to cope with newlines - [7340889](../../../commit/7340889485d602d796b37e78088f6f39bb00a28e)
 - Toasties in the Asset Picker shouldn't play the sound if the item is already selected - [0381772](../../../commit/0381772cfa0c0588e21d339dccba03de9ec2e3ce)
 ### Fixed
+- ALSA didn't load basically ever - [b77e7d4](../../../commit/b77e7d435da1b952cea781c1a0150b9a7c8f84a5)
 - Blank DisplayNames for Profiles stopped prompting users to set a name - [b84d391](../../../commit/b84d391c14f501bcc8a7fc36c23d12b91ed2b61d)
 - Build order for CMake caused issues for everything but Windows - [#561](../../../pull/561)
+- DirectSound-sw didn't load basically ever - [96517f7](../../../commit/96517f7afb435ea10da8da683a0143b0b1b1b904)
 - Colors for some Pump Difficulties caused errors due to removed code - [ddd57aa](../../../commit/ddd57aab828152033ecc7f40a19c67571c7197a7)
 - DownloadManager had broken logic which made updating Online rankings impossible - [68be106](../../../commit/68be106bf14bdebe4b416b5abfe500fce3c3b61c)
 - Linux builds failed due to a last minute CMake change - [#559](../../../pull/559)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 All releases of Etterna are listed in this file as well as links to files detailing all of the changes for each. All changes for each version apply in supplement to the ones below it. Changes are not in chronological order, only versions are.
 
-## [0.66.1] - 2019-06-10 - Hotfix
+## [0.66.1] - 2019-06-13 - Hotfix
 
 Windows x64, Windows i386, and Mac installer release.
 - Bugfixes for various changes from the previous release.

--- a/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
@@ -14,7 +14,9 @@
 #include <sys/time.h>
 #include <sys/resource.h>
 
+// clang-format off
 REGISTER_SOUND_DRIVER_CLASS2(ALSA-sw, ALSA9_Software);
+// clang-format on
 
 static const int channels = 2;
 static const int samples_per_frame = channels;

--- a/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
@@ -14,7 +14,7 @@
 #include <sys/time.h>
 #include <sys/resource.h>
 
-REGISTER_SOUND_DRIVER_CLASS2(ALSA - sw, ALSA9_Software);
+REGISTER_SOUND_DRIVER_CLASS2(ALSA-sw, ALSA9_Software);
 
 static const int channels = 2;
 static const int samples_per_frame = channels;

--- a/src/arch/Sound/RageSoundDriver_DSound_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_DSound_Software.cpp
@@ -8,7 +8,9 @@
 #include "Etterna/Singletons/PrefsManager.h"
 #include "archutils/Win32/ErrorStrings.h"
 
-REGISTER_SOUND_DRIVER_CLASS2(DirectSound - sw, DSound_Software);
+// clang-format off
+REGISTER_SOUND_DRIVER_CLASS2(DirectSound-sw, DSound_Software);
+// clang-format on
 
 static const int channels = 2;
 static const int bytes_per_frame = channels * 2; /* 16-bit */


### PR DESCRIPTION
It looks like clang-format added some spacing that completely broke the ALSA driver.

I fixed the spacing and disabled clang-format on the offending line.