### PR TITLE
Preserve event timestamps in X11 input driver

### DIFF
--- a/src/arch/InputHandler/InputHandler_X11.h
+++ b/src/arch/InputHandler/InputHandler_X11.h
@@ -12,6 +12,13 @@ class InputHandler_X11 : public InputHandler
 	~InputHandler_X11();
 	void Update();
 	void GetDevicesAndDescriptions(std::vector<InputDeviceInfo>& vDevicesOut);
+
+  private:
+	// timestamp is unsigned long to match X11 Time type
+	void RegisterKeyEvent(unsigned long timestamp,
+						  bool keyDown,
+						  InputDevice input,
+						  DeviceButton button);
 };
 
 #endif


### PR DESCRIPTION
Fix for #642 .

Analogous to [this](https://github.com/stepmania/stepmania/pull/1702) pull request:

> The X11 XKeyEvent structure (and others) include a timestamp field, with 1ms resolution.
> This was previously ignored causing the input timestamps to be set to the middle of each frame.
> If the timestamps are passed through then the event timestamps are not coupled to the framerate and the polling issues are resolved.