### PR TITLE
Change Windows CPack to use the old directory & generate the old shortcut

### DIFF
--- a/.changelog/Release_0-67.md
+++ b/.changelog/Release_0-67.md
@@ -85,6 +85,7 @@ Windows x64, Windows i386, and Mac installer release.
 - Use InsertCoin to set the Bookmark/Loop region in Practice - [7cb4630](../../../commit/7cb46308a6a0feefa1bb0b671ea241d0d0dafc3e)
 - Use separate thread for CrashHandler on Windows - [#640](../../../pull/640)
 - WifePercent recalculation should use the same floor process so the numbers are consistent - [5322ee2](../../../commit/5322ee271c5b25e3623492966315ef4193671fcb)
+- Windows Installer (CPack with NSIS) should generate a proper shortcut and install into a consistent directory - [#660](../../../pull/660)
 - Using / as a modifier key (like Select) shouldn't let the Chat Overlay pop up - [1ab2cbd](../../../commit/1ab2cbdc1c5c7d11af32c886f50fa4faaf4d2591)
 ### Removed
 - AI.ini - [055ef81](../../../commit/055ef81d96095b416ca9ea7dee99fba316817ad6)

--- a/CMake/Helpers/CPackSetup.cmake
+++ b/CMake/Helpers/CPackSetup.cmake
@@ -1,4 +1,5 @@
 ## CPack Setup
+set(CPACK_PACKAGE_NAME "Etterna")
 set(CPACK_PACKAGE_VENDOR "Etterna Team")
 set(CMAKE_PACKAGE_DESCRIPTION "Advanced cross-platform rhythm game focused on keyboard play")
 set(CPACK_RESOURCE_FILE_LICENSE ${PROJECT_SOURCE_DIR}/CMake/CPack/license_install.txt)
@@ -17,9 +18,13 @@ if(WIN32)
     set(CPACK_NSIS_MUI_UNIICON ${PROJECT_SOURCE_DIR}/CMake/CPack/Windows/Install.ico)
     set(CPACK_NSIS_MUI_WELCOMEFINISHPAGE_BITMAP ${PROJECT_SOURCE_DIR}/CMake/CPack/Windows/welcome-ett.bmp)
 	set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
-	set(CPACK_NSIS_MODIFY_PATH ON)
+	set(CPACK_NSIS_MODIFY_PATH OFF)
+    set(CPACK_PACKAGE_INSTALL_DIRECTORY Etterna)
+    set(CPACK_PACKAGE_EXECUTABLES Etterna;Etterna)
 	set(CPACK_CREATE_DESKTOP_LINKS Etterna.exe)
     set(CPACK_PACKAGE_ICON ${PROJECT_SOURCE_DIR}\\\\CMake\\\\CPack\\\\Windows\\\\header-ett.bmp)
+    set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS "CreateShortCut \\\"$INSTDIR\\\\Etterna.lnk\\\" \\\"$INSTDIR\\\\Program\\\\Etterna.exe\\\"")
+    set(CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS "Delete \\\"$INSTDIR\\\\Etterna.lnk\\\"")
 
     ## Switch the strings below to use backslashes. NSIS requires it for those variables in particular. Copied from original script.
     string(REGEX REPLACE "/" "\\\\\\\\" CPACK_NSIS_MUI_WELCOMEFINISHPAGE_BITMAP "${CPACK_NSIS_MUI_WELCOMEFINISHPAGE_BITMAP}")


### PR DESCRIPTION
We used to prepackage a shortcut to the program that sat in the main folder of the game because of reasons and then stopped doing that. People apparently didn't like that.
This also disables the section asking if you want to add Etterna to PATH (we dont need this yet).
This also changes the install directory to `Etterna` from `Etterna <version>`