### PR TITLE
Added X11 event handling to handle delete window event

### DIFF
--- a/src/arch/LowLevelWindow/LowLevelWindow_X11.h
+++ b/src/arch/LowLevelWindow/LowLevelWindow_X11.h
@@ -17,6 +17,7 @@ class LowLevelWindow_X11 : public LowLevelWindow
 	void LogDebugInformation() const;
 	bool IsSoftwareRenderer(RString& sError);
 	void SwapBuffers();
+	void Update();
 
 	const VideoModeParams* GetActualVideoModeParams() const
 	{


### PR DESCRIPTION
The existing LowLevelWindow_X11 didn't listen for window destroy events, so the program wouldn't exit when the window was destroyed.