### PR TITLE
Reduce copying and code duplication in dlman score uploads

### DIFF
--- a/src/Etterna/Singletons/DownloadManager.h
+++ b/src/Etterna/Singletons/DownloadManager.h
@@ -35,9 +35,10 @@ class Download
 {
   public:
 	function<void(Download*)> Done;
-	Download(string url,
-			 string filename = "",
-			 function<void(Download*)> done = [](Download*) { return; });
+	Download(
+	  string url,
+	  string filename = "",
+	  function<void(Download*)> done = [](Download*) { return; });
 	~Download();
 	void Install();
 	void Update(float fDeltaSeconds);
@@ -90,12 +91,13 @@ class DownloadablePack
 class HTTPRequest
 {
   public:
-	HTTPRequest(CURL* h,
-				function<void(HTTPRequest&, CURLMsg*)> done =
-				  [](HTTPRequest& req, CURLMsg*) { return; },
-				curl_httppost* postform = nullptr,
-				function<void(HTTPRequest&, CURLMsg*)> fail =
-				  [](HTTPRequest& req, CURLMsg*) { return; })
+	HTTPRequest(
+	  CURL* h,
+	  function<void(HTTPRequest&, CURLMsg*)> done = [](HTTPRequest& req,
+													   CURLMsg*) { return; },
+	  curl_httppost* postform = nullptr,
+	  function<void(HTTPRequest&, CURLMsg*)> fail = [](HTTPRequest& req,
+													   CURLMsg*) { return; })
 	  : handle(h)
 	  , form(postform)
 	  , Done(done)
@@ -183,7 +185,7 @@ class DownloadManager
 	bool initialized{ false };
 	string error{ "" };
 	vector<DownloadablePack> downloadablePacks;
-	string authToken{ "" };   // Session cookie content
+	string authToken{ "" };	  // Session cookie content
 	string sessionUser{ "" }; // Currently logged in username
 	string sessionPass{ "" }; // Currently logged in password
 	string lastVersion{
@@ -224,12 +226,15 @@ class DownloadManager
 					  function<void(bool loggedIn)>
 						done); // Sends login request if not already logging in
 	void OnLogin();
-	void uploadSequentiallyTWEO();
 	bool UploadScores(); // Uploads all scores not yet uploaded to current
-	void creepypasta();
-	void ForceUploadScoresForChart(const std::string& ck, bool startnow);	// forced upload wrapper for charts
-	void ForceUploadScoresForPack(const std::string& pack, bool startnow);	// forced upload wrapper for packs
-	void ForceUploadAllScores(bool startnow);
+	void BeginSequentialUploadOfAccumulatedQueue();
+	void ForceUploadScoresForChart(
+	  const std::string& ck,
+	  bool startnow = true); // forced upload wrapper for charts
+	void ForceUploadScoresForPack(
+	  const std::string& pack,
+	  bool startnow = true); // forced upload wrapper for packs
+	void ForceUploadAllScores();
 	void RefreshPackList(const string& url);
 
 	void init();
@@ -248,11 +253,13 @@ class DownloadManager
 	bool Error() { return error == ""; }
 	bool EncodeSpaces(string& str);
 
+	void UploadScore(HighScore* hs,
+					 function<void()> callback,
+					 bool load_from_disk);
 	void UploadScoreWithReplayData(HighScore* hs);
 	void UploadScoreWithReplayDataFromDisk(
-	  const string& sk,
+	  HighScore* hs,
 	  function<void()> callback = function<void()>());
-	void UploadScore(HighScore* hs);
 
 	bool ShouldUploadScores();
 

--- a/src/Etterna/Singletons/DownloadManager.h
+++ b/src/Etterna/Singletons/DownloadManager.h
@@ -259,7 +259,7 @@ class DownloadManager
 	void UploadScoreWithReplayData(HighScore* hs);
 	void UploadScoreWithReplayDataFromDisk(
 	  HighScore* hs,
-	  function<void()> callback = function<void()>());
+	  function<void()> callback = []() {});
 
 	bool ShouldUploadScores();
 

--- a/src/Etterna/Singletons/DownloadManager.h
+++ b/src/Etterna/Singletons/DownloadManager.h
@@ -227,7 +227,6 @@ class DownloadManager
 						done); // Sends login request if not already logging in
 	void OnLogin();
 	bool UploadScores(); // Uploads all scores not yet uploaded to current
-	void BeginSequentialUploadOfAccumulatedQueue();
 	void ForceUploadScoresForChart(
 	  const std::string& ck,
 	  bool startnow = true); // forced upload wrapper for charts
@@ -311,7 +310,8 @@ class DownloadManager
 	// most recent single score upload result -mina
 	RString mostrecentresult = "";
 	deque<pair<DownloadablePack*, bool>> DownloadQueue; // (pack,isMirror)
-	deque<HighScore*> ForceUploadScoreQueue;
+	deque<HighScore*> ScoreUploadSequentialQueue;
+	unsigned int sequentialScoreUploadTotalWorkload{ 0 };
 	const int maxPacksToDownloadAtOnce = 1;
 	const float DownloadCooldownTime = 5.f;
 	float timeSinceLastDownload = 0.f;

--- a/src/Etterna/Singletons/PrefsManager.h
+++ b/src/Etterna/Singletons/PrefsManager.h
@@ -163,7 +163,7 @@ class PrefsManager
 	Preference<float> m_fLifeDifficultyScale;
 
 	// Whoever added these: Please add a comment saying what they do. -Chris
-	Preference<int> m_iRegenComboAfterMiss;	// combo that must be met after a
+	Preference<int> m_iRegenComboAfterMiss;	   // combo that must be met after a
 											   // Miss to regen life
 	Preference<int> m_iMaxRegenComboAfterMiss; // caps RegenComboAfterMiss if
 											   // multiple Misses occur in rapid
@@ -248,8 +248,9 @@ class PrefsManager
 	Preference<bool> m_bPseudoLocalize;
 	Preference<bool> m_show_theme_errors;
 
-	Preference<int> m_verbose_log; // levels 0, 1, and 2 where higher numbers
-								   // means more logging
+	// levels 0, 1, and 2 where higher numbers
+	// means more logging
+	Preference<int> m_verbose_log;
 
 	Preference<bool>
 	  m_bEnableScoreboard; // Alows disabling of scoreboard in network play


### PR DESCRIPTION
Also add a bit more logging for failure scenarios, and try to avoid
marking failed scores as uploaded

@MinaciousGrace do you want to test this before it gets merged?

I did a small test by playing you suffer in 2 rates offline, then logging in, and it uploaded fine and I saw the progress bar.