### PR TITLE
Revert "Preserve event timestamps in X11 input driver"

### DIFF
--- a/src/arch/InputHandler/InputHandler_X11.cpp
+++ b/src/arch/InputHandler/InputHandler_X11.cpp
@@ -344,7 +344,7 @@ InputHandler_X11::Update()
 				break;
 		}
 		if (real_release) {
-			RegisterKeyEvent(event.xkey.time, false, release_dv, release_db);
+			ButtonPressed(DeviceInput(release_dv, release_db, 0));
 		}
 		switch (event.type) {
 			case MotionNotify:
@@ -354,8 +354,7 @@ InputHandler_X11::Update()
 			case KeyPress:
 				curr_db = XSymToDeviceButton(XLookupKeysym(&event.xkey, 0));
 				if (curr_db != DeviceButton_Invalid) {
-					RegisterKeyEvent(
-					  event.xkey.time, true, DEVICE_KEYBOARD, curr_db);
+					ButtonPressed(DeviceInput(DEVICE_KEYBOARD, curr_db, 1));
 				}
 				break;
 			case KeyRelease:
@@ -382,8 +381,7 @@ InputHandler_X11::Update()
 						default:
 							break;
 					}
-					RegisterKeyEvent(
-					  event.xkey.time, true, DEVICE_MOUSE, curr_db);
+					ButtonPressed(DeviceInput(DEVICE_MOUSE, curr_db, 1));
 				}
 				break;
 			case ButtonRelease:
@@ -404,7 +402,7 @@ InputHandler_X11::Update()
 		}
 	}
 	if (last_release.type != 0) {
-		RegisterKeyEvent(event.xkey.time, false, release_dv, release_db);
+		ButtonPressed(DeviceInput(release_dv, release_db, 0));
 	}
 	InputHandler::UpdateTimer();
 }
@@ -417,21 +415,4 @@ InputHandler_X11::GetDevicesAndDescriptions(
 		vDevicesOut.push_back(InputDeviceInfo(DEVICE_KEYBOARD, "Keyboard"));
 		vDevicesOut.push_back(InputDeviceInfo(DEVICE_MOUSE, "Mouse"));
 	}
-}
-
-void
-InputHandler_X11::RegisterKeyEvent(unsigned long timestamp,
-								   bool keyDown,
-								   InputDevice input,
-								   DeviceButton button)
-{
-	// https://linux.die.net/man/3/xkeyevent
-	// Event timestamp is in milliseconds
-
-	std::chrono::steady_clock::time_point timer(
-	  std::chrono::milliseconds((long)timestamp));
-
-	DeviceInput di(input, button, keyDown ? 1 : 0, timer);
-
-	ButtonPressed(di);
 }

--- a/src/arch/InputHandler/InputHandler_X11.h
+++ b/src/arch/InputHandler/InputHandler_X11.h
@@ -12,13 +12,6 @@ class InputHandler_X11 : public InputHandler
 	~InputHandler_X11();
 	void Update();
 	void GetDevicesAndDescriptions(std::vector<InputDeviceInfo>& vDevicesOut);
-
-  private:
-	// timestamp is unsigned long to match X11 Time type
-	void RegisterKeyEvent(unsigned long timestamp,
-						  bool keyDown,
-						  InputDevice input,
-						  DeviceButton button);
 };
 
 #endif


### PR DESCRIPTION
Reverts etternagame/etterna#643

Pending conclusion of: #655 

If merged, reopen #642 