### PR TITLE
Improve RageUtil's vssprintf on Win32

### DIFF
--- a/src/RageUtil/Utils/RageUtil.cpp
+++ b/src/RageUtil/Utils/RageUtil.cpp
@@ -396,15 +396,20 @@ vssprintf(const char* szFormat, va_list argList)
 	int iTry = 0;
 
 	do {
+		// must free the buffer: _malloca allocates on the heap OR the stack
+		// depending on the space needed
+		_freea(pBuf);
 		// Grow more than linearly (e.g. 512, 1536, 3072, etc)
 		iChars += iTry * FMT_BLOCK_SIZE;
-		pBuf = (char*)_alloca(sizeof(char) * iChars);
+		pBuf = (char*)_malloca(sizeof(char) * iChars);
 		iUsed = vsnprintf(pBuf, iChars - 1, szFormat, argList);
 		++iTry;
 	} while (iUsed < 0);
 
 	// assign whatever we managed to format
 	sStr.assign(pBuf, iUsed);
+	// free the buffer one last time
+	_freea(pBuf);
 #else
 	static bool bExactSizeSupported;
 	static bool bInitialized = false;

--- a/src/RageUtil/Utils/RageUtil.cpp
+++ b/src/RageUtil/Utils/RageUtil.cpp
@@ -388,12 +388,10 @@ GetLocalTime()
 
 #define FMT_BLOCK_SIZE 2048 // # of bytes to increment per try
 
-RString
-vssprintf(const char* szFormat, va_list argList)
-{
-	RString sStr;
-
 #ifdef _WIN32
+int
+FillCharBuffer(char** eBuf, const char* szFormat, va_list argList)
+{
 	char* pBuf = NULL;
 	int iChars = 1;
 	int iUsed = 0;
@@ -414,6 +412,20 @@ vssprintf(const char* szFormat, va_list argList)
 		iUsed = vsnprintf(pBuf, iChars - 1, szFormat, argList);
 		++iTry;
 	} while (iUsed < 0);
+
+	*eBuf = pBuf;
+	return iUsed;
+}
+#endif
+
+RString
+vssprintf(const char* szFormat, va_list argList)
+{
+	RString sStr;
+
+#ifdef _WIN32
+	char* pBuf = NULL;
+	int iUsed = FillCharBuffer(&pBuf, szFormat, argList);
 
 	// assign whatever we managed to format
 	sStr.assign(pBuf, iUsed);


### PR DESCRIPTION
Here's another change that might maybe possibly fix the stack overflow bug. Apparently when I thought I fixed it I actually didn't because I wasn't paying attention. Rather than copy pasting the solution I made for ssprintf, I chose to stick with the C ways for the purpose of speed. If we switch to spdlog, this becomes entirely irrelevant, anyways... probably.

The function change from `_alloca` to `_malloca` should get it to use heap space after it passes a threshold of bytes, but it still has the potential to overflow before using the heap space (it uses the stack space until the threshold is reached). And it requires a free. I could put the buffer into some C++ pointer or whatever but that again would be reducing speed. Apparently we really want to be fast here, so I wanted to avoid taking steps backwards.

Initially the PR would have also removed these redefinitions:
https://github.com/etternagame/etterna/blob/a85b29c7196da4326d3558b7f71c5ebbff220720/src/Etterna/Globals/StepMania.cpp#L68
https://github.com/etternagame/etterna/blob/a85b29c7196da4326d3558b7f71c5ebbff220720/src/Etterna/Globals/StdString.h#L328

but some testing proved that removing them introduced more unnecessary hassle at the moment.