### PR TITLE
Uncomment Win32 GraphicsWindow DisplaySpec Validation

### DIFF
--- a/src/archutils/Win32/GraphicsWindow.cpp
+++ b/src/archutils/Win32/GraphicsWindow.cpp
@@ -592,9 +592,9 @@ GraphicsWindow::GetDisplaySpecs(DisplaySpecs& out)
 	int i = 0;
 	std::set<DisplayMode> modes;
 	while (EnumDisplaySettingsEx(nullptr, i++, dm.get(), 0)) {
-		if (isvalid(dm) /*&& ChangeDisplaySettingsEx(
+		if (isvalid(dm) && ChangeDisplaySettingsEx(
 							 nullptr, dm.get(), nullptr, CDS_TEST, nullptr) ==
-							 DISP_CHANGE_SUCCESSFUL*/) {
+							 DISP_CHANGE_SUCCESSFUL) {
 			DisplayMode m = { dm->dmPelsWidth,
 							  dm->dmPelsHeight,
 							  static_cast<double>(dm->dmDisplayFrequency) };


### PR DESCRIPTION
the reason this was commented was because commenting didnt seem to break anything and the particular function commented out caused a huge amount of lag (several seconds) when entering the options menu on opengl

need to test