### PR TITLE
Experimentally Rewrite RageTimer Implementation

### DIFF
--- a/src/Etterna/Actor/Base/BitmapText.cpp
+++ b/src/Etterna/Actor/Base/BitmapText.cpp
@@ -356,7 +356,7 @@ BitmapText::BuildChars()
 	}
 
 	if (m_bUsingDistortion) {
-		int iSeed = lround(RageTimer::GetTimeSinceStartFast() * 500000.0f);
+		int iSeed = lround(RageTimer::GetTimeSinceStart() * 500000.0f);
 		RandomGen rnd(iSeed);
 		for (unsigned int i = 0; i < m_aVertices.size(); i += 4) {
 			float w = m_aVertices[i + 2].p.x - m_aVertices[i].p.x;
@@ -785,7 +785,7 @@ BitmapText::DrawPrimitives()
 		// render the diffuse pass
 		if (m_bRainbowScroll) {
 			int color_index =
-			  static_cast<int>(RageTimer::GetTimeSinceStartFast() / 0.200) %
+			  static_cast<int>(RageTimer::GetTimeSinceStart() / 0.200) %
 			  RAINBOW_COLORS.size();
 			for (unsigned i = 0; i < m_aVertices.size(); i += 4) {
 				const RageColor color = RAINBOW_COLORS[color_index];
@@ -808,9 +808,9 @@ BitmapText::DrawPrimitives()
 														  : iter->first * 4;
 				iEnd = min(iEnd, m_aVertices.size());
 				for (; i < iEnd; i += 4) {
-					m_aVertices[i + 0].c = what; // top left
-					m_aVertices[i + 1].c = is; // bottom left
-					m_aVertices[i + 2].c = wrong; // bottom right
+					m_aVertices[i + 0].c = what;		  // top left
+					m_aVertices[i + 1].c = is;			  // bottom left
+					m_aVertices[i + 2].c = wrong;		  // bottom right
 					m_aVertices[i + 3].c = withyoupeople; // top right
 				}
 				if (iter == m_mAttributes.end())
@@ -844,7 +844,7 @@ BitmapText::DrawPrimitives()
 		// apply jitter to verts
 		vector<RageVector3> vGlyphJitter;
 		if (m_bJitter) {
-			int iSeed = lround(RageTimer::GetTimeSinceStartFast() * 8);
+			int iSeed = lround(RageTimer::GetTimeSinceStart() * 8);
 			RandomGen rnd(iSeed);
 
 			for (unsigned i = 0; i < m_aVertices.size(); i += 4) {

--- a/src/Etterna/Actor/Gameplay/ArrowEffects.cpp
+++ b/src/Etterna/Actor/Gameplay/ArrowEffects.cpp
@@ -135,7 +135,7 @@ void
 ArrowEffects::Update()
 {
 	static float fLastTime = 0;
-	float fTime = RageTimer::GetTimeSinceStartFast();
+	float fTime = RageTimer::GetTimeSinceStart();
 
 	FOREACH_EnabledPlayer(pn)
 	{
@@ -238,7 +238,7 @@ ArrowEffects::Update()
 
 		// Update Tipsy
 		if (effects[PlayerOptions::EFFECT_TIPSY] != 0) {
-			const float time = RageTimer::GetTimeSinceStartFast();
+			const float time = RageTimer::GetTimeSinceStart();
 			const float time_times_timer = time * TIPSY_TIMER_FREQUENCY;
 			const float arrow_times_mag = ARROW_SIZE * TIPSY_ARROW_MAGNITUDE;
 			const float time_times_offset_timer =
@@ -596,7 +596,7 @@ ArrowEffects::GetXPos(const PlayerState* pPlayerState,
 	if (fEffects[PlayerOptions::EFFECT_DRUNK] != 0)
 		fPixelOffsetFromCenter +=
 		  fEffects[PlayerOptions::EFFECT_DRUNK] *
-		  (RageFastCos(RageTimer::GetTimeSinceStartFast() +
+		  (RageFastCos(RageTimer::GetTimeSinceStart() +
 					   iColNum * DRUNK_COLUMN_FREQUENCY +
 					   fYOffset * DRUNK_OFFSET_FREQUENCY / SCREEN_HEIGHT) *
 		   ARROW_SIZE * DRUNK_ARROW_MAGNITUDE);
@@ -817,7 +817,7 @@ ArrowGetPercentVisible(float fYPosWithoutReverse)
 	if (fAppearances[PlayerOptions::APPEARANCE_STEALTH] != 0)
 		fVisibleAdjust -= fAppearances[PlayerOptions::APPEARANCE_STEALTH];
 	if (fAppearances[PlayerOptions::APPEARANCE_BLINK] != 0) {
-		float f = RageFastSin(RageTimer::GetTimeSinceStartFast() * 10);
+		float f = RageFastSin(RageTimer::GetTimeSinceStart() * 10);
 		f = Quantize(f, BLINK_MOD_FREQUENCY);
 		fVisibleAdjust += SCALE(f, 0, 1, -1, 0);
 	}

--- a/src/Etterna/Actor/Gameplay/Background.cpp
+++ b/src/Etterna/Actor/Gameplay/Background.cpp
@@ -11,7 +11,6 @@
 #include "Etterna/Actor/Base/Quad.h"
 #include "RageUtil/Graphics/RageDisplay.h"
 #include "RageUtil/Graphics/RageTextureManager.h"
-#include "RageUtil/Misc/RageTimer.h"
 #include "RageUtil/Utils/RageUtil.h"
 #include "Etterna/Models/Misc/ScreenDimensions.h"
 #include "Etterna/Models/Songs/Song.h"

--- a/src/Etterna/Actor/Gameplay/DancingCharacters.cpp
+++ b/src/Etterna/Actor/Gameplay/DancingCharacters.cpp
@@ -52,7 +52,6 @@ DancingCharacters::DancingCharacters()
 {
 	PlayerNumber p = PLAYER_1;
 	m_pCharacter = new Model;
-	m_2DIdleTimer.SetZero();
 	m_i2DAnimState = AS2D_IDLE; // start on idle state
 	if (!GAMESTATE->IsPlayerEnabled(p))
 		return;
@@ -66,7 +65,7 @@ DancingCharacters::DancingCharacters()
 	std::string sCurrentAnim;
 	sCurrentAnim = sCharacterDirectory + "2DIdle";
 	if (DoesFileExist(sCurrentAnim +
-						"/BGAnimation.ini")) // check 2D Idle BGAnim exists
+					  "/BGAnimation.ini")) // check 2D Idle BGAnim exists
 	{
 		m_bgIdle.Load(sCurrentAnim);
 		m_bgIdle->SetXY(DC_X(p), DC_Y(p));
@@ -74,7 +73,7 @@ DancingCharacters::DancingCharacters()
 
 	sCurrentAnim = sCharacterDirectory + "2DMiss";
 	if (DoesFileExist(sCurrentAnim +
-						"/BGAnimation.ini")) // check 2D Idle BGAnim exists
+					  "/BGAnimation.ini")) // check 2D Idle BGAnim exists
 	{
 		m_bgMiss.Load(sCurrentAnim);
 		m_bgMiss->SetXY(DC_X(p), DC_Y(p));
@@ -82,7 +81,7 @@ DancingCharacters::DancingCharacters()
 
 	sCurrentAnim = sCharacterDirectory + "2DGood";
 	if (DoesFileExist(sCurrentAnim +
-						"/BGAnimation.ini")) // check 2D Idle BGAnim exists
+					  "/BGAnimation.ini")) // check 2D Idle BGAnim exists
 	{
 		m_bgGood.Load(sCurrentAnim);
 		m_bgGood->SetXY(DC_X(p), DC_Y(p));
@@ -90,7 +89,7 @@ DancingCharacters::DancingCharacters()
 
 	sCurrentAnim = sCharacterDirectory + "2DGreat";
 	if (DoesFileExist(sCurrentAnim +
-						"/BGAnimation.ini")) // check 2D Idle BGAnim exists
+					  "/BGAnimation.ini")) // check 2D Idle BGAnim exists
 	{
 		m_bgGreat.Load(sCurrentAnim);
 		m_bgGreat->SetXY(DC_X(p), DC_Y(p));
@@ -98,7 +97,7 @@ DancingCharacters::DancingCharacters()
 
 	sCurrentAnim = sCharacterDirectory + "2DFever";
 	if (DoesFileExist(sCurrentAnim +
-						"/BGAnimation.ini")) // check 2D Idle BGAnim exists
+					  "/BGAnimation.ini")) // check 2D Idle BGAnim exists
 	{
 		m_bgFever.Load(sCurrentAnim);
 		m_bgFever->SetXY(DC_X(p), DC_Y(p));
@@ -106,7 +105,7 @@ DancingCharacters::DancingCharacters()
 
 	sCurrentAnim = sCharacterDirectory + "2DFail";
 	if (DoesFileExist(sCurrentAnim +
-						"/BGAnimation.ini")) // check 2D Idle BGAnim exists
+					  "/BGAnimation.ini")) // check 2D Idle BGAnim exists
 	{
 		m_bgFail.Load(sCurrentAnim);
 		m_bgFail->SetXY(DC_X(p), DC_Y(p));
@@ -114,7 +113,7 @@ DancingCharacters::DancingCharacters()
 
 	sCurrentAnim = sCharacterDirectory + "2DWin";
 	if (DoesFileExist(sCurrentAnim +
-						"/BGAnimation.ini")) // check 2D Idle BGAnim exists
+					  "/BGAnimation.ini")) // check 2D Idle BGAnim exists
 	{
 		m_bgWin.Load(sCurrentAnim);
 		m_bgWin->SetXY(DC_X(p), DC_Y(p));
@@ -122,7 +121,7 @@ DancingCharacters::DancingCharacters()
 
 	sCurrentAnim = sCharacterDirectory + "2DWinFever";
 	if (DoesFileExist(sCurrentAnim +
-						"/BGAnimation.ini")) // check 2D Idle BGAnim exists
+					  "/BGAnimation.ini")) // check 2D Idle BGAnim exists
 	{
 		m_bgWinFever.Load(sCurrentAnim);
 		m_bgWinFever->SetXY(DC_X(p), DC_Y(p));
@@ -135,14 +134,14 @@ DancingCharacters::DancingCharacters()
 
 	m_pCharacter->LoadMilkshapeAscii(pChar->GetModelPath());
 	m_pCharacter->LoadMilkshapeAsciiBones("rest",
-												pChar->GetRestAnimationPath());
-	m_pCharacter->LoadMilkshapeAsciiBones(
-		"warmup", pChar->GetWarmUpAnimationPath());
-	m_pCharacter->LoadMilkshapeAsciiBones(
-		"dance", pChar->GetDanceAnimationPath());
+										  pChar->GetRestAnimationPath());
+	m_pCharacter->LoadMilkshapeAsciiBones("warmup",
+										  pChar->GetWarmUpAnimationPath());
+	m_pCharacter->LoadMilkshapeAsciiBones("dance",
+										  pChar->GetDanceAnimationPath());
 	m_pCharacter->SetCullMode(CULL_NONE); // many of the models floating
-												// around have the vertex order
-												// flipped
+										  // around have the vertex order
+										  // flipped
 
 	m_pCharacter->RunCommands(pChar->m_cmdInit);
 }
@@ -203,7 +202,7 @@ DancingCharacters::Update(float fDelta)
 	bool bGameplayStarting = GAMESTATE->m_bGameplayLeadIn;
 	if (!bWasGameplayStarting && bGameplayStarting) {
 		if (GAMESTATE->IsPlayerEnabled(PLAYER_1))
-		  m_pCharacter->PlayAnimation("warmup");
+			m_pCharacter->PlayAnimation("warmup");
 	}
 	bWasGameplayStarting = bGameplayStarting;
 
@@ -259,47 +258,6 @@ DancingCharacters::Update(float fDelta)
 		m_fThisCameraStartBeat = static_cast<float>(iCurBeat);
 		m_fThisCameraEndBeat = float(iCurBeat + 8);
 	}
-	/*
-	// is there any of this still around? This block of code is _ugly_. -Colby
-	// update any 2D stuff
-	if( m_bgIdle.IsLoaded() )
-	{
-		if( m_bgIdle.IsLoaded() && m_i2DAnimState[p] == AS2D_IDLE )
-			m_bgIdle->Update( fDelta );
-		if( m_bgMiss[p].IsLoaded() && m_i2DAnimState[p] == AS2D_MISS )
-			m_bgMiss[p]->Update( fDelta );
-		if( m_bgGood[p].IsLoaded() && m_i2DAnimState[p] == AS2D_GOOD )
-			m_bgGood[p]->Update( fDelta );
-		if( m_bgGreat[p].IsLoaded() && m_i2DAnimState[p] == AS2D_GREAT )
-			m_bgGreat[p]->Update( fDelta );
-		if( m_bgFever[p].IsLoaded() && m_i2DAnimState[p] == AS2D_FEVER )
-			m_bgFever[p]->Update( fDelta );
-		if( m_bgFail[p].IsLoaded() && m_i2DAnimState[p] == AS2D_FAIL )
-			m_bgFail[p]->Update( fDelta );
-		if( m_bgWin[p].IsLoaded() && m_i2DAnimState[p] == AS2D_WIN )
-			m_bgWin[p]->Update( fDelta );
-		if( m_bgWinFever[p].IsLoaded() && m_i2DAnimState[p] == AS2D_WINFEVER
-	) m_bgWinFever[p]->Update(fDelta);
-
-		if(m_i2DAnimState[p] != AS2D_IDLE) // if we're not in idle state,
-	start a timer to return us to idle
-		{
-			// never return to idle state if we have failed / passed (i.e.
-	completed) the song if(m_i2DAnimState[p] != AS2D_WINFEVER &&
-	m_i2DAnimState[p] != AS2D_FAIL && m_i2DAnimState[p] != AS2D_WIN)
-			{
-				if(m_2DIdleTimer[p].IsZero())
-					m_2DIdleTimer[p].Touch();
-				if(!m_2DIdleTimer[p].IsZero() && m_2DIdleTimer[p].Ago()
-	> 1.0f)
-				{
-					m_2DIdleTimer[p].SetZero();
-					m_i2DAnimState[p] = AS2D_IDLE;
-				}
-			}
-		}
-	}
-	*/
 }
 
 void

--- a/src/Etterna/Actor/Gameplay/DancingCharacters.h
+++ b/src/Etterna/Actor/Gameplay/DancingCharacters.h
@@ -4,7 +4,6 @@
 #include "Etterna/Actor/Base/ActorFrame.h"
 #include "Etterna/Actor/Base/AutoActor.h"
 #include "Etterna/Models/Misc/PlayerNumber.h"
-#include "RageUtil/Misc/RageTimer.h"
 class Model;
 
 /** @brief The different animation states for the dancer. */
@@ -60,7 +59,6 @@ class DancingCharacters : public ActorFrame
 	AutoActor m_bgFail;
 	AutoActor m_bgWin;
 	AutoActor m_bgWinFever;
-	RageTimer m_2DIdleTimer;
 
 	int m_i2DAnimState;
 };

--- a/src/Etterna/Actor/Gameplay/NoteField.cpp
+++ b/src/Etterna/Actor/Gameplay/NoteField.cpp
@@ -138,8 +138,10 @@ NoteField::UncacheNoteSkin(const RString& sNoteSkin_)
 void
 NoteField::CacheAllUsedNoteSkins()
 {
-	/* Cache all note skins that we might need for the whole song, course or battle
-	 * play, so we don't have to load them later (such as between course songs). */
+	/* Cache all note skins that we might need for the whole song, course or
+	 * battle
+	 * play, so we don't have to load them later (such as between course songs).
+	 */
 	vector<RString> asSkinsLower;
 	GAMESTATE->GetAllUsedNoteSkins(asSkinsLower);
 	asSkinsLower.push_back(
@@ -181,9 +183,8 @@ NoteField::CacheAllUsedNoteSkins()
 
 	FOREACH_EnabledPlayer(pn)
 	{
-		RString sNoteSkinLower = GAMESTATE->m_pPlayerState
-								   ->m_PlayerOptions.GetCurrent()
-								   .m_sNoteSkin;
+		RString sNoteSkinLower =
+		  GAMESTATE->m_pPlayerState->m_PlayerOptions.GetCurrent().m_sNoteSkin;
 		NOTESKIN->ValidateNoteSkinName(sNoteSkinLower);
 		sNoteSkinLower.MakeLower();
 		it = m_NoteDisplays.find(sNoteSkinLower);
@@ -193,7 +194,7 @@ NoteField::CacheAllUsedNoteSkins()
 
 	// I don't think this is needed?
 	// It's done in Load -- Nick12
-	//InitColumnRenderers();
+	// InitColumnRenderers();
 }
 
 void
@@ -248,7 +249,6 @@ NoteField::Load(const NoteData* pNoteData,
 					  GAMESTATE->GetCurrentStyle(m_pPlayerState->m_PlayerNumber)
 						->m_iColsPerPlayer));
 
-
 	ensure_note_displays_have_skin();
 	InitColumnRenderers();
 }
@@ -281,23 +281,23 @@ NoteField::ensure_note_displays_have_skin()
 	if (it == m_NoteDisplays.end()) {
 		CacheAllUsedNoteSkins();
 		it = m_NoteDisplays.find(sNoteSkinLower);
-		ASSERT_M(it != m_NoteDisplays.end(),
-			ssprintf("iterator != m_NoteDisplays.end() [sNoteSkinLower = %s]",
-				sNoteSkinLower.c_str()));
+		ASSERT_M(
+		  it != m_NoteDisplays.end(),
+		  ssprintf("iterator != m_NoteDisplays.end() [sNoteSkinLower = %s]",
+				   sNoteSkinLower.c_str()));
 	}
 	memset(m_pDisplays, 0, sizeof(m_pDisplays));
 	FOREACH_EnabledPlayer(pn)
 	{
-		sNoteSkinLower = GAMESTATE->m_pPlayerState
-						   ->m_PlayerOptions.GetCurrent()
-						   .m_sNoteSkin;
+		sNoteSkinLower =
+		  GAMESTATE->m_pPlayerState->m_PlayerOptions.GetCurrent().m_sNoteSkin;
 
 		// XXX: Re-setup sNoteSkinLower. Unsure if inserting the skin again is
 		// needed.
 		if (sNoteSkinLower.empty()) {
-			sNoteSkinLower = GAMESTATE->m_pPlayerState
-							   ->m_PlayerOptions.GetPreferred()
-							   .m_sNoteSkin;
+			sNoteSkinLower =
+			  GAMESTATE->m_pPlayerState->m_PlayerOptions.GetPreferred()
+				.m_sNoteSkin;
 
 			if (sNoteSkinLower.empty()) {
 				sNoteSkinLower = "default";
@@ -823,9 +823,8 @@ NoteField::DrawPrimitives()
 
 	unsigned i = 0;
 	// Draw beat bars
-	if( SHOW_BEAT_BARS && pTiming != NULL )
-	{
-		const vector<TimingSegment *> &tSigs = *segs[SEGMENT_TIME_SIG];
+	if (SHOW_BEAT_BARS && pTiming != NULL) {
+		const vector<TimingSegment*>& tSigs = *segs[SEGMENT_TIME_SIG];
 		int iMeasureIndex = 0;
 		for (i = 0; i < tSigs.size(); i++) {
 			const TimeSignatureSegment* ts = ToTimeSignature(tSigs[i]);
@@ -864,9 +863,9 @@ NoteField::DrawPrimitives()
 		}
 	}
 
-	// Optimization is very important here because there are so many arrows to draw.
-	// Draw the arrows in order of column. This minimizes texture switches and
-	// lets us draw in big batches.
+	// Optimization is very important here because there are so many arrows to
+	// draw. Draw the arrows in order of column. This minimizes texture switches
+	// and lets us draw in big batches.
 
 	const Style* pStyle =
 	  GAMESTATE->GetCurrentStyle(m_pPlayerState->m_PlayerNumber);
@@ -880,12 +879,8 @@ NoteField::DrawPrimitives()
 
 	if (*m_FieldRenderArgs.selection_begin_marker != -1 &&
 		*m_FieldRenderArgs.selection_end_marker != -1) {
-		m_FieldRenderArgs.selection_glow =
-		  SCALE(RageFastCos(RageTimer::GetTimeSinceStartFast() * 2),
-				-1,
-				1,
-				0.1f,
-				0.3f);
+		m_FieldRenderArgs.selection_glow = SCALE(
+		  RageFastCos(RageTimer::GetTimeSinceStart() * 2), -1, 1, 0.1f, 0.3f);
 	}
 	m_FieldRenderArgs.fade_before_targets = FADE_BEFORE_TARGETS_PERCENT;
 

--- a/src/Etterna/Actor/Gameplay/Player.cpp
+++ b/src/Etterna/Actor/Gameplay/Player.cpp
@@ -22,7 +22,6 @@
 #include "Etterna/Models/Misc/Profile.h"
 #include "Etterna/Singletons/ProfileManager.h"
 #include "RageUtil/Graphics/RageDisplay.h"
-#include "RageUtil/Misc/RageTimer.h"
 #include "RageUtil/Utils/RageUtil.h"
 #include "Etterna/Models/ScoreKeepers/ScoreKeeperNormal.h"
 #include "Etterna/Singletons/ScoreManager.h"
@@ -1338,10 +1337,10 @@ Player::UpdateHoldNotes(int iSongRow,
 				// give positive life in Step(), not here.
 
 				// Decrease life
-				// Also clamp the roll decay window to the accepted "Judge 7" value for it. -poco
+				// Also clamp the roll decay window to the accepted "Judge 7"
+				// value for it. -poco
 				fLife -= fDeltaTime / max(GetWindowSeconds(TW_Roll), 0.25f);
-				fLife =
-				  max(fLife, 0); // clamp life
+				fLife = max(fLife, 0); // clamp life
 				break;
 			/*
 			case TapNoteSubType_Mine:
@@ -3234,8 +3233,9 @@ Player::UpdateTapNotesMissedOlderThan(float fMissIfOlderThanSeconds)
 			// avoid scoring notes that get passed when seeking in pm
 			// not sure how many rows grace time is needed (if any?)
 			if (GAMESTATE->m_pPlayerState->m_PlayerOptions.GetCurrent()
-				  .m_bPractice && iMissIfOlderThanThisRow - iter.Row() > 8)
-					tn.result.tns = TNS_None;
+				  .m_bPractice &&
+				iMissIfOlderThanThisRow - iter.Row() > 8)
+				tn.result.tns = TNS_None;
 			if (GAMESTATE->CountNotesSeparately()) {
 				SetJudgment(iter.Row(), iter.Track(), tn);
 				HandleTapRowScore(iter.Row());

--- a/src/Etterna/Actor/GameplayAndMenus/BGAnimationLayer.cpp
+++ b/src/Etterna/Actor/GameplayAndMenus/BGAnimationLayer.cpp
@@ -1,4 +1,4 @@
-﻿#include "Etterna/Globals/global.h"
+#include "Etterna/Globals/global.h"
 #include "Etterna/Actor/Base/ActorUtil.h"
 #include "Etterna/Actor/Base/AutoActor.h"
 #include "BGAnimationLayer.h"
@@ -660,7 +660,7 @@ BGAnimationLayer::UpdateInternal(float fDeltaTime)
 			}
 			break;
 		case TYPE_TILES: {
-			float fSecs = RageTimer::GetTimeSinceStartFast();
+			float fSecs = RageTimer::GetTimeSinceStart();
 			float fTotalWidth = m_iNumTilesWide * m_fTilesSpacingX;
 			float fTotalHeight = m_iNumTilesHigh * m_fTilesSpacingY;
 

--- a/src/Etterna/Screen/Network/ScreenNetSelectMusic.cpp
+++ b/src/Etterna/Screen/Network/ScreenNetSelectMusic.cpp
@@ -17,7 +17,6 @@
 #include "RageUtil/Misc/RageInput.h"
 #include "RageUtil/Misc/RageLog.h"
 #include "Etterna/Models/StepsAndStyles/Style.h"
-#include "RageUtil/Misc/RageTimer.h"
 #include "RageUtil/Utils/RageUtil.h"
 #include "Etterna/Singletons/ScreenManager.h"
 #include "ScreenNetSelectMusic.h"

--- a/src/Etterna/Screen/Others/ScreenExit.h
+++ b/src/Etterna/Screen/Others/ScreenExit.h
@@ -1,7 +1,6 @@
 #ifndef SCREEN_EXIT_H
 #define SCREEN_EXIT_H
 
-#include "RageUtil/Misc/RageTimer.h"
 #include "Screen.h"
 
 class ScreenExit : public Screen

--- a/src/Etterna/Singletons/GameState.cpp
+++ b/src/Etterna/Singletons/GameState.cpp
@@ -572,8 +572,10 @@ GameState::CommitStageStats()
 	STATSMAN->CommitStatsToProfiles(&STATSMAN->m_CurStageStats);
 
 	// Update TotalPlaySeconds.
-	int iPlaySeconds = static_cast<int>(
-	  (std::chrono::high_resolution_clock::now() - m_timeGameStarted).count());
+	int iPlaySeconds =
+	  static_cast<int>(std::chrono::duration_cast<std::chrono::seconds>(
+						 std::chrono::steady_clock::now() - m_timeGameStarted)
+						 .count());
 
 	FOREACH_HumanPlayer(p)
 	{

--- a/src/Etterna/Singletons/GameState.h
+++ b/src/Etterna/Singletons/GameState.h
@@ -10,7 +10,6 @@
 #include "discord_rpc.h"
 
 #include <deque>
-#include <chrono>
 
 class Character;
 struct Game;
@@ -113,9 +112,8 @@ class GameState
 	Difficulty GetClosestShownDifficulty(PlayerNumber pn) const;
 	Difficulty GetEasiestStepsDifficulty() const;
 	Difficulty GetHardestStepsDifficulty() const;
-	std::chrono::high_resolution_clock::time_point
-	  m_timeGameStarted; // from the moment the first
-						 // player pressed Start
+	RageTimer m_timeGameStarted; // from the moment the first
+								 // player pressed Start
 	LuaTable* m_Environment;
 
 	// This is set to a random number per-game/round; it can be used for a

--- a/src/Etterna/Singletons/GameState.h
+++ b/src/Etterna/Singletons/GameState.h
@@ -10,6 +10,7 @@
 #include "discord_rpc.h"
 
 #include <deque>
+#include <chrono>
 
 class Character;
 struct Game;
@@ -112,8 +113,9 @@ class GameState
 	Difficulty GetClosestShownDifficulty(PlayerNumber pn) const;
 	Difficulty GetEasiestStepsDifficulty() const;
 	Difficulty GetHardestStepsDifficulty() const;
-	RageTimer
-	  m_timeGameStarted; // from the moment the first player pressed Start
+	std::chrono::high_resolution_clock::time_point
+	  m_timeGameStarted; // from the moment the first
+						 // player pressed Start
 	LuaTable* m_Environment;
 
 	// This is set to a random number per-game/round; it can be used for a

--- a/src/Etterna/Singletons/InputQueue.h
+++ b/src/Etterna/Singletons/InputQueue.h
@@ -1,4 +1,4 @@
-﻿#ifndef INPUT_QUEUE_H
+#ifndef INPUT_QUEUE_H
 #define INPUT_QUEUE_H
 
 #include "Etterna/Models/Misc/GameInput.h"
@@ -6,7 +6,6 @@
 #include <chrono>
 
 class InputEventPlus;
-class RageTimer;
 
 /** @brief Stores a list of the most recently pressed MenuInputs for each
  * player. */

--- a/src/Etterna/Singletons/ThemeManager.cpp
+++ b/src/Etterna/Singletons/ThemeManager.cpp
@@ -4,8 +4,6 @@
 #include "RageUtil/File/RageFile.h"
 #include "RageUtil/File/RageFileManager.h"
 #include "RageUtil/Misc/RageLog.h"
-#include "RageUtil/Misc/RageTimer.h"
-#include "RageUtil/Misc/RageTimer.h"
 #include "RageUtil/Utils/RageUtil.h"
 #include "arch/ArchHooks/ArchHooks.h"
 #include "arch/Dialog/Dialog.h"

--- a/src/RageUtil/Misc/RageTimer.cpp
+++ b/src/RageUtil/Misc/RageTimer.cpp
@@ -34,9 +34,9 @@ static std::chrono::microseconds g_iStartTime =
   ArchHooks::GetChronoDurationSinceStart();
 
 static uint64_t
-GetTime(bool /* bAccurate */)
+GetTime()
 {
-	return ArchHooks::GetMicrosecondsSinceStart(true);
+	return ArchHooks::GetMicrosecondsSinceStart();
 }
 
 static std::chrono::microseconds
@@ -46,7 +46,7 @@ GetChronoTime()
 }
 
 float
-RageTimer::GetTimeSinceStart(bool bAccurate)
+RageTimer::GetTimeSinceStart()
 {
 	auto usecs = GetChronoTime();
 	std::chrono::duration<float, std::micro> g = usecs - g_iStartTime;
@@ -57,13 +57,13 @@ RageTimer::GetTimeSinceStart(bool bAccurate)
 uint64_t
 RageTimer::GetUsecsSinceStart()
 {
-	return GetTime(true) - g_iStartTime.count();
+	return GetTime() - g_iStartTime.count();
 }
 
 void
 RageTimer::Touch()
 {
-	uint64_t usecs = GetTime(true);
+	uint64_t usecs = GetTime();
 
 	this->m_secs = unsigned(usecs / 1000000);
 	this->m_us = unsigned(usecs % 1000000);
@@ -157,7 +157,7 @@ RageTimer::Difference(const RageTimer& lhs, const RageTimer& rhs)
 }
 
 #include "Etterna/Singletons/LuaManager.h"
-LuaFunction(GetTimeSinceStart, RageTimer::GetTimeSinceStartFast())
+LuaFunction(GetTimeSinceStart, RageTimer::GetTimeSinceStart())
 
   /*
    * Copyright (c) 2001-2003 Chris Danford, Glenn Maynard

--- a/src/RageUtil/Misc/RageTimer.h
+++ b/src/RageUtil/Misc/RageTimer.h
@@ -13,6 +13,10 @@ class RageTimer
 	{
 		this->c_dur = std::chrono::microseconds(microseconds);
 	}
+	RageTimer(unsigned secs, unsigned microseconds)
+	{
+		this->c_dur = std::chrono::microseconds(secs * 1000000 + microseconds);
+	}
 
 	/* Time ago this RageTimer represents. */
 	float Ago() const;
@@ -47,9 +51,9 @@ class RageTimer
 	float operator-(const RageTimer& rhs) const;
 
 	bool operator<(const RageTimer& rhs) const;
+	std::chrono::microseconds c_dur;
 
   private:
-	std::chrono::microseconds c_dur;
 	static RageTimer Sum(const RageTimer& lhs, float tm);
 	static float Difference(const RageTimer& lhs, const RageTimer& rhs);
 };

--- a/src/RageUtil/Misc/RageTimer.h
+++ b/src/RageUtil/Misc/RageTimer.h
@@ -1,4 +1,4 @@
-﻿/* RageTimer - Timer services. */
+/* RageTimer - Timer services. */
 
 #ifndef RAGE_TIMER_H
 #define RAGE_TIMER_H
@@ -24,11 +24,9 @@ class RageTimer
 	/* (alias) */
 	float PeekDeltaTime() const { return Ago(); }
 
-	/* deprecated: */
-	static float GetTimeSinceStart(
-	  bool bAccurate = true); // seconds since the program was started
-	static float GetTimeSinceStartFast() { return GetTimeSinceStart(false); }
-	static uint64_t GetUsecsSinceStart();
+	static float GetTimeSinceStart(); // seconds since the program was started
+	static uint64_t
+	GetUsecsSinceStart(); // microseconds since the program was started
 
 	/* Get a timer representing half of the time ago as this one. */
 	RageTimer Half() const;

--- a/src/RageUtil/Misc/RageTimer.h
+++ b/src/RageUtil/Misc/RageTimer.h
@@ -3,25 +3,29 @@
 #ifndef RAGE_TIMER_H
 #define RAGE_TIMER_H
 
+#include <chrono>
+
 class RageTimer
 {
   public:
 	RageTimer() { Touch(); }
-	RageTimer(int secs, int us)
-	  : m_secs(secs)
-	  , m_us(us)
+	RageTimer(unsigned microseconds)
 	{
+		this->c_dur = std::chrono::microseconds(microseconds);
 	}
 
 	/* Time ago this RageTimer represents. */
 	float Ago() const;
 	void Touch();
-	bool IsZero() const { return m_secs == 0 && m_us == 0; }
-	void SetZero() { m_secs = m_us = 0; }
+	bool IsZero() const
+	{
+		return this->c_dur == std::chrono::microseconds::zero();
+	}
+	void SetZero() { this->c_dur = std::chrono::microseconds::zero(); }
 
 	/* Time between last call to GetDeltaTime() (Ago() + Touch()): */
 	float GetDeltaTime();
-	/* (alias) */
+	/* Alias for Ago */
 	float PeekDeltaTime() const { return Ago(); }
 
 	static float GetTimeSinceStart(); // seconds since the program was started
@@ -44,14 +48,8 @@ class RageTimer
 
 	bool operator<(const RageTimer& rhs) const;
 
-	/* "float" is bad for a "time since start" RageTimer.  If the game is
-	 * running for several days, we'll lose a lot of resolution.  I don't want
-	 * to use double everywhere, since it's slow.  I'd rather not use double
-	 * just for RageTimers, since it's too easy to get a type wrong and end up
-	 * with obscure resolution problems. */
-	unsigned m_secs{ 0 }, m_us{ 0 };
-
   private:
+	std::chrono::microseconds c_dur;
 	static RageTimer Sum(const RageTimer& lhs, float tm);
 	static float Difference(const RageTimer& lhs, const RageTimer& rhs);
 };

--- a/src/arch/ArchHooks/ArchHooks.h
+++ b/src/arch/ArchHooks/ArchHooks.h
@@ -71,28 +71,13 @@ class ArchHooks
 	 * Return the amount of time since the program started.  (This may actually
 	 * be since the initialization of HOOKS.
 	 *
-	 * Full microsecond accuracy may not be available.
-	 *
-	 * bAccurate is a hint: it specifies whether to prefer short-term precision
-	 * or long-term accuracy.  If false, the implementation may give higher
-	 * resolution results, but not be as stable over long periods (eg. may drift
-	 * depending on clock speed shifts on laptops).  If true, lower precision
-	 * results (usually with no less than a 1ms granularity) are returned, but
-	 * the results should be stable over long periods of time.
-	 *
-	 * Note that bAccurate may change the result significantly; it may use a
-	 * different timer, and may have a different concept of when the program
-	 * "started".
-	 *
 	 * This is a static function, implemented in whichever ArchHooks source is
 	 * used, so it can be used at any time (such as in global constructors),
 	 * before HOOKS is initialized.
 	 *
-	 * RageTimer layers on top of this, and attempts to correct wrapping, as the
-	 * underlying timers may be 32-bit, but implementations should try to avoid
-	 * wrapping if possible.
+	 * RageTimer layers on top of this.
 	 */
-	static int64_t GetMicrosecondsSinceStart(bool bAccurate);
+	static int64_t GetMicrosecondsSinceStart();
 	static std::chrono::microseconds GetChronoDurationSinceStart();
 
 	/*

--- a/src/arch/ArchHooks/ArchHooks.h
+++ b/src/arch/ArchHooks/ArchHooks.h
@@ -1,6 +1,8 @@
 #ifndef ARCH_HOOKS_H
 #define ARCH_HOOKS_H
 
+#include <chrono>
+
 struct lua_State;
 class ArchHooks
 {
@@ -33,8 +35,7 @@ class ArchHooks
 
 	/* If this is a second instance, return true.
 	 * Optionally, give focus to the existing window. */
-	virtual bool CheckForMultipleInstances(int /* argc */,
-										   char* [] /* argv[] */)
+	virtual bool CheckForMultipleInstances(int /* argc */, char*[] /* argv[] */)
 	{
 		return false;
 	}
@@ -92,6 +93,7 @@ class ArchHooks
 	 * wrapping if possible.
 	 */
 	static int64_t GetMicrosecondsSinceStart(bool bAccurate);
+	static std::chrono::microseconds GetChronoDurationSinceStart();
 
 	/*
 	 * Add file search paths, higher priority first.

--- a/src/arch/ArchHooks/ArchHooks_Unix.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Unix.cpp
@@ -154,7 +154,7 @@ ArchHooks_Unix::GetClock()
 }
 
 int64_t
-ArchHooks::GetMicrosecondsSinceStart(bool bAccurate)
+ArchHooks::GetMicrosecondsSinceStart()
 {
 	OpenGetTime();
 
@@ -168,7 +168,7 @@ ArchHooks::GetMicrosecondsSinceStart(bool bAccurate)
 }
 #else
 int64_t
-ArchHooks::GetMicrosecondsSinceStart(bool bAccurate)
+ArchHooks::GetMicrosecondsSinceStart()
 {
 	struct timeval tv;
 	gettimeofday(&tv, NULL);

--- a/src/arch/ArchHooks/ArchHooks_Unix.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Unix.cpp
@@ -35,6 +35,20 @@ extern "C" {
 #include <X11/Xatom.h>
 #endif
 
+#include <chrono>
+
+static bool g_bTimerInitialized;
+static std::chrono::steady_clock::time_point g_momentInitialized;
+
+static void
+InitTimer()
+{
+	if (g_bTimerInitialized)
+		return;
+	g_bTimerInitialized = true;
+	g_momentInitialized = std::chrono::steady_clock::now();
+}
+
 static bool
 IsFatalSignal(int signal)
 {
@@ -165,6 +179,19 @@ ArchHooks::GetMicrosecondsSinceStart()
 	if (g_Clock != CLOCK_MONOTONIC)
 		iRet = ArchHooks::FixupTimeIfBackwards(iRet);
 	return iRet;
+}
+std::chrono::microseconds
+ArchHooks::GetChronoDurationSinceStart()
+{
+	if (!g_bTimerInitialized)
+		InitTimer();
+
+	std::chrono::steady_clock::time_point now =
+	  std::chrono::steady_clock::now();
+	auto us = std::chrono::duration_cast<std::chrono::microseconds>(
+	  now - g_momentInitialized);
+
+	return us;
 }
 #else
 int64_t

--- a/src/arch/ArchHooks/ArchHooks_Unix.h
+++ b/src/arch/ArchHooks/ArchHooks_Unix.h
@@ -2,6 +2,7 @@
 #define ARCH_HOOKS_UNIX_H
 
 #include "ArchHooks.h"
+#include <chrono>
 class ArchHooks_Unix : public ArchHooks
 {
   public:
@@ -11,6 +12,7 @@ class ArchHooks_Unix : public ArchHooks
 
 	void SetTime(tm newtime);
 	int64_t GetMicrosecondsSinceStart();
+	std::chrono::microseconds GetChronoDurationSinceStart();
 
 	void MountInitialFilesystems(const RString& sDirOfExecutable);
 	float GetDisplayAspectRatio() { return 4.0f / 3; }

--- a/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
@@ -27,7 +27,7 @@ InitTimer()
 }
 
 int64_t
-ArchHooks::GetMicrosecondsSinceStart(bool bAccurate)
+ArchHooks::GetMicrosecondsSinceStart()
 {
 	if (!g_bTimerInitialized)
 		InitTimer();

--- a/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
+++ b/src/arch/ArchHooks/ArchHooks_Win32Static.cpp
@@ -6,14 +6,16 @@
 #include "RageUtil/File/RageFileManager.h"
 #include "Etterna/Globals/SpecialFiles.h"
 
-// for timeGetTime
 #include <windows.h>
 #include <mmsystem.h>
 #if defined(_MSC_VER)
 #pragma comment(lib, "winmm.lib")
 #endif
 
+#include <chrono>
+
 static bool g_bTimerInitialized;
+static std::chrono::steady_clock::time_point g_momentInitialized;
 
 static void
 InitTimer()
@@ -21,8 +23,7 @@ InitTimer()
 	if (g_bTimerInitialized)
 		return;
 	g_bTimerInitialized = true;
-
-	timeBeginPeriod(1);
+	g_momentInitialized = std::chrono::steady_clock::now();
 }
 
 int64_t
@@ -31,13 +32,27 @@ ArchHooks::GetMicrosecondsSinceStart(bool bAccurate)
 	if (!g_bTimerInitialized)
 		InitTimer();
 
-	int64_t ret = timeGetTime() * int64_t(1000);
-	if (bAccurate) {
-		ret = FixupTimeIfLooped(ret);
-		ret = FixupTimeIfBackwards(ret);
-	}
+	std::chrono::steady_clock::time_point now =
+	  std::chrono::steady_clock::now();
+	auto us = std::chrono::duration_cast<std::chrono::microseconds>(
+	  now - g_momentInitialized);
+	int64_t ret = us.count();
 
 	return ret;
+}
+
+std::chrono::microseconds
+ArchHooks::GetChronoDurationSinceStart()
+{
+	if (!g_bTimerInitialized)
+		InitTimer();
+
+	std::chrono::steady_clock::time_point now =
+	  std::chrono::steady_clock::now();
+	auto us = std::chrono::duration_cast<std::chrono::microseconds>(
+	  now - g_momentInitialized);
+
+	return us;
 }
 
 static RString

--- a/src/arch/InputHandler/InputHandler_DirectInput.cpp
+++ b/src/arch/InputHandler/InputHandler_DirectInput.cpp
@@ -11,7 +11,6 @@
 #include "InputHandler_DirectInputHelper.h"
 #include "Etterna/Singletons/PrefsManager.h"
 #include "RageUtil/Misc/RageLog.h"
-#include "RageUtil/Misc/RageTimer.h"
 #include "RageUtil/Utils/RageUtil.h"
 
 REGISTER_INPUT_HANDLER_CLASS2(DirectInput, DInput);

--- a/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
+++ b/src/arch/Sound/RageSoundDriver_ALSA9_Software.cpp
@@ -5,7 +5,6 @@
 #include "RageUtil/Sound/RageSound.h"
 #include "RageUtil/Sound/RageSoundManager.h"
 #include "RageUtil/Utils/RageUtil.h"
-#include "RageUtil/Misc/RageTimer.h"
 #include "ALSA9Dynamic.h"
 #include "Etterna/Singletons/PrefsManager.h"
 

--- a/src/arch/Sound/RageSoundDriver_WaveOut.cpp
+++ b/src/arch/Sound/RageSoundDriver_WaveOut.cpp
@@ -5,7 +5,6 @@
 #pragma comment(lib, "winmm.lib")
 #endif
 
-#include "RageUtil/Misc/RageTimer.h"
 #include "RageUtil/Misc/RageLog.h"
 #include "RageUtil/Sound/RageSound.h"
 #include "RageUtil/Utils/RageUtil.h"

--- a/src/archutils/Win32/CrashHandlerNetworking.cpp
+++ b/src/archutils/Win32/CrashHandlerNetworking.cpp
@@ -3,7 +3,6 @@
 #include "RageUtil/Misc/RageThreads.h"
 #include "RageUtil/Misc/RageLog.h"
 #include "RageUtil/Misc/RageThreads.h"
-#include "RageUtil/Misc/RageTimer.h"
 #include "RageUtil/Utils/RageUtil.h"
 #include "Etterna/Models/Misc/Foreach.h"
 


### PR DESCRIPTION
This is done with the hope of fixing some stutter, drift, or inconsistency issues.
More testing is needed, and I have no idea what I'm doing here. 

RageTimer hasn't been touched for many years, and it's looking a bit outdated (and with outdated comments). Some discussion may need to take place as for what to do with it exactly. What I've done to RageTimer here is change its internal time-keeping stuff with a std chrono duration to hopefully make things both more precise and more consistent. However, I don't know if that has actually done anything. All I do know is that it didn't break anything. (and for the things it did break, I fixed)

Some decisions I made in working on this (for example removing the bAccuracy parameter) are based on the fact that some of these comments and practices are pointing to things that are relevant for many years ago, and shouldn't be an issue in my opinion.