### PR TITLE
Re-add Git Hash & Version Info Variables

### DIFF
--- a/.changelog/Release_0-67.md
+++ b/.changelog/Release_0-67.md
@@ -81,6 +81,7 @@ Windows x64, Windows i386, and Mac installer release.
 - Macros for PlayerNumbers - [cd23136](../../../commit/cd231368b4f27d61b2ce5cd4e440951d32c76fe4) [f6dd063](../../../commit/f6dd0638e31e8c5b82eb8088c09e3655eade26f7)
 - Norf - [934c6a2](../../../commit/934c6a24a5760ff3bfa1f48b71ea497826cbcafa)
 - Tokens? - [5468cc6](../../../commit/5468cc60faa2406f535b0ee7764100e94ae0d174)
+- Version Date/Time info internally and in crash logs - [14acf71](../../../commit/14acf7178b558f90c88d60bda1c41a9c3fc7d23d) [4b6a20c](../../../commit/4b6a20cbcdfc2e3f12d702680eedf909c347681a)
 ### Fixed
 - Banners in SelectMusic were not properly cropped - [120bd5a](../../../commit/120bd5a42a21781b5916668cb16013bc32a0b8dc)
 - BPM didn't properly update for SSC files with different specified BPM - [#619](../../../pull/619)
@@ -92,6 +93,7 @@ Windows x64, Windows i386, and Mac installer release.
 - Chart Preview seeking fails to work when moving from a pack to a song - [97c99c0](../../../commit/97c99c0f1fb9a2af6029e38b259f56898f98fc45)
 - Chart Preview sometimes restarted when changing tabs and doing other stuff - [44a4999](../../../commit/44a4999facc71135bd05c0d8af1507fd3255ba77) [66a54ea](../../../commit/66a54ea3a63239eafd70d87d2a2fd3140b45d8cf)
 - Chord Density Graphs were not synced for files that end in a hold - [7bc619f](../../../commit/7bc619f2a9112691b12df0513bf483bcf8de84dd)
+- Crash logs stopped showing the Build information at some point due to a CMake change - [14acf71](../../../commit/14acf7178b558f90c88d60bda1c41a9c3fc7d23d) [a9794ff](../../../commit/a9794ffd54c37cd2cad0ac1614748074131276cf)
 - Crashed rarely on multithreaded startup in a specific case where a profile has at least 1 score for each difficulty on a song that has multiple difficulties - [c988456](../../../commit/c988456cf0fe010c0e1b113a7ea74c0cb5ace93c)
 - Customize Gameplay movement caused very heavy I/O usage - [852cd31](../../../commit/852cd31d4d0495cd867be17b0b75f3b2faf9463c)
 - Custom Windows caused a rare Lua error in Offset Plots - [d75dd20](../../../commit/d75dd20d14812dc4755a5cfd992ec6cdbc73a634)

--- a/CMake/Helpers/CMakeLinux.cmake
+++ b/CMake/Helpers/CMakeLinux.cmake
@@ -5,7 +5,7 @@ list(APPEND cdefs CPU_X86_64 HAVE_LIBPTHREAD
 	"BACKTRACE_LOOKUP_METHOD_TEXT=\"backtrace_symbols\""
 	"BACKTRACE_LOOKUP_METHOD_DLADDR"
 	PACKAGE_NAME="Etterna"
-	PACKAGE_VERSION="EtteraVersion")
+	PACKAGE_VERSION="EtternaVersion")
 set_target_properties(Etterna PROPERTIES COMPILE_DEFINITIONS "${cdefs}")
 
 # Find Libraries

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,14 @@ project(Etterna
         HOMEPAGE_URL https://github.com/etternagame/etterna/
         LANGUAGES C CXX ASM)
 
+# Git Hash Info
+execute_process(COMMAND git describe --tags
+  WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+  OUTPUT_VARIABLE PRODUCT_GIT_HASH
+  RESULT_VARIABLE ret
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
 ## CMake and Compiler Setup
 set(CMAKE_CXX_STANDARD 14)                                  # Minimum C++ Version
 set(CMAKE_CXX_EXTENSIONS OFF)                               # True if compiler extensions are necessary. (Changes -std flag)

--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/other.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/other.lua
@@ -41,7 +41,6 @@ local offsetY = 20
 
 local stringList = {
 	{"Etterna Version:", ProductFamily() .. " " .. ProductVersion()},
-	{"Build Date:", VersionDate() .. " " .. VersionTime()},
 	{"Theme Version:", getThemeName() .. " " .. getThemeVersion()},
 	{"Total Songs:", SONGMAN:GetNumSongs() .. " Songs in " .. SONGMAN:GetNumSongGroups() .. " Groups"},
 	{"Total Courses:", SONGMAN:GetNumCourses() .. " Courses in " .. SONGMAN:GetNumCourseGroups() .. " Groups"},

--- a/src/Etterna/Globals/StepMania.cpp
+++ b/src/Etterna/Globals/StepMania.cpp
@@ -969,10 +969,7 @@ WriteLogHeader()
 {
 	LOG->Info("%s%s", PRODUCT_FAMILY, product_version);
 
-	LOG->Info("Compiled %s @ %s (build %s)",
-			  version_date,
-			  version_time,
-			  ::sm_version_git_hash);
+	LOG->Info("(build %s)", ::version_git_hash);
 
 	time_t cur_time;
 	time(&cur_time);

--- a/src/Etterna/Singletons/CommandLineActions.cpp
+++ b/src/Etterna/Singletons/CommandLineActions.cpp
@@ -96,10 +96,7 @@ Version()
 #ifdef _WIN32
 	RString sProductID =
 	  ssprintf("%s", (string(PRODUCT_FAMILY) + product_version).c_str());
-	RString sVersion = ssprintf("build %s\nCompile Date: %s @ %s",
-								::sm_version_git_hash,
-								version_date,
-								version_time);
+	RString sVersion = ssprintf("build %s", ::version_git_hash);
 
 	AllocConsole();
 	freopen("CONOUT$", "wb", stdout);

--- a/src/Etterna/Singletons/LuaManager.cpp
+++ b/src/Etterna/Singletons/LuaManager.cpp
@@ -1504,11 +1504,6 @@ LuaFunction(ProductFamily, (std::string)PRODUCT_FAMILY);
 LuaFunction(ProductVersion, (std::string)product_version);
 LuaFunction(ProductID, (std::string)PRODUCT_ID);
 
-extern char const* const version_date;
-extern char const* const version_time;
-LuaFunction(VersionDate, (std::string)version_date);
-LuaFunction(VersionTime, (std::string)version_time);
-
 LuaFunction(scale, SCALE(FArg(1), FArg(2), FArg(3), FArg(4), FArg(5)));
 
 LuaFunction(clamp, clamp(FArg(1), FArg(2), FArg(3)));

--- a/src/Etterna/verstub.in.cpp
+++ b/src/Etterna/verstub.in.cpp
@@ -1,6 +1,4 @@
 // clang-format off
-extern char const* const sm_version_git_hash = "@SM_VERSION_GIT_HASH@";
-extern char const* const version_date = "@SM_TIMESTAMP_DATE@";
-extern char const* const version_time = "@SM_TIMESTAMP_TIME@";
-extern char const* const product_version = "@SM_VERSION_GIT@";
+extern char const* const version_git_hash = "@PRODUCT_GIT_HASH@";
+extern char const* const product_version = "@PROJECT_VERSION@";
 // clang-format on

--- a/src/archutils/Unix/CrashHandlerChild.cpp
+++ b/src/archutils/Unix/CrashHandlerChild.cpp
@@ -199,11 +199,7 @@ child_process()
 	}
 
 	fprintf(CrashDump, "%s%s crash report", PRODUCT_FAMILY, product_version);
-	fprintf(CrashDump,
-			" (build %s, %s @ %s)",
-			::sm_version_git_hash,
-			version_date,
-			version_time);
+	fprintf(CrashDump, " (build %s)", ::version_git_hash);
 	fprintf(CrashDump, "\n");
 	fprintf(CrashDump, "--------------------------------------\n");
 	fprintf(CrashDump, "\n");

--- a/src/archutils/Win32/CrashHandlerChild.cpp
+++ b/src/archutils/Win32/CrashHandlerChild.cpp
@@ -462,12 +462,10 @@ struct CompleteCrashData
 static void
 MakeCrashReport(const CompleteCrashData& Data, RString& sOut)
 {
-	sOut += ssprintf("%s crash report (build %s, %s @ %s)\n"
+	sOut += ssprintf("%s crash report (build %s)\n"
 					 "--------------------------------------\n\n",
 					 (string(PRODUCT_FAMILY) + product_version).c_str(),
-					 ::sm_version_git_hash,
-					 version_date,
-					 version_time);
+					 ::version_git_hash);
 
 	sOut += ssprintf("Crash reason: %s\n", Data.m_CrashInfo.m_CrashReason);
 	sOut += ssprintf("\n");

--- a/src/ver.h
+++ b/src/ver.h
@@ -2,13 +2,6 @@
 #define STEPMANIA_VER_H
 
 extern char const* const product_version;
-
-// XXX: These names are misnomers. This is actually the BUILD number, time and
-// date. NOTE: In GNU toolchain these are defined in ver.cpp. In MSVC these are
-// defined in archutils/Win32/verinc.c I think. Why? I don't know and I don't
-// have MSVC. --root
-extern char const* const version_time;
-extern char const* const version_date;
-extern char const* const sm_version_git_hash;
+extern char const* const version_git_hash;
 
 #endif


### PR DESCRIPTION
At some point during the CMake rewrite for 0.65, these disappeared and were not replaced. This resulted in blanks showing up all over the place and especially in crash logs.
Now, it should show the version (no extra work is needed, it is pulled from the project version) and the exact commit/tag the build is from. Date and Time are removed.

Found a little typo that didn't affect anything, and I fixed that too.