### PR TITLE
Add exit tip to ScreenTestInput

### DIFF
--- a/Themes/_fallback/BGAnimations/ScreenTestInput underlay.lua
+++ b/Themes/_fallback/BGAnimations/ScreenTestInput underlay.lua
@@ -1,3 +1,8 @@
+local translated_info = {
+	ExitText = THEME:GetString("ScreenTestInput", "ExitText"),
+	Start = THEME:GetString("GameButton", "Start")
+}
+
 return Def.ActorFrame {
 	--Def.ControllerStateDisplay {
 	--	InitCommand=function(self)
@@ -24,10 +29,11 @@ return Def.ActorFrame {
 	LoadFont("Common Large") ..
 	{
 		InitCommand = function(self)
-			self:x(SCREEN_CENTER_X):y(SCREEN_CENTER_Y+150):zoom(0.5):halign(0.5)
+			self:x(SCREEN_CENTER_X):y(SCREEN_CENTER_Y+150):zoom(0.5):halign(0.5):maxwidth(240 / 0.5)
 		end,
 		OnCommand = function(self)
-			self:settext("Hold 'Enter' to exit")
+			local fmtstr = translated_info["ExitText"]
+			self:settextf(fmtstr, translated_info["Start"])
 		end
 	}
 }

--- a/Themes/_fallback/BGAnimations/ScreenTestInput underlay.lua
+++ b/Themes/_fallback/BGAnimations/ScreenTestInput underlay.lua
@@ -15,5 +15,19 @@ return Def.ActorFrame {
 		InitCommand = function(self)
 			self:x(SCREEN_CENTER_X - 250):y(SCREEN_CENTER_Y):zoom(1):halign(0):vertspacing(8)
 		end
+	},
+	Def.Quad {
+		InitCommand = function(self)
+			self:x(SCREEN_CENTER_X):y(SCREEN_CENTER_Y+150):halign(0.5):valign(0.5):zoomto(240,40):diffuse(color("#000000")):diffusealpha(0.5)
+		end
+	},
+	LoadFont("Common Large") ..
+	{
+		InitCommand = function(self)
+			self:x(SCREEN_CENTER_X):y(SCREEN_CENTER_Y+150):zoom(0.5):halign(0.5)
+		end,
+		OnCommand = function(self)
+			self:settext("Hold 'Enter' to exit")
+		end
 	}
 }

--- a/Themes/_fallback/Languages/en.ini
+++ b/Themes/_fallback/Languages/en.ini
@@ -2603,6 +2603,7 @@ HeaderText=
 
 [ScreenTestInput]
 HeaderText=Test Input
+ExitText=Hold %s to exit.
 [ScreenMiniMenuContext]
 HeaderText=!
 [ScreenOptionsManageProfiles]


### PR DESCRIPTION
Places `Hold 'Enter' to exit` near the bottom center of the screen, along with a transparent box behind the text to prevent overlapping