### PR TITLE
rework calc/calcdisplay structure (calc version 273)

### DIFF
--- a/Themes/Til Death/BGAnimations/_calcdisplay.lua
+++ b/Themes/Til Death/BGAnimations/_calcdisplay.lua
@@ -180,7 +180,6 @@ local function updateCoolStuff()
             for i = 1, #v do        -- loop through specifc mods
                 graphVecs[v[i]] = {}
                 for h = 1, 2 do     -- left/right hand loop
-                    ms.ok(v[i])
                     graphVecs[v[i]][h] = bap[k][v[i]][h]
                     if k == "CalcDiffValue" then
                         for j = 1, #graphVecs[v[i]][h] do
@@ -434,14 +433,14 @@ local modnames = {
     "jsr",
     "cjl",
     "cjr",
-    "sl",
-    "sr",
     "stl",
     "str",
     "ohtl",
     "ohtr",
     "cl",
-    "cr"
+    "cr",
+    "sl",
+    "sr",
 }
 
 local modColors = {

--- a/Themes/Til Death/BGAnimations/_calcdisplay.lua
+++ b/Themes/Til Death/BGAnimations/_calcdisplay.lua
@@ -169,7 +169,7 @@ local function updateCoolStuff()
     end
     if steps then
        --ssrs = getGraphForSteps(steps) // maybe add back the new wrapper
-
+        lowerGraphMax = 0
         local bap = steps:GetCalcDebugOutput()
 
         -- loop through types of debug output
@@ -178,7 +178,6 @@ local function updateCoolStuff()
                 graphVecs[v[i]] = {}
                 for h = 1, 2 do     -- left/right hand loop
                     graphVecs[v[i]][h] = bap[k][v[i]][h]
-
                     if k == "CalcDiffValue" then
                         for j = 1, #graphVecs[v[i]][h] do
                             local val = graphVecs[v[i]][h][j]
@@ -641,7 +640,7 @@ o[#o+1] = makeskillsetlabeltext((#CalcDebugTypes["CalcPatternMod"] * 2) + 2, "St
 o[#o+1] = topGraphLine("base_line", modColors[14])    -- super hack to make 1.0 value indicator line
 
 for i, mod in pairs(CalcDebugTypes["CalcDiffValue"]) do
-    if i > 2 then   -- cut out the base stuff atm cause noise
+    if i == 2 or i == 4 then   -- these are the most interesting ones atm
         o[#o+1] = bottomGraphLineMSD(mod, skillsetColors[(i * 2) - 1], 1)
         o[#o+1] = bottomGraphLineMSD(mod, skillsetColors[i * 2], 2)
     end

--- a/Themes/Til Death/BGAnimations/_calcdisplay.lua
+++ b/Themes/Til Death/BGAnimations/_calcdisplay.lua
@@ -149,6 +149,7 @@ local CalcDebugTypes = {
         "StreamMod",
         "OHTrill",
         "Chaos",
+        "FlamJam"
     },
     CalcDiffValue =
     {
@@ -439,6 +440,8 @@ local modnames = {
     "ohtr",
     "cl",
     "cr",
+    "fcl",
+    "fcr",
     "sl",
     "sr",
 }

--- a/Themes/Til Death/BGAnimations/_calcdisplay.lua
+++ b/Themes/Til Death/BGAnimations/_calcdisplay.lua
@@ -466,7 +466,9 @@ local modColors = {
     color(".4,0.9,0.3"),       
     color(".4,0.9,0.3"),
     color(".4,0.5,0.59"),       
-    color(".4,0.3,0.49")
+    color(".4,0.3,0.49"),
+    color("1,0,0"),
+    color("1,0,0"),
 }
 
 -- top graph average text

--- a/Themes/Til Death/BGAnimations/_calcdisplay.lua
+++ b/Themes/Til Death/BGAnimations/_calcdisplay.lua
@@ -435,7 +435,13 @@ local modnames = {
     "cjl",
     "cjr",
     "sl",
-    "sr"
+    "sr",
+    "stl",
+    "str",
+    "ohtl",
+    "ohtr",
+    "cl",
+    "cr"
 }
 
 local modColors = {
@@ -452,16 +458,22 @@ local modColors = {
     color("1.4,1.3,1"),       
     color("1.4,1.3,0.9"),
     color(".4,1.3,1"),       
-    color(".4,1.3,0.9")          
+    color(".4,1.3,0.9"),
+    color(".7,1.3,1"),       
+    color(".7,1.3,0.9"),
+    color(".4,0.9,0.3"),       
+    color(".4,0.9,0.3"),
+    color(".4,0.5,0.59"),       
+    color(".4,0.3,0.49")
 }
 
 -- top graph average text
 makeskillsetlabeltext = function(i, mod, hand) 
     return LoadFont("Common Normal") .. {
         InitCommand = function(self)
-            local xspace = 30   -- this is gonna look like shit on 4:3 no matter what so w.e
+            local xspace = 22   -- this is gonna look like shit on 4:3 no matter what so w.e
             self:xy(-plotWidth/2 + 5 + ((i -1) * xspace), plotHeight/3):halign(0)
-            self:zoom(0.35)
+            self:zoom(0.3)
             self:settext("")
             self:maxwidth((plotWidth-10) / 0.5)
             if hand % 2 == 0 then

--- a/Themes/Til Death/BGAnimations/_calcdisplay.lua
+++ b/Themes/Til Death/BGAnimations/_calcdisplay.lua
@@ -156,7 +156,7 @@ local function updateCoolStuff()
         graphVecs[1][13] = bap[23]  -- stammod (should be separate prolly?)
         graphVecs[1][14] = bap[24]
 
-        for i = 13, 24 do
+        for i = 13, 22 do
             graphVecs[2][i - 12] = bap[i]
         end
 
@@ -342,11 +342,13 @@ o[#o + 1] = Def.Quad {
             local bmsdr = graphVecs[2][6][index]
             local msdl = graphVecs[2][7][index]
             local msdr = graphVecs[2][8][index]
+            local pll = graphVecs[2][9][index]
+            local plr = graphVecs[2][10][index]
             if msdl == nil then
                 txt:settext("")
             else
-                txt:settextf("npsl: %5.4f\nnpsr: %5.4f\nmsl: %5.4f\nmsr: %5.4f\nbmsdl: %5.4f\nbmsdr: %5.4f\nmsdl: %5.4f\nmsdr: %5.4f\n",
-                    npsl, npsr, msl, msr, bmsdl, bmsdr, msdl, msdr)
+                txt:settextf("npsl: %5.4f\nnpsr: %5.4f\nmsl: %5.4f\nmsr: %5.4f\nbmsdl: %5.4f\nbmsdr: %5.4f\nmsdl: %5.4f\nmsdr: %5.4f\npll: %5.4f\nplr: %5.4f",
+                    npsl, npsr, msl, msr, bmsdl, bmsdr, msdl, msdr, pll, plr)
                 --txt:settextf("Percent: %5.4f\nOverall: %.2f\nStream: %.2f\nJumpstream: %.2f\nHandstream: %.2f\nStamina: %.2f\nJackspeed: %.2f\nChordjack: %.2f\nTechnical: %.2f", (ssrLowerBoundWife + (ssrUpperBoundWife-ssrLowerBoundWife)*perc)*100, ovrl, strm, js, hs, stam, jack, chjk, tech)
             end
 		else
@@ -599,9 +601,12 @@ local skillsetColors = {
     color("#6c969d"),   -- jack
     color("#a5f8d3"),   -- chordjack
     color("#b0cec2"),    -- tech
+    color("#b0cec2"),    -- tech
+    color("1,0,0"),   
+    color("1,0,0"),
 }
 
-for i = 1, 10 do
+for i = 7, 10 do
     --o[#o+1] = bottomGraphLine(i, skillsetColors[i])
     o[#o+1] = bottomGraphLineMSD(i, skillsetColors[i])
 end

--- a/Themes/Til Death/BGAnimations/_calcdisplay.lua
+++ b/Themes/Til Death/BGAnimations/_calcdisplay.lua
@@ -25,6 +25,30 @@ local finalSecond
 local graphVecs = {}
 local ssrs
 
+local CalcPatternMod = 
+{
+	"OHJump", 
+	"Anchor", 
+	"Roll",   
+	"HS",		
+	"Jump",   
+	"CJ",		
+}
+
+local CalcDebugMisc = 
+{
+    "PtLoss", -- goes in bot graph
+	"StamMod",-- goes in top graph
+}
+
+local CalcDiffValue =
+{
+	"BaseNPS", 
+	"BaseMS",  
+	"BaseMSD", 
+	"MSD",
+}
+
 local function fitX(x, lastX) -- Scale time values to fit within plot width.
 	if lastX == 0 then
 		return 0
@@ -148,11 +172,15 @@ local function updateCoolStuff()
         graphVecs[1] = {}
         graphVecs[2] = {}
         graphVecs[3] = {}
-        for i= 1, 12 do
-            graphVecs[1][i] = bap[i]
+        ms.ok(#bap["Jump"][1])
+        for i= 1, #CalcPatternMod do
+            graphVecs[1][i] = bap[CalcPatternMod[i]]
+            --ms.ok(showKeys(bap))
+            --ms.ok(#bap[CalcPatternMod[1]])
+            for ii = 1, #bap[CalcPatternMod[1]] do 
+            --ms.ok(bap[CalcPatternMod[1]][ii])
+            end
         end
-
-        -- need to properly enum this garbo
         graphVecs[1][13] = bap[23]  -- stammod (should be separate prolly?)
         graphVecs[1][14] = bap[24]
 

--- a/Themes/Til Death/BGAnimations/_calcdisplay.lua
+++ b/Themes/Til Death/BGAnimations/_calcdisplay.lua
@@ -72,7 +72,7 @@ local function convertPercentToIndexForMods(x)
     if output < 0 then output = 0 end
     if output > 1 then output = 1 end
 
-    local ind = notShit.round(output * #graphVecs[1][1])
+    local ind = notShit.round(output * #graphVecs["Jump"][1])
     if ind < 1 then ind = 1 end
     return ind
 end
@@ -182,7 +182,6 @@ local function updateCoolStuff()
                     if k == "CalcDiffValue" then
                         for j = 1, #graphVecs[v[i]][h] do
                             local val = graphVecs[v[i]][h][j]
-                            if val < lowerGraphMin then lowerGraphMin = val end
                             if val > lowerGraphMax then lowerGraphMax = val end
                         end
                     end
@@ -190,17 +189,8 @@ local function updateCoolStuff()
             end
         end
 
-        -- hardcode these numbers for constant upper graph bounds
-        upperGraphMin = 0.4
-        upperGraphMax = 1.3
-        --[[-- uncomment to have adaptive upper graph
-        for _, line in ipairs(graphVecs[1]) do
-            for ind, val in pairs(line) do
-                if val < upperGraphMin then upperGraphMin = val end
-                if val > upperGraphMax then upperGraphMax = val end
-            end
-        end]]
-        -- same as immediately above
+        upperGraphMin = 0.3
+        upperGraphMax = 1.2
     else
         graphVecs = {}
     end
@@ -255,9 +245,9 @@ local o =
         end
     }
 }
-local gg= {}
+
 -- graph bg
-gg[#o + 1] = Def.Quad {
+o[#o + 1] = Def.Quad {
     InitCommand = function(self)
         self:zoomto(plotWidth, plotHeight):diffuse(color("#232323")):diffusealpha(
             bgalpha
@@ -290,24 +280,35 @@ gg[#o + 1] = Def.Quad {
             bg:x(goodXPos)
             bg:y(ypos + 3)
             local index = convertPercentToIndexForMods(perc)
+
+            local farts = {}
+            local toofartstoofury = ""
+            local fartsfartsFOUR = {}
+            for i, mod in pairs(CalcDebugTypes["CalcPatternMod"]) do
+                for h = 1, 2 do
+                    local blah = "L"
+                    if h == 2 then
+                        blah = "R"
+                    end
+                    farts[#farts + 1] = graphVecs[mod][h]
+                    fartsfartsFOUR[#fartsfartsFOUR + 1] = mod..blah
+                end
+            end
+            -- add stammod
+            for h = 1, 2 do
+                local blah = "L"
+                    if h == 2 then
+                        blah = "R"
+                    end
+                farts[#farts + 1] = graphVecs["StamMod"][h]
+                fartsfartsFOUR[#fartsfartsFOUR + 1] = "StamMod"..blah
+            end
             
-            -- this is so bad it ceases to be lazy, it's more work than iterating :|
-            local ohjl =    graphVecs[1][1][index]
-            local ohjr =    graphVecs[1][2][index]
-            local anchrl =  graphVecs[1][3][index]
-            local anchrr =  graphVecs[1][4][index]
-            local rolll =   graphVecs[1][5][index]
-            local rollr =   graphVecs[1][6][index]
-            local hsdsl =   graphVecs[1][7][index]
-            local hsdsr =   graphVecs[1][8][index]
-            local jumpdsl = graphVecs[1][9][index]
-            local jumpdsr = graphVecs[1][10][index]
-            local cjl = graphVecs[1][11][index]
-            local cjr = graphVecs[1][12][index]
-            local sl = graphVecs[1][13][index]
-            local sr = graphVecs[1][14][index]
-            txt:settextf("ohjl: %5.4f\nohjr: %5.4f\nanchrl: %5.4f\nanchrr: %5.4f\nrolll: %5.4f\nrollr: %5.4f\nhsdsl: %5.4f\nhsdsr: %5.4f\njumpdsl: %5.4f\njumpdsr: %5.4f\nsl: %5.4f\nsr: %5.4f\ncjl: %5.4f\ncjr: %5.4f",
-                ohjl, ohjr, anchrl, anchrr, rolll, rollr, hsdsl, hsdsr, jumpdsl, jumpdsr, sl, sr, cjl, cjr)
+            for k, v in pairs(farts) do
+                local txt = string.format(fartsfartsFOUR[k]..": %5.4f\n", v[index])
+                toofartstoofury = toofartstoofury .. txt
+            end
+            txt:settext(toofartstoofury)
 		else
 			bar:visible(false)
             txt:visible(false)
@@ -317,7 +318,7 @@ gg[#o + 1] = Def.Quad {
 }
 
 -- second bg
-gg[#o + 1] = Def.Quad {
+o[#o + 1] = Def.Quad {
     Name = "G2BG",
     InitCommand = function(self)
         self:y(plotHeight + 5)
@@ -353,23 +354,36 @@ gg[#o + 1] = Def.Quad {
             bg:y(ypos + 3)
             
             local index = convertPercentToIndexForMods(perc)
-            local npsl = graphVecs[2][1][index]
-            local npsr = graphVecs[2][2][index]
-            local msl = graphVecs[2][3][index]
-            local msr = graphVecs[2][4][index]
-            local bmsdl = graphVecs[2][5][index]
-            local bmsdr = graphVecs[2][6][index]
-            local msdl = graphVecs[2][7][index]
-            local msdr = graphVecs[2][8][index]
-            local pll = graphVecs[2][9][index]
-            local plr = graphVecs[2][10][index]
-            if msdl == nil then
-                txt:settext("")
-            else
-                txt:settextf("npsl: %5.4f\nnpsr: %5.4f\nmsl: %5.4f\nmsr: %5.4f\nbmsdl: %5.4f\nbmsdr: %5.4f\nmsdl: %5.4f\nmsdr: %5.4f\npll: %5.4f\nplr: %5.4f",
-                    npsl, npsr, msl, msr, bmsdl, bmsdr, msdl, msdr, pll, plr)
-                --txt:settextf("Percent: %5.4f\nOverall: %.2f\nStream: %.2f\nJumpstream: %.2f\nHandstream: %.2f\nStamina: %.2f\nJackspeed: %.2f\nChordjack: %.2f\nTechnical: %.2f", (ssrLowerBoundWife + (ssrUpperBoundWife-ssrLowerBoundWife)*perc)*100, ovrl, strm, js, hs, stam, jack, chjk, tech)
+            local farts = {}
+            local toofartstoofury = ""
+            local fartsfartsFOUR = {}
+            for i, mod in pairs(CalcDebugTypes["CalcDiffValue"]) do
+                for h = 1, 2 do
+                    local blah = "L"
+                    if h == 2 then
+                        blah = "R"
+                    end
+                    farts[#farts + 1] = graphVecs[mod][h]
+                    fartsfartsFOUR[#fartsfartsFOUR + 1] = mod..blah
+                end
             end
+            
+            -- add ptloss
+            for h = 1, 2 do
+                local blah = "L"
+                    if h == 2 then
+                        blah = "R"
+                    end
+                farts[#farts + 1] = graphVecs["PtLoss"][h]
+                fartsfartsFOUR[#fartsfartsFOUR + 1] = "PtLoss"..blah
+            end
+
+            for k, v in pairs(farts) do
+                local txt = string.format(fartsfartsFOUR[k]..": %5.4f\n", v[index])
+                toofartstoofury = toofartstoofury .. txt
+            end
+
+            txt:settext(toofartstoofury)
 		else
 			bar:visible(false)
             txt:visible(false)
@@ -404,7 +418,7 @@ o[#o + 1] = LoadFont("Common Normal") .. {
     5 = Jumpstream downscaler
     anything else = no output
 ]]
-modnames = {
+local modnames = {
     "ohjl",
     "ohjr",
     "anchl",
@@ -466,7 +480,7 @@ makeskillsetlabeltext = function(i, mod, hand)
                 end
             end
             self:diffuse(modColors[i])
-            self:settextf("%s: %.4f", modnames[i * 2 ], aves[i])
+            self:settextf("%s: %.4f", modnames[i], aves[i])
         end
     end
 }
@@ -475,13 +489,13 @@ end
 -- lower graph average text
 o[#o + 1] = LoadFont("Common Normal") .. {
     InitCommand = function(self)
-        self:xy(-plotWidth/2 + 5, plotHeight + plotHeight/3):halign(0)
+        self:xy(-plotWidth/2 + 5, plotHeight/2 + 20):halign(0)
         self:zoom(0.5)
         self:settext("")
     end,
     DoTheThingCommand = function(self)
         if song and enabled then
-            self:settextf("Upper Bound: %.4f\nLower Bound: %.4f", lowerGraphMax, lowerGraphMin)
+            self:settextf("Upper Bound: %.4f", lowerGraphMax)
         end
     end
 }
@@ -622,15 +636,18 @@ end
 -- add stam since it's not technically a pattern mod
 o[#o+1] = topGraphLine("StamMod", modColors[(#CalcDebugTypes["CalcPatternMod"] * 2) + 1], 1)
 o[#o+1] = topGraphLine("StamMod", modColors[(#CalcDebugTypes["CalcPatternMod"] * 2) + 2], 2)
+o[#o+1] = makeskillsetlabeltext((#CalcDebugTypes["CalcPatternMod"] * 2) + 1, "StamMod", 1)
+o[#o+1] = makeskillsetlabeltext((#CalcDebugTypes["CalcPatternMod"] * 2) + 2, "StamMod", 2)
 o[#o+1] = topGraphLine("base_line", modColors[14])    -- super hack to make 1.0 value indicator line
 
 for i, mod in pairs(CalcDebugTypes["CalcDiffValue"]) do
-    --o[#o+1] = bottomGraphLine(i, skillsetColors[i])
-    o[#o+1] = bottomGraphLineMSD(mod, skillsetColors[(i * 2) - 1], 1)
-    o[#o+1] = bottomGraphLineMSD(mod, skillsetColors[i * 2], 2)
+    if i > 2 then   -- cut out the base stuff atm cause noise
+        o[#o+1] = bottomGraphLineMSD(mod, skillsetColors[(i * 2) - 1], 1)
+        o[#o+1] = bottomGraphLineMSD(mod, skillsetColors[i * 2], 2)
+    end
 end
-o[#o+1] = topGraphLine("PtLoss", skillsetColors[(#CalcDebugTypes["CalcPatternMod"] * 2) + 1], 1)
-o[#o+1] = topGraphLine("PtLoss", skillsetColors[(#CalcDebugTypes["CalcPatternMod"] * 2) + 2], 2)
+o[#o+1] = bottomGraphLineMSD("PtLoss", skillsetColors[(#CalcDebugTypes["CalcDiffValue"] * 2) + 1], 1)
+o[#o+1] = bottomGraphLineMSD("PtLoss", skillsetColors[(#CalcDebugTypes["CalcDiffValue"] * 2) + 2], 2)
 
 -- a bunch of things for stuff and things
 o[#o + 1] = LoadFont("Common Normal") .. {

--- a/Themes/Til Death/BGAnimations/_calcdisplay.lua
+++ b/Themes/Til Death/BGAnimations/_calcdisplay.lua
@@ -264,7 +264,7 @@ o[#o + 1] = Def.Quad {
         local bg = self:GetParent():GetChild("GraphTextBG")
         if isOver(self) then
             local mx = INPUTFILTER:GetMouseX()
-            local ypos = INPUTFILTER:GetMouseY() - self:GetParent():GetY()
+            local ypos = INPUTFILTER:GetMouseY() - self:GetParent():GetY() + 80
             
             local w = self:GetZoomedWidth() * self:GetParent():GetTrueZoom()
             local leftEnd = self:GetTrueX() - (self:GetHAlign() * w)

--- a/Themes/Til Death/BGAnimations/_calcdisplay.lua
+++ b/Themes/Til Death/BGAnimations/_calcdisplay.lua
@@ -145,7 +145,10 @@ local CalcDebugTypes = {
 	    "Roll",   
 	    "HS",		
 	    "Jump",   
-	    "CJ",
+        "CJ",
+        "StreamMod",
+        "OHTrill",
+        "Chaos",
     },
     CalcDiffValue =
     {
@@ -177,6 +180,7 @@ local function updateCoolStuff()
             for i = 1, #v do        -- loop through specifc mods
                 graphVecs[v[i]] = {}
                 for h = 1, 2 do     -- left/right hand loop
+                    ms.ok(v[i])
                     graphVecs[v[i]][h] = bap[k][v[i]][h]
                     if k == "CalcDiffValue" then
                         for j = 1, #graphVecs[v[i]][h] do

--- a/Themes/Til Death/BGAnimations/_calcdisplay.lua
+++ b/Themes/Til Death/BGAnimations/_calcdisplay.lua
@@ -475,7 +475,7 @@ local modColors = {
 makeskillsetlabeltext = function(i, mod, hand) 
     return LoadFont("Common Normal") .. {
         InitCommand = function(self)
-            local xspace = 22   -- this is gonna look like shit on 4:3 no matter what so w.e
+            local xspace = 20   -- this is gonna look like shit on 4:3 no matter what so w.e
             self:xy(-plotWidth/2 + 5 + ((i -1) * xspace), plotHeight/3):halign(0)
             self:zoom(0.3)
             self:settext("")

--- a/src/Etterna/Globals/CMakeLists.txt
+++ b/src/Etterna/Globals/CMakeLists.txt
@@ -1,5 +1,6 @@
 list(APPEND GLOBAL_FILES_SRC
 	"MinaCalc.cpp"
+	"MinaCalcOld.cpp"
 	"GameLoop.cpp"
 	"global.cpp"
 	"SpecialFiles.cpp"
@@ -7,6 +8,7 @@ list(APPEND GLOBAL_FILES_SRC
 
 list(APPEND GLOBAL_FILES_HPP
 	"MinaCalc.h"
+	"MinaCalcOld.h"
 	"GameLoop.h"
 	"global.h"
 	"OptionsBinding.h"

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -164,9 +164,9 @@ Calc::CalcMain(const vector<NoteInfo>& NoteInfo,
 	TotalMaxPoints();
 
 	vector<float> mcbloop(NUM_SkillsetTWO);
-	// overall and stam will be left as 0.f by this block
+	// overall and stam will be left as 0.f by this loop
 	for (int i = 0; i < NUM_SkillsetTWO; ++i)
-		mcbloop[i] = Chisel(0.1f, 10.24f, score_goal, i, false);
+		mcbloop[i] = Chisel(0.1f, 5.12f, score_goal, i, false);
 
 	// stam is based on which calc produced the highest output without it
 	size_t highest_base_skillset = std::distance(
@@ -176,7 +176,7 @@ Calc::CalcMain(const vector<NoteInfo>& NoteInfo,
 	// rerun all with stam on, optimize by starting at the non-stam adjusted
 	// base value for each skillset
 	for (int i = 0; i < NUM_SkillsetTWO; ++i)
-		mcbloop[i] = Chisel(mcbloop[i] -0.1f, 10.24f, score_goal, i, true);
+		mcbloop[i] = Chisel(mcbloop[i] - 1.28f, 0.64f, score_goal, i, true);
 
 	// stam jams, stamina should push up the base ratings for files so files
 	// that are more difficult by virtue of being twice as long for more or less

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -540,7 +540,7 @@ Calc::Chisel(float player_skill,
 			 bool debugoutput)
 {
 	float gotpoints = 0.f;
-	int possiblepoints = 0.f;
+	int possiblepoints = 0;
 	float reqpoints = static_cast<float>(MaxPoints) * score_goal;
 	for (int iter = 1; iter <= 7; iter++) {
 		do {
@@ -908,35 +908,31 @@ Calc::SetStreamMod(const vector<NoteInfo>& NoteInfo,
 				   float music_rate)
 {
 	doot[StreamMod].resize(nervIntervals.size());
-
+	vector<float> giraffeasaurus(5000);
 	float lasttime = -1.f;
 	for (size_t i = 0; i < nervIntervals.size(); i++) {
 		unsigned int taps = 0;
 		unsigned int singletaps = 0;
+		unsigned int boink = 0;
 		vector<float> whatwhat;
 		for (int row : nervIntervals[i]) {
-			bool l = NoteInfo[row].notes & 1;
-			bool d = NoteInfo[row].notes & 2;
-			bool u = NoteInfo[row].notes & 4;
-			bool r = NoteInfo[row].notes & 8;
 			unsigned int notes = column_count(NoteInfo[row].notes);
 			taps += notes;
 			if (notes == 1)
 				singletaps += notes;
 
 			float curtime = NoteInfo[row].rowTime / music_rate;
-			// push to thing i dunno what im doing with yet
-			float WOT = curtime - lasttime;
-			if (l)
-				whatwhat.push_back(WOT);
-			if (d)
-				whatwhat.push_back(WOT);
-			if (u)
-				whatwhat.push_back(WOT);
-			if (r)
-				whatwhat.push_back(WOT);
+
+			// asdlkfaskdjlf
+			for (unsigned int pajamas = 0; pajamas < notes; ++pajamas)
+				giraffeasaurus[boink + pajamas] = curtime - lasttime;
+			boink += notes;
 			lasttime = curtime;
 		}
+
+		whatwhat.resize(boink);
+		for (unsigned int n = 0; n < boink; ++n)
+			whatwhat[n] = giraffeasaurus[n];
 
 		// something something push up polyrhythms???
 		float butt = 0.f;
@@ -946,8 +942,8 @@ Calc::SetStreamMod(const vector<NoteInfo>& NoteInfo,
 		if (whatwhat.size() <= 1)
 			butt = 1.f;
 		else
-			for (auto in : whatwhat)
-				for (auto the : whatwhat)
+			for (auto& in : whatwhat)
+				for (auto& the : whatwhat)
 					if (in >= the)
 						if (in <= 3.f * the)
 							if (the * 10000.f > 0.5f)

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -26,7 +26,7 @@ fastpow(double a, double b)
 }
 
 // reasonably accurate taylor approximation for ^ 1.8
-float
+inline float
 fast_pw(float x)
 {
 	float xbar = x - 0.5f;

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -508,11 +508,13 @@ Calc::InitializeHands(const vector<NoteInfo>& NoteInfo, float music_rate)
 	SetJumpMod(NoteInfo, left_hand.doot);
 	SetCJMod(NoteInfo, left_hand.doot);
 	SetStreamMod(NoteInfo, left_hand.doot, music_rate);
+	SetFlamJamMod(NoteInfo, left_hand.doot, music_rate);
 	right_hand.doot[HS] = left_hand.doot[HS];
 	right_hand.doot[Jump] = left_hand.doot[Jump];
 	right_hand.doot[CJ] = left_hand.doot[CJ];
 	right_hand.doot[StreamMod] = left_hand.doot[StreamMod];
 	right_hand.doot[Chaos] = left_hand.doot[Chaos];
+	right_hand.doot[FlamJam] = left_hand.doot[FlamJam];
 
 	// pattern mods and base msd never change so set them immediately
 	if (debugmode) {
@@ -690,7 +692,7 @@ Hand::CalcInternal(float& gotpoints,
 				break;
 			case Stream: // vanilla, apply everything based on nps diff
 				adj_diff[i] = soap[BaseNPS][i] * doot[HS][i] * doot[Jump][i] *
-							  doot[CJ][i] * doot[Chaos][i];
+							  doot[CJ][i] * doot[Chaos][i] * doot[FlamJam][i];
 				adj_diff[i] *= basescalers[ss];
 				break;
 			case Jumpstream: // dont apply cj
@@ -916,6 +918,164 @@ Calc::SetCJMod(const vector<NoteInfo>& NoteInfo, vector<float> doot[])
 	}
 	if (SmoothPatterns)
 		Smooth(doot[CJ], 1.f);
+}
+
+// try to sniff out chords that are built as flams. BADLY NEEDS REFACTOR
+void
+Calc::SetFlamJamMod(const vector<NoteInfo>& NoteInfo,
+					vector<float> doot[],
+					float& music_rate)
+{
+	doot[FlamJam].resize(nervIntervals.size());
+	// scan for flam chords in this window
+	float grouping_tolerance = 25.f;
+	// tracks which columns were seen in the current flam chord
+	// this is essentially the same as if NoteInfo[row].notes
+	// was tracked over multiple rows
+	int cols = 0;
+	// all permutations of these values are unique identifiers
+	int col_id[4] = { 1, 2, 4, 8 };
+	// unused atm but we might want this information, allocate once
+	vector<int> flam_rows(4);
+	// timing points of the elements of the flam chord, allocate once
+	vector<float> flamjam(4);
+	// we don't actually need this counter since we can derive it from cols but
+	// it might just be faster to track it locally since we will be recycling
+	// the flamjam vector memory
+	int flam_row_counter = 0;
+	bool flamjamslamwham = false;
+	for (size_t i = 0; i < nervIntervals.size(); i++) {
+		vector<float> temp_mod;
+		for (int row : nervIntervals[i]) {
+			// perhaps we should start tracking this instead of tracking it over
+			// and over....
+			float scaled_time = NoteInfo[row].rowTime / music_rate * 1000.f;
+
+			// this can be optimized a lot by properly mapping out the notes
+			// value to arrow combinations (as it is constructed from them) and
+			// deterministic
+
+			// we are traversing intervals->rows->columns
+			for (auto& id : col_id) {
+				// check if there's a note here
+				bool isnoteatcol = NoteInfo[row].notes & id;
+				if (isnoteatcol) {
+					// we're past the tolerance range, break if we have grouped
+					// more than 1 note, or if we have filled an entire quad.
+					// with this behavior if we fill a quad of 192nd flams with
+					// order 1234 and there's still another note on 1 within the
+					// tolerance range we'll flag this as a flam chord and
+					// downscale appropriately, not sure if we want this as it
+					// could be the case that there is a second flamchord
+					// immediately after, and it's just vibro, or it could be
+					// the case that there are complex reasonable patterns
+					// following, perhaps a different behavior would be better
+
+					// we cannot exceed tolerance without at least 1 note
+					bool tol_exceed =
+					  flam_row_counter > 0 &&
+					  (scaled_time - flamjam[0]) > grouping_tolerance;
+
+					if (tol_exceed && flam_row_counter == 1) {
+						// single note, don't flag a detect
+						flamjamslamwham = false;
+
+						// reset
+						flam_row_counter = 0;
+						cols = 0;
+					}
+					if (tol_exceed && flam_row_counter > 1|| flam_row_counter == 4)
+						// at least a flam jump has been detected, flag it
+						flamjamslamwham = true;
+
+					// if we have identified a flam chord in some way; handle and
+					// reset, we don't want to skip the notes in this iteration
+					// yes this should be done in the column loop since a flam
+					// can start and end on any columns in any order
+
+					// conditions to be here are at least 2 different columns
+					// have been logged as part of a flam chord and we have
+					// exceeded the tolerance for flam duration, or we have a
+					// full quad flam detected, though not necessarily exceeding
+					// the tolerance window. we do want to reset if it doesn't,
+					// because we want to pick up vibro flams and nerf them into
+					// oblivion too, i think
+					if (flamjamslamwham) {
+						// we'll construct the final pattern mod value from the
+						// flammyness and number of detected flam chords
+						float mod_part = 0.f;
+
+						// lower means more cheesable means nerf harder
+						float fc_dur =
+						  flamjam[flam_row_counter - 1] - flamjam[0];
+
+						// we don't want to affect explicit chords, but we have
+						// to be sure that the entire flam we've picked up is an
+						// actual chord and only an actual chord, if the first
+						// and last elements detected were on the same row,
+						// ignore it, trying to do fc_dur == 0.f didn't work
+						// because of float precision
+						if (flam_rows[0] != flam_rows[flam_row_counter]) {
+							// basic linear scale for testing purposes, scaled
+							// to the window length and also flam size
+							mod_part =
+							  fc_dur / grouping_tolerance / flam_row_counter;
+							temp_mod.push_back(mod_part);
+						}
+
+						// reset
+						flam_row_counter = 0;
+						cols = 0;
+						flamjamslamwham = false;
+					}
+
+					// we know chord flams can't contain multiple notes of the
+					// same column (those are just gluts), reset if detected
+					// even within the tolerance range (we can't be outside of
+					// it here by definition)
+					if (cols & id) {
+						flamjamslamwham = false;
+
+						// reset
+						flam_row_counter = 0;
+						cols = 0;
+					}
+
+					// conditions to reach here are that a note in this column
+					// has not been logged yet and we are still within the
+					// grouping tolerance. we don't need cur/last times here,
+					// the time of the first element will be used to determine
+					// the size of the total group
+
+					// track the time point of this note
+					flamjam[flam_row_counter] = scaled_time;
+					// track which row its on
+					flam_rows[flam_row_counter] = row;
+
+					// update unique column identifier
+					cols += id;
+					++flam_row_counter;
+				}
+			}
+
+			// forgive a single instance of a chord flam for now; handle none
+			if (temp_mod.size() < 2)
+				doot[FlamJam][i] = 1.f;
+
+			float wee = 0.f;
+			for (auto& v : temp_mod)
+				wee += v;
+
+			// we can do this for now without worring about /0 since size is at
+			// least 2 to get here
+			wee /= static_cast<float>(temp_mod.size() - 1);
+
+			wee = CalcClamp(1.f - wee, 0.5f, 1.f);
+			doot[FlamJam][i] = wee;
+		}
+	}
+	if (SmoothPatterns)
+		Smooth(doot[FlamJam], 1.f);
 }
 
 void

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -180,7 +180,7 @@ static const float stam_prop =
 // since chorded patterns have lower enps than streams, streams default to 1
 // and chordstreams start lower
 // stam is a special case and may use normalizers again
-static const float basescalers[NUM_SkillsetTWO] = {
+static const float basescalers[NUM_Skillset] = {
 	0.f, 0.975f, 0.9f, 0.925f, 0.95f, 0.8f, 0.8f, 0.95f
 };
 
@@ -333,9 +333,9 @@ Calc::CalcMain(const vector<NoteInfo>& NoteInfo,
 	InitializeHands(NoteInfo, music_rate);
 	TotalMaxPoints();
 
-	vector<float> mcbloop(NUM_SkillsetTWO);
+	vector<float> mcbloop(NUM_Skillset);
 	// overall and stam will be left as 0.f by this loop
-	for (int i = 0; i < NUM_SkillsetTWO; ++i)
+	for (int i = 0; i < NUM_Skillset; ++i)
 		mcbloop[i] = Chisel(0.1f, 10.24f, score_goal, i, false);
 
 	// stam is based on which calc produced the highest output without it
@@ -345,7 +345,7 @@ Calc::CalcMain(const vector<NoteInfo>& NoteInfo,
 
 	// rerun all with stam on, optimize by starting at the non-stam adjusted
 	// base value for each skillset
-	for (int i = 0; i < NUM_SkillsetTWO; ++i)
+	for (int i = 0; i < NUM_Skillset; ++i)
 		mcbloop[i] = Chisel(mcbloop[i] - 0.64f, 1.28f, score_goal, i, true);
 
 	// stam jams, stamina should push up the base ratings for files so files
@@ -374,7 +374,7 @@ Calc::CalcMain(const vector<NoteInfo>& NoteInfo,
 	// leaderboards with charts that are just very high rated but have no
 	// stamina component
 	mcfroggerbopper = CalcClamp(mcfroggerbopper, 0.f, 1.1f);
-	mcbloop[Stamina] = 0.65f * poodle_in_a_porta_potty +
+	mcbloop[Skill_Stamina] = 0.65f * poodle_in_a_porta_potty +
 					   (mcfroggerbopper * 0.35f * poodle_in_a_porta_potty);
 
 	// yes i know how dumb this looks
@@ -642,7 +642,7 @@ Calc::Chisel(float player_skill,
 			if (player_skill > 41.f)
 				return player_skill;
 			player_skill += resolution;
-			if (ss == Overall || ss == Stamina)
+			if (ss == Skill_Overall || ss == Skill_Stamina)
 				return 0.f; // not how we set these values
 
 			// reset tallied score
@@ -695,33 +695,35 @@ Hand::CalcInternal(float& gotpoints,
 		// only slightly less cancerous than before, this can/should be
 		// refactored once the areas of redundancy are more clearly defined
 		switch (ss) {
-			case Overall: // should never be the case, handled up the stack
+			case Skill_Overall: // should never be the case, handled up the
+								// stack
 				break;
-			case Stream: // vanilla, apply everything based on nps diff
+			case Skill_Stream: // vanilla, apply everything based on nps diff
 				adj_diff[i] = soap[BaseNPS][i] * doot[HS][i] * doot[Jump][i] *
 							  doot[CJ][i] * doot[Chaos][i] * doot[FlamJam][i];
 				adj_diff[i] *= basescalers[ss];
 				break;
-			case Jumpstream: // dont apply cj
+			case Skill_Jumpstream: // dont apply cj
 				adj_diff[i] = soap[BaseNPS][i] * doot[HS][i] / doot[Jump][i];
 				adj_diff[i] *= basescalers[ss];
 				break;
-			case Handstream: // here cj counterbalances hs a bit, not good
+			case Skill_Handstream: // here cj counterbalances hs a bit, not good
 				adj_diff[i] =
 				  soap[BaseNPS][i] / max(doot[HS][i], 0.925f) * doot[Jump][i];
 				adj_diff[i] *= basescalers[ss];
 				break;
-			case Stamina: // should never be the case, handled up the stack
+			case Skill_Stamina: // should never be the case, handled up the
+								// stack
 				break;
-			case JackSpeed: // use ms hybrid base
+			case Skill_JackSpeed: // use ms hybrid base
 				adj_diff[i] = soap[BaseMSD][i] * doot[HS][i] * doot[Jump][i];
 				adj_diff[i] *= basescalers[ss];
 				break;
-			case Chordjack: // use ms hybrid base
+			case Skill_Chordjack: // use ms hybrid base
 				adj_diff[i] = soap[BaseMSD][i] / doot[CJ][i];
 				adj_diff[i] *= basescalers[ss];
 				break;
-			case Technical: // use ms hybrid base
+			case Skill_Technical: // use ms hybrid base
 				adj_diff[i] = soap[BaseMSD][i] * doot[HS][i] * doot[Jump][i] *
 							  doot[CJ][i] * doot[Chaos][i];
 				adj_diff[i] *= basescalers[ss];
@@ -736,7 +738,7 @@ Hand::CalcInternal(float& gotpoints,
 		// not entirely happy how this is handled but stam is really a special
 		// case
 		for (auto& d : adj_diff)
-			d *= basescalers[Stamina];
+			d *= basescalers[Skill_Stamina];
 		StamAdjust(x, adj_diff);
 	}
 

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -176,7 +176,7 @@ Calc::CalcMain(const vector<NoteInfo>& NoteInfo,
 	// rerun all with stam on, optimize by starting at the non-stam adjusted
 	// base value for each skillset
 	for (int i = 0; i < NUM_SkillsetTWO; ++i)
-		mcbloop[i] = Chisel(mcbloop[highest_base_skillset] -0.1f, 10.24f, score_goal, i, true);
+		mcbloop[i] = Chisel(mcbloop[i] -0.1f, 10.24f, score_goal, i, true);
 
 	// stam jams, stamina should push up the base ratings for files so files
 	// that are more difficult by virtue of being twice as long for more or less

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -131,12 +131,12 @@ highest_difficulty(const DifficultyRating& difficulty)
 
 // DON'T WANT TO RECOMPILE HALF THE GAME IF I EDIT THE HEADER FILE
 static const float finalscaler = 2.564f * 1.05f * 1.1f * 1.10f * 1.10f *
-					1.025f; // multiplier to standardize baselines
+								 1.025f; // multiplier to standardize baselines
 
 // Stamina Model params
-static const float stam_ceil = 1.0933f; // stamina multiplier max
-static const float stam_mag = 505.f;	// multiplier generation scaler
-static const float stam_fscale = 2222.f; // how fast the floor rises (it's lava)
+static const float stam_ceil = 1.0933f;  // stamina multiplier max
+static const float stam_mag = 505.f;	 // multiplier generation scaler
+static const float stam_fscale = 2000.f; // how fast the floor rises (it's lava)
 static const float stam_prop =
   0.725f; // proportion of player difficulty at which stamina tax begins
 
@@ -666,8 +666,7 @@ Hand::StamAdjust(float x, vector<float>& diff, bool debug)
 		for (size_t i = 0; i < diff.size(); i++) {
 			avs1 = avs2;
 			avs2 = diff[i];
-			float ebb = (avs1 + avs2) / 2.f;
-			mod += ((ebb / (stam_prop * x)) - 1.f) / stam_mag;
+			mod += ((((avs1 + avs2) / 2.f) / (stam_prop * x)) - 1.f) / stam_mag;
 			if (mod > 1.f)
 				floor += (mod - 1.f) / stam_fscale;
 			mod = CalcClamp(mod, floor, stam_ceil);
@@ -678,8 +677,7 @@ Hand::StamAdjust(float x, vector<float>& diff, bool debug)
 		for (size_t i = 0; i < diff.size(); i++) {
 			avs1 = avs2;
 			avs2 = diff[i];
-			float ebb = (avs1 + avs2) / 2.f;
-			mod += ((ebb / (stam_prop * x)) - 1.f) / stam_mag;
+			mod += ((((avs1 + avs2) / 2.f) / (stam_prop * x)) - 1.f) / stam_mag;
 			if (mod > 1.f)
 				floor += (mod - 1.f) / stam_fscale;
 			mod = CalcClamp(mod, floor, stam_ceil);

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <numeric>
 #include <xmmintrin.h>
+#include <cstring>
 
 using std::max;
 using std::min;

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -173,9 +173,10 @@ Calc::CalcMain(const vector<NoteInfo>& NoteInfo,
 	  mcbloop.begin(), std::max_element(mcbloop.begin(), mcbloop.end()));
 	float base = mcbloop[highest_base_skillset];
 
-	// rerun all with stam on
+	// rerun all with stam on, optimize by starting at the non-stam adjusted
+	// base value for each skillset
 	for (int i = 0; i < NUM_SkillsetTWO; ++i)
-		mcbloop[i] = Chisel(0.1f, 10.24f, score_goal, i, true);
+		mcbloop[i] = Chisel(mcbloop[highest_base_skillset] -0.1f, 10.24f, score_goal, i, true);
 
 	// stam jams, stamina should push up the base ratings for files so files
 	// that are more difficult by virtue of being twice as long for more or less

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -982,7 +982,7 @@ Calc::SetFlamJamMod(const vector<NoteInfo>& NoteInfo,
 						flam_row_counter = 0;
 						cols = 0;
 					}
-					if (tol_exceed && flam_row_counter > 1|| flam_row_counter == 4)
+					if ((tol_exceed && flam_row_counter > 1) || flam_row_counter == 4)
 						// at least a flam jump has been detected, flag it
 						flamjamslamwham = true;
 

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -188,7 +188,7 @@ Calc::CalcMain(const vector<NoteInfo>& NoteInfo,
 	vector<float> mcbloop(NUM_SkillsetTWO);
 	// overall and stam will be left as 0.f by this loop
 	for (int i = 0; i < NUM_SkillsetTWO; ++i)
-		mcbloop[i] = Chisel(0.1f, 5.12f, score_goal, i, false);
+		mcbloop[i] = Chisel(0.1f, 10.24f, score_goal, i, false);
 
 	// stam is based on which calc produced the highest output without it
 	size_t highest_base_skillset = std::distance(
@@ -198,7 +198,7 @@ Calc::CalcMain(const vector<NoteInfo>& NoteInfo,
 	// rerun all with stam on, optimize by starting at the non-stam adjusted
 	// base value for each skillset
 	for (int i = 0; i < NUM_SkillsetTWO; ++i)
-		mcbloop[i] = Chisel(mcbloop[i] - 1.28f, 0.64f, score_goal, i, true);
+		mcbloop[i] = Chisel(mcbloop[i] - 0.64f, 1.28f, score_goal, i, true);
 
 	// stam jams, stamina should push up the base ratings for files so files
 	// that are more difficult by virtue of being twice as long for more or less
@@ -483,7 +483,7 @@ Calc::ProcessFinger(const vector<NoteInfo>& NoteInfo,
 
 		if (NoteInfo[i].notes & column) {
 			AllIntervals[Interval].emplace_back(
-			  CalcClamp(1000 * (scaledtime - last), 40.f, 5000.f));
+			  CalcClamp(1000.f * (scaledtime - last), 40.f, 5000.f));
 			last = scaledtime;
 		}
 

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -45,22 +45,6 @@ fastsqrt(float _in)
 	return out;
 }
 
-// completely untested potential alternative to above
-inline float
-fastsqrt2(float _in)
-{
-	constexpr __m128 zero = { 0.0f, 0.0f, 0.0f, 0.0f };
-
-	__m128 x = _mm_load_ss(&_in); // load the float
-
-	// sqrt = rsqrt(in)*in
-	__m128 xmm1 = _mm_rsqrt_ps(x);
-	__m128 sqrt = _mm_mul_ss(xmm1, x);
-	__m128 is_zero = _mm_cmpeq_ps(zero, x);
-	// andnot to handle zero and get the float out
-	return _mm_cvtss_f32(_mm_andnot_ps(is_zero, sqrt));
-}
-
 template<typename T>
 inline T
 CalcClamp(T x, T l, T h)

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -213,8 +213,8 @@ Calc::CalcMain(const vector<NoteInfo>& NoteInfo,
 	// sets the 'proper' debug output, doesn't (shouldn't) affect actual values
 	// this is the only time debugoutput arg should be set to true
 	if (debugmode)
-		Chisel(mcbloop[highest_base_skillset] - 0.001f,
-			   10.24f,
+		Chisel(mcbloop[highest_base_skillset] - 2.56f,
+			   0.32f,
 			   score_goal,
 			   highest_base_skillset,
 			   true,

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -1010,7 +1010,7 @@ Calc::SetFlamJamMod(const vector<NoteInfo>& NoteInfo,
 						// and last elements detected were on the same row,
 						// ignore it, trying to do fc_dur == 0.f didn't work
 						// because of float precision
-						if (flam_rows[0] != flam_rows[flam_row_counter]) {
+						if (flam_rows[0] != flam_rows[flam_row_counter - 1]) {
 							// basic linear scale for testing purposes, scaled
 							// to the window length and also flam size
 							mod_part =

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -592,6 +592,19 @@ Hand::InitPoints(const Finger& f1, const Finger& f2)
 								 static_cast<int>(f2[ki_is_rising].size()));
 }
 
+
+inline void
+gratuitious_optimization_ebb(float& m, float& avs1, float& avs2, float& x)
+{
+	(((avs1 + avs2 / 2.f) / (stam_prop * x)) - 1.f) / stam_mag;
+}
+
+inline void
+gratuitious_optimization_floor(float& f, float& m)
+{
+	f += (m - 1.f) / stam_fscale;
+}
+
 void
 Hand::StamAdjust(float x, vector<float>& diff, bool debug)
 {
@@ -607,10 +620,9 @@ Hand::StamAdjust(float x, vector<float>& diff, bool debug)
 		for (size_t i = 0; i < diff.size(); i++) {
 			avs1 = avs2;
 			avs2 = diff[i];
-			float ebb = (avs1 + avs2) / 2.f;
-			mod += ((ebb / (stam_prop * x)) - 1.f) / stam_mag;
+			gratuitious_optimization_ebb(mod, avs1, avs2, x);
 			if (mod > 1.f)
-				floor += (mod - 1.f) / stam_fscale;
+				gratuitious_optimization_floor(floor, mod);
 			mod = CalcClamp(mod, floor, stam_ceil);
 			stam_adj_diff[i] = diff[i] * mod;
 			debugValues[2][StamMod][i] = mod;
@@ -619,10 +631,9 @@ Hand::StamAdjust(float x, vector<float>& diff, bool debug)
 		for (size_t i = 0; i < diff.size(); i++) {
 			avs1 = avs2;
 			avs2 = diff[i];
-			float ebb = (avs1 + avs2) / 2.f;
-			mod += ((ebb / (stam_prop * x)) - 1.f) / stam_mag;
+			gratuitious_optimization_ebb(mod, avs1, avs2, x);
 			if (mod > 1.f)
-				floor += (mod - 1.f) / stam_fscale;
+				gratuitious_optimization_floor(floor, mod);
 			mod = CalcClamp(mod, floor, stam_ceil);
 			stam_adj_diff[i] = diff[i] * mod;
 		}

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -405,6 +405,11 @@ Calc::InitializeHands(const vector<NoteInfo>& NoteInfo, float music_rate)
 	left_hand.stam_adj_diff.resize(numitv);
 	right_hand.stam_adj_diff.resize(numitv);
 
+	// at least for the moment there are a few mods we want to apply evenly
+	// to all skillset, so pre-multiply them in these after they're generated
+	left_hand.pre_multiplied_pattern_mod_group_a.resize(numitv);
+	right_hand.pre_multiplied_pattern_mod_group_a.resize(numitv);
+
 	ProcessedFingers fingers;
 	for (int i = 0; i < 4; i++)
 		fingers.emplace_back(ProcessFinger(NoteInfo, i, music_rate));
@@ -457,6 +462,18 @@ Calc::InitializeHands(const vector<NoteInfo>& NoteInfo, float music_rate)
 			right_hand.debugValues[1][i] = right_hand.soap[i];
 		}
 	}
+
+	// it's probably time to loop over hands more sensibly or
+	// do this stuff inside the class
+	for (int i = 0; i < numitv; ++i) {
+		left_hand.pre_multiplied_pattern_mod_group_a[i] =
+		  left_hand.doot[Roll][i] * left_hand.doot[OHJump][i] *
+		  left_hand.doot[Anchor][i];
+		right_hand.pre_multiplied_pattern_mod_group_a[i] =
+		  right_hand.doot[Roll][i] * right_hand.doot[OHJump][i] *
+		  right_hand.doot[Anchor][i];
+	}
+	
 
 	j0 = SequenceJack(NoteInfo, 0, music_rate);
 	j1 = SequenceJack(NoteInfo, 1, music_rate);
@@ -738,7 +755,7 @@ Hand::CalcInternal(float& gotpoints,
 		}
 
 		// we always want to apply these mods, i think
-		adj_diff[i] *= doot[Roll][i] * doot[OHJump][i] * doot[Anchor][i];
+		adj_diff[i] *= pre_multiplied_pattern_mod_group_a[i];
 	}
 
 	if (stam) {

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -651,9 +651,10 @@ Hand::CalcInternal(float x, int ss, bool stam, bool debug)
 	const vector<float>& v = stam ? stam_adj_diff : adj_diff;
 
 	if (debug) {
-		debugValues[MSD] = adj_diff;
+		
 		// final debug output should always be with stam activated
 		StamAdjust(x, adj_diff, true);
+		debugValues[MSD] = stam_adj_diff;
 	}
 
 	float output = 0.f;
@@ -664,8 +665,7 @@ Hand::CalcInternal(float x, int ss, bool stam, bool debug)
 
 		output += gainedpoints;
 		if (debug)
-			debugValues[PtLoss][i] = stam_adj_diff[i];
-			  //(static_cast<float>(v_itvpoints[i]) - gainedpoints);
+			debugValues[PtLoss][i] = (static_cast<float>(v_itvpoints[i]) - gainedpoints);
 	}
 
 	return output;

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -165,7 +165,7 @@ Calc::CalcMain(const vector<NoteInfo>& NoteInfo,
 	  0.9f + (0.1f * (NoteInfo.back().rowTime - 150.f) / 150.f), 0.9f, 1.f);
 
 	// all this garbage should be handled by pattern mods, before chisel is run
-  // ok maybe that isn't a hard and fast rule, but we should avoid it here
+	// ok maybe that isn't a hard and fast rule, but we should avoid it here
 	/*
 	float jprop = chord_proportion(NoteInfo, 2);
 	float nojumpsdownscaler =
@@ -509,7 +509,8 @@ Calc::ProcessFinger(const vector<NoteInfo>& NoteInfo,
 
 		if (NoteInfo[i].notes & column) {
 			// log all rows for this interval in pre-allocated mem
-			temp_queue[row_counter] = CalcClamp(1000.f * (scaledtime - last), 40.f, 5000.f);
+			temp_queue[row_counter] =
+			  CalcClamp(1000.f * (scaledtime - last), 40.f, 5000.f);
 			++row_counter;
 			last = scaledtime;
 		}
@@ -518,7 +519,6 @@ Calc::ProcessFinger(const vector<NoteInfo>& NoteInfo,
 			temp_queue_two[row_counter_two] = i;
 			++row_counter_two;
 		}
-			
 	}
 	return AllIntervals;
 }
@@ -707,8 +707,8 @@ Hand::CalcInternal(float& gotpoints,
 			case Overall: // should never be the case, handled up the stack
 				break;
 			case Stream: // vanilla, apply everything based on nps diff
-				adj_diff[i] =
-				  soap[BaseNPS][i] * doot[HS][i] * doot[Jump][i] * doot[CJ][i] * doot[Chaos][i];
+				adj_diff[i] = soap[BaseNPS][i] * doot[HS][i] * doot[Jump][i] *
+							  doot[CJ][i] * doot[Chaos][i];
 				adj_diff[i] *= basescalers[ss];
 				break;
 			case Jumpstream: // dont apply cj
@@ -716,8 +716,8 @@ Hand::CalcInternal(float& gotpoints,
 				adj_diff[i] *= basescalers[ss];
 				break;
 			case Handstream: // here cj counterbalances hs a bit, not good
-				adj_diff[i] = soap[BaseNPS][i] / max(doot[HS][i], 0.925f) *
-							  doot[Jump][i];
+				adj_diff[i] =
+				  soap[BaseNPS][i] / max(doot[HS][i], 0.925f) * doot[Jump][i];
 				adj_diff[i] *= basescalers[ss];
 				break;
 			case Stamina: // should never be the case, handled up the stack
@@ -727,8 +727,7 @@ Hand::CalcInternal(float& gotpoints,
 				adj_diff[i] *= basescalers[ss];
 				break;
 			case Chordjack: // use ms hybrid base
-				adj_diff[i] =
-				  soap[BaseMSD][i] / doot[CJ][i];
+				adj_diff[i] = soap[BaseMSD][i] / doot[CJ][i];
 				adj_diff[i] *= basescalers[ss];
 				break;
 			case Technical: // use ms hybrid base
@@ -777,7 +776,8 @@ Hand::CalcInternal(float& gotpoints,
 			// rounding error here, this about breaks even when calculating
 			// scores and is mostly an optimization to songload
 			if (i % 32 == 31)
-				if (MaxPoints - possiblepoints + static_cast<int>(gotpoints) <= static_cast<int>(reqpoints))
+				if (MaxPoints - possiblepoints + static_cast<int>(gotpoints) <=
+					static_cast<int>(reqpoints))
 					return;
 
 			possiblepoints += v_itvpoints[i];
@@ -904,7 +904,8 @@ Calc::SetCJMod(const vector<NoteInfo>& NoteInfo, vector<float> doot[])
 
 void
 Calc::SetStreamMod(const vector<NoteInfo>& NoteInfo,
-				   vector<float> doot[ModCount], float music_rate)
+				   vector<float> doot[ModCount],
+				   float music_rate)
 {
 	doot[StreamMod].resize(nervIntervals.size());
 
@@ -950,9 +951,11 @@ Calc::SetStreamMod(const vector<NoteInfo>& NoteInfo,
 					if (in >= the)
 						if (in <= 3.f * the)
 							if (the * 10000.f > 0.5f)
-								butt += pow(static_cast<float>(
-								  static_cast<int>(in * 10000.f + 0.5f) %
-								  static_cast<int>(10000.f * the + 0.5f)), 0.25f);
+								butt +=
+								  pow(static_cast<float>(
+										static_cast<int>(in * 10000.f + 0.5f) %
+										static_cast<int>(10000.f * the + 0.5f)),
+									  0.25f);
 
 		if (!whatwhat.empty())
 			butt /= static_cast<float>(whatwhat.size());
@@ -979,7 +982,6 @@ Calc::SetStreamMod(const vector<NoteInfo>& NoteInfo,
 		Smooth(doot[Chaos], 1.f);
 		Smooth(doot[Chaos], 1.f);
 	}
-		
 }
 
 // downscales full rolls or rolly js, it looks explicitly for consistent cross
@@ -1111,7 +1113,6 @@ Calc::SetSequentialDownscalers(const vector<NoteInfo>& NoteInfo,
 			lastcol = thiscol;
 		}
 
-
 		int cvtaps = ltaps + rtaps;
 
 		// if this is true we have some combination of single notes and
@@ -1132,7 +1133,7 @@ Calc::SetSequentialDownscalers(const vector<NoteInfo>& NoteInfo,
 			// no rolls here by definition
 			doot[Roll][i] = 1.f;
 			doot[OHTrill][i] = 1.f;
-			
+
 			continue;
 		}
 

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -1059,5 +1059,5 @@ MinaSDCalcDebug(const vector<NoteInfo>& NoteInfo,
 int
 GetCalcVersion()
 {
-	return 269;
+	return 271;
 }

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -1192,12 +1192,13 @@ Calc::SetSequentialDownscalers(const vector<NoteInfo>& NoteInfo,
 	// how that case is handled atm
 	int lastcol = -1;
 	float lasttime = 0.f;
-
+	vector<float> lr;
+	vector<float> rl;
 	for (size_t i = 0; i < nervIntervals.size(); i++) {
 		// roll downscaler stuff
 		int totaltaps = 0;
-		vector<float> lr;
-		vector<float> rl;
+		lr.clear();
+		rl.clear();
 		int ltaps = 0;
 		int rtaps = 0;
 

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -181,7 +181,7 @@ static const float stam_prop =
 // and chordstreams start lower
 // stam is a special case and may use normalizers again
 static const float basescalers[NUM_Skillset] = {
-	0.f, 0.975f, 0.9f, 0.925f, 0.95f, 0.8f, 0.8f, 0.95f
+	0.f, 0.975f, 0.9f, 0.925f, 0.f, 0.8f, 0.8f, 0.95f
 };
 
 void
@@ -734,13 +734,8 @@ Hand::CalcInternal(float& gotpoints,
 		adj_diff[i] *= pre_multiplied_pattern_mod_group_a[i];
 	}
 
-	if (stam) {
-		// not entirely happy how this is handled but stam is really a special
-		// case
-		for (auto& d : adj_diff)
-			d *= basescalers[Skill_Stamina];
+	if (stam)
 		StamAdjust(x, adj_diff);
-	}
 
 	// final difficulty values to use
 	const vector<float>& v = stam ? stam_adj_diff : adj_diff;

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -1,8 +1,8 @@
-#pragma once
 #include "MinaCalc.h"
 #include <cmath>
 #include <iostream>
 #include <algorithm>
+#include <memory>
 #include <numeric>
 
 using std::max;
@@ -12,7 +12,7 @@ using std::sqrt;
 using std::vector;
 
 template<typename T>
-inline T&
+inline T
 CalcClamp(T x, T l, T h)
 {
 	return x > h ? h : (x < l ? l : x);

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -713,13 +713,18 @@ Calc::SetAnchorMod(const vector<NoteInfo>& NoteInfo,
 				++rcol;
 		}
 		bool anyzero = lcol == 0 || rcol == 0;
+		float bort = static_cast<float>(min(lcol, rcol)) /
+						static_cast<float>(
+						  max(lcol, rcol));
+		bort = (0.3f + (1.f + (1.f / bort)) / 4.f);
+
+		// 
+		bort = CalcClamp(bort, 0.9f, 1.1f);
+
 		doot[Anchor][i] =
 		  anyzero
 			? 1.f
-			: CalcClamp(sqrt(1.1f - (static_cast<float>(min(lcol , rcol) + 0.25f) /
-								  static_cast<float>(max(lcol, rcol)) / 5.f)),
-						0.8f,
-						1.05f);
+			: bort;
 
 		fingerbias += (static_cast<float>(max(lcol, rcol)) + 2.f) /
 					  (static_cast<float>(min(lcol, rcol)) + 1.f);

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -347,7 +347,7 @@ Calc::CalcMain(const vector<NoteInfo>& NoteInfo,
 		  4.5f - difficulty.technical + difficulty.jumpstream, 0.f, 4.5f);
 	}
 
-	
+	
 	 */
 
 	difficulty.overall = highest_difficulty(difficulty);
@@ -804,7 +804,7 @@ Calc::SetCJMod(const vector<NoteInfo>& NoteInfo, vector<float> doot[])
 
 		doot[CJ][i] =
 		  CalcClamp(sqrt(sqrt(1.f - (static_cast<float>(chordtaps) /
-								   static_cast<float>(taps) / 3.f))),
+									 static_cast<float>(taps) / 3.f))),
 					0.5f,
 					1.f);
 	}
@@ -821,7 +821,7 @@ Calc::SetStreamMod(const vector<NoteInfo>& NoteInfo,
 	for (size_t i = 0; i < nervIntervals.size(); i++) {
 		unsigned int taps = 0;
 		unsigned int singletaps = 0;
-		
+
 		for (int row : nervIntervals[i]) {
 			unsigned int notes = column_count(NoteInfo[row].notes);
 			taps += notes;
@@ -834,7 +834,8 @@ Calc::SetStreamMod(const vector<NoteInfo>& NoteInfo,
 			continue;
 		}
 
-		doot[StreamMod][i] = CalcClamp(sqrt(sqrt(1.f - (static_cast<float>(singletaps) /
+		doot[StreamMod][i] =
+		  CalcClamp(sqrt(sqrt(1.f - (static_cast<float>(singletaps) /
 									 static_cast<float>(taps) / 3.f))),
 					0.5f,
 					1.f);
@@ -884,6 +885,9 @@ Calc::SetSequentialDownscalers(const vector<NoteInfo>& NoteInfo,
 		int maxseqjumptaps = 0; // basically the biggest sequence of ohj
 		float ohj = 0.f;
 
+		// BEWOOP
+		vector<float> whatwhat;
+
 		for (int row : nervIntervals[i]) {
 			bool lcol = NoteInfo[row].notes & t1;
 			bool rcol = NoteInfo[row].notes & t2;
@@ -904,6 +908,10 @@ Calc::SetSequentialDownscalers(const vector<NoteInfo>& NoteInfo,
 					else
 						lastcol = 1;
 
+				// dunno what im doing with this yet
+				if (!lastcol == -1)
+					whatwhat.push_back(curtime - lasttime);
+
 				// yes we want to set this for jumps
 				lasttime = curtime;
 
@@ -913,8 +921,11 @@ Calc::SetSequentialDownscalers(const vector<NoteInfo>& NoteInfo,
 
 				// set the largest ohj sequence
 				maxseqjumptaps = max(maxseqjumptaps, jumptaps);
+
 				continue;
 			}
+			// push to thing i dunno what im doing with yet
+			whatwhat.push_back(curtime - lasttime);
 
 			int thiscol = lcol < rcol;
 			if (thiscol != lastcol) { // ignore consecutive notes
@@ -970,6 +981,21 @@ Calc::SetSequentialDownscalers(const vector<NoteInfo>& NoteInfo,
 
 			lastcol = thiscol;
 		}
+
+		// something something push up polyrhythms???
+		float butt = 0.f;
+		std::sort(whatwhat.begin(), whatwhat.end());
+		if (whatwhat.size() <= 1)
+			butt = 1.f;
+		else
+			for (auto in : whatwhat)
+				for (auto the : whatwhat)
+					butt += static_cast<float>(static_cast<int>(in * 1000.f) %
+							static_cast<int>(1000.f * the));
+
+		if (!whatwhat.empty())
+			butt /= static_cast<float>(whatwhat.size()) * 1000.f;
+
 		int cvtaps = ltaps + rtaps;
 
 		// if this is true we have some combination of single notes and
@@ -990,7 +1016,7 @@ Calc::SetSequentialDownscalers(const vector<NoteInfo>& NoteInfo,
 			// no rolls here by definition
 			doot[Roll][i] = 1.f;
 			doot[OHTrill][i] = 1.f;
-			doot[Chaos][i] = 1.f;
+			doot[Chaos][i] = butt;
 			continue;
 		}
 
@@ -1027,7 +1053,7 @@ Calc::SetSequentialDownscalers(const vector<NoteInfo>& NoteInfo,
 			}
 			yes_trills = cv - notrills; // store high oh trill detection in case
 										// we want to do stuff with it later
-			cv += notrills * 1.f; // just straight up add to cv
+			cv += notrills * 1.f;		// just straight up add to cv
 		}
 
 		// then scaled against how many taps we ignored
@@ -1041,7 +1067,7 @@ Calc::SetSequentialDownscalers(const vector<NoteInfo>& NoteInfo,
 		// probably)
 		doot[Roll][i] = CalcClamp(0.5f + sqrt(cv), 0.5f, 1.f);
 		doot[OHTrill][i] = CalcClamp(0.5f + sqrt(cv), 0.8f, 1.f);
-		doot[Chaos][i] = 1.f;
+		doot[Chaos][i] = butt;
 
 		// ohj stuff, wip
 		if (jumptaps < 1 && maxseqjumptaps < 1)

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -951,11 +951,9 @@ Calc::SetStreamMod(const vector<NoteInfo>& NoteInfo,
 					if (in >= the)
 						if (in <= 3.f * the)
 							if (the * 10000.f > 0.5f)
-								butt +=
-								  pow(static_cast<float>(
-										static_cast<int>(in * 10000.f + 0.5f) %
-										static_cast<int>(10000.f * the + 0.5f)),
-									  0.25f);
+								butt += sqrt(sqrt(static_cast<float>(
+								  static_cast<int>(in * 10000.f + 0.5f) %
+								  static_cast<int>(10000.f * the + 0.5f))));
 
 		if (!whatwhat.empty())
 			butt /= static_cast<float>(whatwhat.size());

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -392,11 +392,21 @@ Calc::InitializeHands(const vector<NoteInfo>& NoteInfo, float music_rate)
 	right_hand.doot[CJ] = left_hand.doot[CJ];
 
 	// pattern mods and base msd never change so set them immediately
-	if (debugmode)
-		for (size_t i = 0; i < 9; ++i) {
+	if (debugmode) {
+		for (size_t i = 0; i < ModCount; ++i) {
 			left_hand.debugValues[i] = left_hand.doot[i];
 			right_hand.debugValues[i] = right_hand.doot[i];
 		}
+		// uhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh yea
+		// somehow i never did this and debug was still getting the
+		// somewhat right values... somehow??
+		left_hand.debugValues[BaseNPS] = left_hand.v_itvNPSdiff;
+		left_hand.debugValues[BaseMS] = left_hand.pureMSdiff;
+		left_hand.debugValues[BaseMSD] = left_hand.v_itvMSdiff;
+		right_hand.debugValues[BaseNPS] = right_hand.v_itvNPSdiff;
+		right_hand.debugValues[BaseMS] = right_hand.pureMSdiff;
+		right_hand.debugValues[BaseMSD] = right_hand.v_itvMSdiff;
+	}
 
 	j0 = SequenceJack(NoteInfo, 0, music_rate);
 	j1 = SequenceJack(NoteInfo, 1, music_rate);
@@ -523,11 +533,9 @@ Hand::InitDiff(Finger& f1, Finger& f2)
 void
 Hand::InitPoints(const Finger& f1, const Finger& f2)
 {
-	v_itvpoints.resize(f1.size());
 	for (size_t ki_is_rising = 0; ki_is_rising < f1.size(); ++ki_is_rising)
-		v_itvpoints[ki_is_rising] =
-		  static_cast<int>(f1[ki_is_rising].size()) +
-		  static_cast<int>(f2[ki_is_rising].size());
+		v_itvpoints.emplace_back(static_cast<int>(f1[ki_is_rising].size()) +
+								   static_cast<int>(f2[ki_is_rising].size()));
 }
 
 void
@@ -1024,5 +1032,5 @@ MinaSDCalcDebug(const vector<NoteInfo>& NoteInfo,
 int
 GetCalcVersion()
 {
-	return 267;
+	return 269;
 }

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -434,6 +434,7 @@ Calc::InitializeHands(const vector<NoteInfo>& NoteInfo, float music_rate)
 	right_hand.doot[Jump] = left_hand.doot[Jump];
 	right_hand.doot[CJ] = left_hand.doot[CJ];
 	right_hand.doot[StreamMod] = left_hand.doot[StreamMod];
+	right_hand.doot[Chaos] = left_hand.doot[Chaos];
 
 	// pattern mods and base msd never change so set them immediately
 	if (debugmode) {
@@ -521,7 +522,7 @@ Calc::Chisel(float player_skill,
 				return 0.f; // not how we set these values
 
 			// jack sequencer point loss for jack speed and (maybe?) cj
-			if (ss == JackSpeed || ss == Chordjack || Technical)
+			if (ss == JackSpeed || ss == Chordjack )
 				gotpoints = MaxPoints - JackLoss(j0, player_skill) -
 							JackLoss(j1, player_skill) -
 							JackLoss(j2, player_skill) -
@@ -632,13 +633,12 @@ Hand::CalcInternal(float x, int ss, bool stam, bool debug)
 				adj_diff[i] *= basescalers[ss];
 				break;
 			case Jumpstream: // dont apply cj
-				adj_diff[i] = soap[BaseNPS][i] * doot[HS][i] / doot[Jump][i] *
-							  doot[StreamMod][i];
+				adj_diff[i] = soap[BaseNPS][i] * doot[HS][i] / doot[Jump][i];
 				adj_diff[i] *= basescalers[ss];
 				break;
 			case Handstream: // here cj counterbalances hs a bit, not good
 				adj_diff[i] = soap[BaseNPS][i] / max(doot[HS][i], 0.925f) *
-							  doot[Jump][i] * doot[StreamMod][i];
+							  doot[Jump][i];
 				adj_diff[i] *= basescalers[ss];
 				break;
 			case Stamina: // should never be the case, handled up the stack
@@ -649,7 +649,7 @@ Hand::CalcInternal(float x, int ss, bool stam, bool debug)
 				break;
 			case Chordjack: // use ms hybrid base
 				adj_diff[i] =
-				  soap[BaseMSD][i] / doot[CJ][i] * doot[StreamMod][i];
+				  soap[BaseMSD][i] / doot[CJ][i];
 				adj_diff[i] *= basescalers[ss];
 				break;
 			case Technical: // use ms hybrid base

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -607,19 +607,6 @@ Hand::InitPoints(const Finger& f1, const Finger& f2)
 								 static_cast<int>(f2[ki_is_rising].size()));
 }
 
-
-inline void
-gratuitious_optimization_ebb(float& m, float& avs1, float& avs2, float& x)
-{
-	(((avs1 + avs2 / 2.f) / (stam_prop * x)) - 1.f) / stam_mag;
-}
-
-inline void
-gratuitious_optimization_floor(float& f, float& m)
-{
-	f += (m - 1.f) / stam_fscale;
-}
-
 void
 Hand::StamAdjust(float x, vector<float>& diff, bool debug)
 {
@@ -635,9 +622,10 @@ Hand::StamAdjust(float x, vector<float>& diff, bool debug)
 		for (size_t i = 0; i < diff.size(); i++) {
 			avs1 = avs2;
 			avs2 = diff[i];
-			gratuitious_optimization_ebb(mod, avs1, avs2, x);
+			float ebb = (avs1 + avs2) / 2.f;
+			mod += ((ebb / (stam_prop * x)) - 1.f) / stam_mag;
 			if (mod > 1.f)
-				gratuitious_optimization_floor(floor, mod);
+				floor += (mod - 1.f) / stam_fscale;
 			mod = CalcClamp(mod, floor, stam_ceil);
 			stam_adj_diff[i] = diff[i] * mod;
 			debugValues[2][StamMod][i] = mod;
@@ -646,9 +634,10 @@ Hand::StamAdjust(float x, vector<float>& diff, bool debug)
 		for (size_t i = 0; i < diff.size(); i++) {
 			avs1 = avs2;
 			avs2 = diff[i];
-			gratuitious_optimization_ebb(mod, avs1, avs2, x);
+			float ebb = (avs1 + avs2) / 2.f;
+			mod += ((ebb / (stam_prop * x)) - 1.f) / stam_mag;
 			if (mod > 1.f)
-				gratuitious_optimization_floor(floor, mod);
+				floor += (mod - 1.f) / stam_fscale;
 			mod = CalcClamp(mod, floor, stam_ceil);
 			stam_adj_diff[i] = diff[i] * mod;
 		}

--- a/src/Etterna/Globals/MinaCalc.cpp
+++ b/src/Etterna/Globals/MinaCalc.cpp
@@ -12,7 +12,7 @@ using std::sqrt;
 using std::vector;
 
 template<typename T>
-T
+inline T&
 CalcClamp(T x, T l, T h)
 {
 	return x > h ? h : (x < l ? l : x);
@@ -88,7 +88,7 @@ AggregateScores(const vector<float>& skillsets, float rating, float resolution)
 	return rating + 2.f * resolution;
 }
 
-unsigned int
+inline unsigned int
 column_count(unsigned int note)
 {
 	return note % 2 + note / 2 % 2 + note / 4 % 2 + note / 8 % 2;
@@ -119,7 +119,7 @@ skillset_vector(const DifficultyRating& difficulty)
 						  difficulty.chordjack,  difficulty.technical };
 }
 
-float
+inline float
 highest_difficulty(const DifficultyRating& difficulty)
 {
 	auto v = { difficulty.stream,	 difficulty.jumpstream,
@@ -130,14 +130,14 @@ highest_difficulty(const DifficultyRating& difficulty)
 }
 
 // DON'T WANT TO RECOMPILE HALF THE GAME IF I EDIT THE HEADER FILE
-float finalscaler = 2.564f * 1.05f * 1.1f * 1.10f * 1.10f *
+static const float finalscaler = 2.564f * 1.05f * 1.1f * 1.10f * 1.10f *
 					1.025f; // multiplier to standardize baselines
 
 // Stamina Model params
-const float stam_ceil = 1.0933f;	 // stamina multiplier max
-const float stam_mag = 505.f;	 // multiplier generation scaler
-const float stam_fscale = 2222.f; // how fast the floor rises (it's lava)
-const float stam_prop =
+static const float stam_ceil = 1.0933f; // stamina multiplier max
+static const float stam_mag = 505.f;	// multiplier generation scaler
+static const float stam_fscale = 2222.f; // how fast the floor rises (it's lava)
+static const float stam_prop =
   0.725f; // proportion of player difficulty at which stamina tax begins
 
 // since we are no longer using the normalizer system we need to lower
@@ -146,8 +146,9 @@ const float stam_prop =
 // since chorded patterns have lower enps than streams, streams default to 1
 // and chordstreams start lower
 // stam is a special case and may use normalizers again
-const float basescalers[NUM_SkillsetTWO] = { 0.f,   0.975f, 0.9f, 0.925f,
-											 0.95f, 0.8f, 0.8f, 0.95f };
+static const float basescalers[NUM_SkillsetTWO] = {
+	0.f, 0.975f, 0.9f, 0.925f, 0.95f, 0.8f, 0.8f, 0.95f
+};
 
 vector<float>
 Calc::CalcMain(const vector<NoteInfo>& NoteInfo,

--- a/src/Etterna/Globals/MinaCalc.h
+++ b/src/Etterna/Globals/MinaCalc.h
@@ -74,7 +74,10 @@ class Hand
 	scoring to assert the average of the distribution of point gain for each
 	interval and then tallies up the result to produce an average total number
 	of points achieved by this hand. */
-	float CalcInternal(float x, int ss, bool stam, bool debug = false);
+	float CalcInternal(float x,
+					   int ss,
+					   bool stam,
+					   bool debug = false);
 
 	std::vector<float> doot[5];
 	std::vector<int> v_itvpoints; // Point allotment for each interval
@@ -109,7 +112,7 @@ class Hand
 	// since chorded patterns have lower enps than streams, streams default to 1
 	// and chordstreams start lower
 	// stam is a special case and may use normalizers again
-	const float basescalers[NUM_SkillsetTWO] = { 0.f,   1.f, 0.9f, 0.9f,
+	const float basescalers[NUM_SkillsetTWO] = { 0.f,   1.f, 0.9f, 0.925f,
 											  0.85f, 1.f, 0.9f, 1.f };
 };
 

--- a/src/Etterna/Globals/MinaCalc.h
+++ b/src/Etterna/Globals/MinaCalc.h
@@ -77,10 +77,7 @@ class Hand
 	scoring to assert the average of the distribution of point gain for each
 	interval and then tallies up the result to produce an average total number
 	of points achieved by this hand. */
-	float CalcInternal(float x,
-					   int ss,
-					   bool stam,
-					   bool debug = false);
+	void CalcInternal(float& gotpoints, float x, int ss, bool stam, bool debug = false);
 
 	std::vector<float> doot[ModCount];
 	std::vector<int> v_itvpoints; // Point allotment for each interval

--- a/src/Etterna/Globals/MinaCalc.h
+++ b/src/Etterna/Globals/MinaCalc.h
@@ -151,7 +151,7 @@ class Calc
 				 bool debugoutput = false);
 
 	void SetStreamMod(const std::vector<NoteInfo>& NoteInfo,
-					 std::vector<float> doot[ModCount]);
+					 std::vector<float> doot[ModCount], float music_rate);
 
 	void SetAnchorMod(const std::vector<NoteInfo>& NoteInfo,
 									unsigned int t1,

--- a/src/Etterna/Globals/MinaCalc.h
+++ b/src/Etterna/Globals/MinaCalc.h
@@ -34,7 +34,10 @@ typedef std::vector<Finger> ProcessedFingers;
 typedef std::vector<float> JackSeq;
 
 // number of pattern mods yes i know this is dumb help
-const static int ModCount = 6;
+// we want to group stamina adjustment with the others for
+// display purposes but we don't want it when initializing pattern arrays
+// because it doesn't get generated until after we're done
+const static int ModCount = NUM_CalcPatternMod;
 
 /*	The difficulties of each hand tend to be independent from one another. This
 is not absolute, as in the case of polyrhythm trilling. However the goal of the
@@ -81,8 +84,7 @@ class Hand
 
 	std::vector<float> doot[ModCount];
 	std::vector<int> v_itvpoints; // Point allotment for each interval
-	std::vector<float> v_itvNPSdiff,
-	  v_itvMSdiff, pureMSdiff; // Calculated difficulty for each interval
+	std::vector<float> soap[NUM_CalcDiffValue]; // Calculated difficulty for each interval
 
 	// pattern adjusted difficulty, allocate only once
 	std::vector<float> adj_diff;

--- a/src/Etterna/Globals/MinaCalc.h
+++ b/src/Etterna/Globals/MinaCalc.h
@@ -100,11 +100,11 @@ class Hand
 						1.025f; // multiplier to standardize baselines
 
 	// Stamina Model params
-	const float ceil = 1.09f;	// stamina multiplier max
-	const float mag = 355.f;	 // multiplier generation scaler
-	const float fscale = 2500.f; // how fast the floor rises (it's lava)
+	const float ceil = 1.15f;	// stamina multiplier max
+	const float mag = 365.f;	 // multiplier generation scaler
+	const float fscale = 2222.f; // how fast the floor rises (it's lava)
 	const float prop =
-	  0.75f; // proportion of player difficulty at which stamina tax begins
+	  0.7f; // proportion of player difficulty at which stamina tax begins
 
 	// since we are no longer using the normalizer system we need to lower
 	// the base difficulty for each skillset and then detect pattern types
@@ -113,7 +113,7 @@ class Hand
 	// and chordstreams start lower
 	// stam is a special case and may use normalizers again
 	const float basescalers[NUM_SkillsetTWO] = { 0.f,   1.f, 0.9f, 0.925f,
-											  0.85f, 1.f, 0.9f, 1.f };
+											  0.1f, 1.f, 0.9f, 1.f };
 };
 
 class Calc

--- a/src/Etterna/Globals/MinaCalc.h
+++ b/src/Etterna/Globals/MinaCalc.h
@@ -79,7 +79,7 @@ class Hand
 					   bool stam,
 					   bool debug = false);
 
-	std::vector<float> doot[5];
+	std::vector<float> doot[ModCount];
 	std::vector<int> v_itvpoints; // Point allotment for each interval
 	std::vector<float> v_itvNPSdiff,
 	  v_itvMSdiff, pureMSdiff; // Calculated difficulty for each interval

--- a/src/Etterna/Globals/MinaCalc.h
+++ b/src/Etterna/Globals/MinaCalc.h
@@ -100,8 +100,8 @@ class Hand
 						1.025f; // multiplier to standardize baselines
 
 	// Stamina Model params
-	const float ceil = 1.15f;	// stamina multiplier max
-	const float mag = 365.f;	 // multiplier generation scaler
+	const float ceil = 1.1f;	// stamina multiplier max
+	const float mag = 465.f;	 // multiplier generation scaler
 	const float fscale = 2222.f; // how fast the floor rises (it's lava)
 	const float prop =
 	  0.7f; // proportion of player difficulty at which stamina tax begins
@@ -113,7 +113,7 @@ class Hand
 	// and chordstreams start lower
 	// stam is a special case and may use normalizers again
 	const float basescalers[NUM_SkillsetTWO] = { 0.f,   1.f, 0.9f, 0.925f,
-											  0.1f, 1.f, 0.9f, 1.f };
+											  0.95f, 1.f, 0.9f, 0.8f };
 };
 
 class Calc

--- a/src/Etterna/Globals/MinaCalc.h
+++ b/src/Etterna/Globals/MinaCalc.h
@@ -150,6 +150,9 @@ class Calc
 				 bool stamina,
 				 bool debugoutput = false);
 
+	void SetStreamMod(const std::vector<NoteInfo>& NoteInfo,
+					 std::vector<float> doot[ModCount]);
+
 	void SetAnchorMod(const std::vector<NoteInfo>& NoteInfo,
 									unsigned int t1,
 									unsigned int t2,

--- a/src/Etterna/Globals/MinaCalc.h
+++ b/src/Etterna/Globals/MinaCalc.h
@@ -92,7 +92,7 @@ class Hand
 	// on the above, and it needs to be recalculated every time the player_skill
 	// value changes, again based on the above
 	std::vector<float> stam_adj_diff;
-	std::vector<std::vector<float>> debugValues;
+	std::vector<std::vector<std::vector<float>>> debugValues;
 
   private:
 	const bool SmoothDifficulty =
@@ -220,6 +220,6 @@ MINACALC_API void
 MinaSDCalcDebug(const std::vector<NoteInfo>& NoteInfo,
 				float musicrate,
 				float goal,
-				std::vector<std::vector<std::vector<float>>>& handInfo);
+				std::vector<std::vector<std::vector<std::vector<float>>>>& handInfo);
 MINACALC_API int
 GetCalcVersion();

--- a/src/Etterna/Globals/MinaCalc.h
+++ b/src/Etterna/Globals/MinaCalc.h
@@ -2,22 +2,6 @@
 #include "Etterna/Models/NoteData/NoteDataStructures.h"
 #include <vector>
 
-// YEAH WHATEVER I HATE THIS DONT WANT TO DEAL WITH REDEFS AND SHIT
-enum SkillsetTWO
-{
-	Overall,
-	Stream,
-	Jumpstream,
-	Handstream,
-	Stamina,
-	JackSpeed,
-	Chordjack,
-	Technical,
-	NUM_SkillsetTWO,
-	garbagegamegarbagecodegarbagemina,
-};
-
-
 // For internal, must be preprocessor defined
 #if defined(MINADLL_COMPILE) && defined(_WIN32)
 #define MINACALC_API __declspec(dllexport)

--- a/src/Etterna/Globals/MinaCalc.h
+++ b/src/Etterna/Globals/MinaCalc.h
@@ -77,7 +77,16 @@ class Hand
 	scoring to assert the average of the distribution of point gain for each
 	interval and then tallies up the result to produce an average total number
 	of points achieved by this hand. */
-	void CalcInternal(float& gotpoints, float x, int ss, bool stam, bool debug = false);
+	// return value is true if a player can no longer reach scoregoal even if
+	// they get 100% of the remaining points
+	void CalcInternal(float& gotpoints,
+					  int& maxpoints,
+					  int& possiblepoints,
+					  float& reqpoints,
+					  float& x,
+					  int ss,
+					  bool stam,
+					  bool debug = false);
 
 	std::vector<float> doot[ModCount];
 	std::vector<int> v_itvpoints; // Point allotment for each interval
@@ -133,7 +142,7 @@ class Calc
 						 float music_rate);
 
 	// Derivative calc params
-	float MaxPoints = 0.f; // Total points achievable in the file
+	int MaxPoints = 0; // Total points achievable in the file
 	void TotalMaxPoints(); // Counts up the total points and assigns it
 
 	/*	Returns estimate of player skill needed to achieve score goal on chart.

--- a/src/Etterna/Globals/MinaCalc.h
+++ b/src/Etterna/Globals/MinaCalc.h
@@ -92,6 +92,9 @@ class Hand
 	std::vector<int> v_itvpoints; // Point allotment for each interval
 	std::vector<float> soap[NUM_CalcDiffValue]; // Calculated difficulty for each interval
 
+
+	// self extraplanetary
+	std::vector<float> pre_multiplied_pattern_mod_group_a;
 	// pattern adjusted difficulty, allocate only once
 	std::vector<float> adj_diff;
 	// pattern adjusted difficulty, allocate only once, stam needs to be based

--- a/src/Etterna/Globals/MinaCalc.h
+++ b/src/Etterna/Globals/MinaCalc.h
@@ -80,9 +80,6 @@ class Hand
 	// return value is true if a player can no longer reach scoregoal even if
 	// they get 100% of the remaining points
 	void CalcInternal(float& gotpoints,
-					  int& maxpoints,
-					  int& possiblepoints,
-					  float& reqpoints,
 					  float& x,
 					  int ss,
 					  bool stam,

--- a/src/Etterna/Globals/MinaCalc.h
+++ b/src/Etterna/Globals/MinaCalc.h
@@ -159,6 +159,11 @@ class Calc
 				 bool stamina,
 				 bool debugoutput = false);
 
+	// nerf psuedo chords that are flams into oblivion
+	void SetFlamJamMod(const std::vector<NoteInfo>& NoteInfo,
+					   std::vector<float> doot[],
+					   float& music_rate);
+
 	void SetStreamMod(const std::vector<NoteInfo>& NoteInfo,
 					 std::vector<float> doot[ModCount], float music_rate);
 

--- a/src/Etterna/Globals/MinaCalc.h
+++ b/src/Etterna/Globals/MinaCalc.h
@@ -97,25 +97,6 @@ class Hand
   private:
 	const bool SmoothDifficulty =
 	  true; // Do we moving average the difficulty intervals?
-
-	float finalscaler = 2.564f * 1.05f * 1.1f * 1.10f * 1.10f *
-						1.025f; // multiplier to standardize baselines
-
-	// Stamina Model params
-	const float ceil = 1.1f;	// stamina multiplier max
-	const float mag = 465.f;	 // multiplier generation scaler
-	const float fscale = 2222.f; // how fast the floor rises (it's lava)
-	const float prop =
-	  0.7f; // proportion of player difficulty at which stamina tax begins
-
-	// since we are no longer using the normalizer system we need to lower
-	// the base difficulty for each skillset and then detect pattern types
-	// to push down OR up, rather than just down and normalizing to a differential
-	// since chorded patterns have lower enps than streams, streams default to 1
-	// and chordstreams start lower
-	// stam is a special case and may use normalizers again
-	const float basescalers[NUM_SkillsetTWO] = { 0.f,   1.f, 0.9f, 0.925f,
-											  0.95f, 1.f, 0.9f, 0.8f };
 };
 
 class Calc

--- a/src/Etterna/Globals/MinaCalcOld.cpp
+++ b/src/Etterna/Globals/MinaCalcOld.cpp
@@ -1,0 +1,1132 @@
+// MinaCalc.cpp : Defines the exported functions for the DLL application.
+//
+
+#include "Etterna/Globals/MinaCalcOld.h"
+#include <iostream>
+#include <algorithm>
+#include <thread>
+#include <future>
+#include <mutex>
+#include <cmath>
+#include <fstream>
+
+using namespace std;
+
+#define SAFE_DELETE(p)                                                         \
+	{                                                                          \
+		delete p;                                                              \
+		p = NULL;                                                              \
+	}
+
+template<typename T, typename U>
+inline U
+lerp(T x, U l, U h)
+{
+	return static_cast<U>(x * (h - l) + l);
+}
+
+template<typename T, typename U, typename V>
+inline void
+CalcClamp(T& x, U l, V h)
+{
+	if (x > static_cast<T>(h))
+		x = static_cast<T>(h);
+	else if (x < static_cast<T>(l))
+		x = static_cast<T>(l);
+}
+
+inline float
+mean(vector<float>& v)
+{
+	float sum = 0.f;
+	for (size_t i = 0; i < v.size(); ++i)
+		sum += v[i];
+
+	return sum / v.size();
+}
+
+// Coefficient of variance
+inline float
+cv(vector<float>& v)
+{
+	float sum = 0.f;
+	float mean;
+	float sd = 0.f;
+
+	for (size_t i = 0; i < v.size(); i++)
+		sum += v[i];
+
+	mean = sum / v.size();
+	for (size_t i = 0; i < v.size(); i++)
+		sd += pow(v[i] - mean, 2);
+
+	return sqrt(sd / v.size()) / mean;
+}
+
+inline float
+downscalebaddies(float& f, float sg)
+{
+	CalcClamp(f, 0.f, 100.f);
+	if (sg >= 0.93f)
+		return f;
+	float o = f * 1 - sqrt(0.93f - sg);
+	CalcClamp(f, 0.f, 100.f);
+	return o;
+}
+
+// Specifically for pattern modifiers as the neutral value is 1
+inline void
+PatternSmooth(vector<float>& v)
+{
+	float f1 = 1.f;
+	float f2 = 1.f;
+	float f3 = 1.f;
+	float total = 3.f;
+
+	for (size_t i = 0; i < v.size(); i++) {
+		total -= f1;
+		f1 = f2;
+		f2 = f3;
+		f3 = v[i];
+		total += f3;
+		v[i] = (f1 + f2 + f3) / 3;
+	}
+}
+
+inline void
+DifficultySmooth(vector<float>& v)
+{
+	float f1 = 0.f;
+	float f2 = 0.f;
+	float f3 = 0.f;
+	float total = 0.f;
+
+	for (size_t i = 0; i < v.size(); i++) {
+		total -= f1;
+		f1 = f2;
+		f2 = f3;
+		f3 = v[i];
+		total += f3;
+		v[i] = (f1 + f2 + f3) / 3;
+	}
+}
+
+inline void
+DifficultyMSSmooth(vector<float>& v)
+{
+	float f1 = 0.f;
+	float f2 = 0.f;
+
+	for (size_t i = 0; i < v.size(); i++) {
+		f1 = f2;
+		f2 = v[i];
+		v[i] = (f1 + f2) / 2.f;
+	}
+}
+
+inline float
+AggregateScores(vector<float>& invector, float rating, float res, int iter)
+{
+	float sum;
+	do {
+		rating += res;
+		sum = 0.0f;
+		for (int i = 0; i < static_cast<int>(invector.size()); i++) {
+			sum += 2.f / erfc(0.5f * (invector[i] - rating)) - 1.f;
+		}
+	} while (3 < sum);
+	if (iter == 11)
+		return rating;
+	return AggregateScores(invector, rating - res, res / 2.f, iter + 1);
+}
+
+float
+normalizer(float x, float y, float z1, float z2)
+{
+	float norm = ((x / y) - 1.f) * z1;
+	CalcClamp(norm, 0.f, 1.f);
+	float o = x * z2 * norm + x * (1.f - z2);
+	return o;
+}
+
+float
+jumpprop(const vector<NoteInfo>& NoteInfo)
+{
+	int left = 1;
+	int down = 1 << 1;
+	int up = 1 << 2;
+	int right = 1 << 3;
+
+	int taps = 0;
+	int jamps = 0;
+
+	for (size_t r = 0; r < NoteInfo.size(); r++) {
+		int notes = (NoteInfo[r].notes & left ? 1 : 0) +
+					(NoteInfo[r].notes & down ? 1 : 0) +
+					(NoteInfo[r].notes & up ? 1 : 0) +
+					(NoteInfo[r].notes & right ? 1 : 0);
+		taps += notes;
+		if (notes == 2)
+			jamps += notes;
+	}
+
+	return static_cast<float>(jamps) / static_cast<float>(taps);
+}
+
+float
+handprop(const vector<NoteInfo>& NoteInfo)
+{
+	int left = 1;
+	int down = 1 << 1;
+	int up = 1 << 2;
+	int right = 1 << 3;
+
+	int taps = 0;
+	int hands = 0;
+
+	for (size_t r = 0; r < NoteInfo.size(); r++) {
+		int notes = (NoteInfo[r].notes & left ? 1 : 0) +
+					(NoteInfo[r].notes & down ? 1 : 0) +
+					(NoteInfo[r].notes & up ? 1 : 0) +
+					(NoteInfo[r].notes & right ? 1 : 0);
+		taps += notes;
+		if (notes == 3)
+			hands += notes;
+	}
+
+	return static_cast<float>(hands) / static_cast<float>(taps);
+}
+
+float
+notcj(const vector<NoteInfo>& NoteInfo)
+{
+	int left = 1;
+	int down = 1 << 1;
+	int up = 1 << 2;
+	int right = 1 << 3;
+
+	int taps = 0;
+	int hands = 0;
+	int lcol = 0;
+	int lnotes = 0;
+	for (size_t r = 0; r < NoteInfo.size(); r++) {
+		int lefty = NoteInfo[r].notes & left ? 1 : 0;
+		int downy = NoteInfo[r].notes & down ? 1 : 0;
+		int upy = NoteInfo[r].notes & up ? 1 : 0;
+		int righty = NoteInfo[r].notes & right ? 1 : 0;
+
+		int notes = lefty + downy + upy + righty;
+		int tcol = 0;
+		if (notes == 1) {
+			if (lefty)
+				tcol = left;
+			if (downy)
+				tcol = down;
+			if (upy)
+				tcol = up;
+			if (righty)
+				tcol = right;
+
+			if (tcol != lcol && (lnotes == 3 || lnotes == 2))
+				taps += 1;
+		}
+
+		if ((notes == 3 || notes == 2) && lnotes == 1) {
+			if (lefty && lcol == left)
+				taps -= 1;
+			if (downy && lcol == down)
+				taps -= 1;
+			if (upy && lcol == up)
+				taps -= 1;
+			if (righty && lcol == right)
+				taps -= 1;
+			taps += 1;
+		}
+
+		taps += notes;
+		if (notes == 3)
+			hands += notes;
+
+		lnotes = notes;
+		if (lefty)
+			lcol = left;
+		if (downy)
+			lcol = down;
+		if (upy)
+			lcol = up;
+		if (righty)
+			lcol = right;
+	}
+
+	return static_cast<float>(hands) / static_cast<float>(taps);
+}
+
+float
+quadprop(const vector<NoteInfo>& NoteInfo)
+{
+	int left = 1;
+	int down = 1 << 1;
+	int up = 1 << 2;
+	int right = 1 << 3;
+
+	int taps = 0;
+	int quads = 0;
+
+	for (size_t r = 0; r < NoteInfo.size(); r++) {
+		int notes = (NoteInfo[r].notes & left ? 1 : 0) +
+					(NoteInfo[r].notes & down ? 1 : 0) +
+					(NoteInfo[r].notes & up ? 1 : 0) +
+					(NoteInfo[r].notes & right ? 1 : 0);
+		taps += notes;
+		if (notes == 4)
+			quads += notes;
+	}
+
+	return static_cast<float>(quads) / static_cast<float>(taps);
+}
+
+vector<float>
+Calc_OLD::CalcMain(const vector<NoteInfo>& NoteInfo,
+			   float timingscale,
+			   float score_goal)
+{
+	// LOG->Trace("%f", etaner.back());
+	float grindscaler =
+	  0.93f + (0.07f * (NoteInfo.back().rowTime - 30.f) / 30.f);
+	CalcClamp(grindscaler, 0.93f, 1.f);
+
+	float grindscaler2 =
+	  0.873f + (0.13f * (NoteInfo.back().rowTime - 15.f) / 15.f);
+	CalcClamp(grindscaler2, 0.87f, 1.f);
+
+	float shortstamdownscaler =
+	  0.9f + (0.1f * (NoteInfo.back().rowTime - 150.f) / 150.f);
+	CalcClamp(shortstamdownscaler, 0.9f, 1.f);
+
+	float jprop = jumpprop(NoteInfo);
+	float nojumpsdownscaler = 0.8f + (0.2f * (jprop + 0.5f));
+	CalcClamp(nojumpsdownscaler, 0.8f, 1.f);
+
+	float hprop = handprop(NoteInfo);
+
+	float nohandsdownscaler = 0.8f + (0.2f * (hprop + 0.75f));
+	CalcClamp(nohandsdownscaler, 0.8f, 1.f);
+
+	float allhandsdownscaler = 1.23f - hprop;
+	CalcClamp(allhandsdownscaler, 0.85f, 1.f);
+
+	float manyjampdownscaler = 1.43f - jprop;
+	CalcClamp(manyjampdownscaler, 0.85f, 1.f);
+
+	float qprop = quadprop(NoteInfo);
+	float lotquaddownscaler = 1.13f - qprop;
+	CalcClamp(lotquaddownscaler, 0.85f, 1.f);
+
+	float jumpthrill = 1.625f - jprop - hprop;
+	CalcClamp(jumpthrill, 0.85f, 1.f);
+
+	vector<float> o;
+	o.reserve(8);
+
+	InitializeHands(NoteInfo, timingscale);
+	TotalMaxPoints();
+	float stream =
+	  Chisel(0.1f, 10.24f, 1, false, false, true, false, false);
+	float js = Chisel(0.1f, 10.24f, 1, false, false, true, true, false);
+	float hs = Chisel(0.1f, 10.24f, 1, false, false, true, false, true);
+	float tech =
+	  Chisel(0.1f, 10.24f, 1, false, false, false, false, false);
+	float jack =
+	  Chisel(0.1f, 10.24f, 1, false, true, true, false, false);
+	float jackstam =
+	  jack;
+
+	float techbase = max(stream, jack);
+	float techorig = tech;
+	tech = (tech / techbase) * tech;
+	CalcClamp(tech, techorig * 0.85f, techorig);
+
+	float stam = 0.f;
+	if (stream > tech || js > tech || hs > tech)
+		if (stream > js && stream > hs)
+			stam = Chisel(
+			  stream - 0.1f, 2.56f, 1, true, false, true, false, false);
+		else if (js > hs)
+			stam = Chisel(
+			  js - 0.1f, 2.56f, 1, true, false, true, true, false);
+		else
+			stam = Chisel(
+			  hs - 0.1f, 2.56f, 1, true, false, true, false, true);
+	else
+		stam = Chisel(
+		  tech - 0.1f, 2.56f, 1, true, false, false, false, false);
+
+	o.emplace_back(0.f); // temp
+	o.emplace_back(downscalebaddies(stream, Scoregoal));
+
+	js = normalizer(js, stream, 7.25f, 0.25f);
+	o.emplace_back(downscalebaddies(js, Scoregoal));
+	hs = normalizer(hs, stream, 6.5f, 0.3f);
+	hs = normalizer(hs, js, 11.5f, 0.15f);
+	o.emplace_back(downscalebaddies(hs, Scoregoal));
+
+	float stambase = max(max(stream, tech * 0.96f), max(js, hs));
+	if (stambase == stream)
+		stambase *= 0.975f;
+
+	stam = normalizer(stam, stambase, 7.75f, 0.2f);
+	o.emplace_back(downscalebaddies(stam, Scoregoal));
+
+	o.emplace_back(downscalebaddies(jack, Scoregoal));
+	jackstam = normalizer(jackstam, jack, 5.5f, 0.25f);
+	o.emplace_back(downscalebaddies(jackstam, Scoregoal));
+	float technorm = max(max(stream, js), hs);
+	tech = normalizer(tech, technorm, 8.f, .15f) * techscaler;
+	o.emplace_back(downscalebaddies(tech, Scoregoal));
+
+	float definitelycj = qprop + hprop + jprop + 0.2f;
+	CalcClamp(definitelycj, 0.5f, 1.f);
+
+	// chordjack
+	float cj = o[3];
+
+	o[1] *= allhandsdownscaler * manyjampdownscaler * lotquaddownscaler;
+	o[2] *= nojumpsdownscaler * allhandsdownscaler * lotquaddownscaler;
+	o[3] *= nohandsdownscaler * allhandsdownscaler * 1.015f *
+			manyjampdownscaler * lotquaddownscaler;
+	o[4] *= shortstamdownscaler * 0.985f * lotquaddownscaler;
+
+	cj = normalizer(cj, o[3], 5.5f, 0.3f) * definitelycj * 1.025f;
+
+	bool iscj = cj > o[5];
+	if (iscj)
+		o[6] = cj;
+
+	o[7] *= allhandsdownscaler * manyjampdownscaler * lotquaddownscaler * 1.01f;
+
+	float stamclamp = max(max(o[1], o[5]), max(o[2], o[3]));
+	CalcClamp(o[4], 1.f, stamclamp * 1.1f);
+
+	dumbvalue = (dumbvalue / static_cast<float>(dumbcounter));
+	float stupidvalue = 1.f - (dumbvalue - 2.55f);
+	CalcClamp(stupidvalue, 0.85f, 1.f);
+	o[7] *= stupidvalue;
+
+	if (stupidvalue <= 0.95f) {
+		o[5] *= 1.f + (1.f - sqrt(stupidvalue));
+	}
+
+	float skadoot = max(o[3], o[2]);
+	if (o[1] < skadoot)
+		o[1] -= sqrt(skadoot - o[1]);
+
+	float overall = AggregateScores(o, 0.f, 10.24f, 1);
+	o[0] = downscalebaddies(overall, Scoregoal);
+
+	float aDvg = mean(o) * 1.2f;
+	for (size_t i = 0; i < o.size(); i++) {
+		if (i == 1 || i == 2 || i == 7) {
+			CalcClamp(o[i], 0.f, aDvg * 1.0416f);
+			o[i] *= grindscaler * grindscaler2;
+		} else {
+			CalcClamp(o[i], 0.f, aDvg);
+			o[i] *= grindscaler * grindscaler2;
+		}
+		o[i] = downscalebaddies(o[i], Scoregoal);
+	}
+
+	o[2] *= jumpthrill;
+	o[3] *= jumpthrill;
+	o[4] *= sqrt(jumpthrill) * 0.996f;
+	o[7] *= sqrt(jumpthrill);
+
+	float highest = 0.f;
+	for (auto v : o) {
+		if (v > highest)
+			highest = v;
+	}
+	o[0] = AggregateScores(o, 0.f, 10.24f, 1);
+	;
+
+	float dating = 0.5f + (highest / 100.f);
+	CalcClamp(dating, 0.f, 0.9f);
+
+	if (Scoregoal < dating) {
+		for (size_t i = 0; i < o.size(); i++) {
+			o[i] = 0.f;
+		}
+	}
+
+	o[5] *= 1.0075f;
+
+	float hsnottech = o[7] - o[3];
+	float jsnottech = o[7] - o[2];
+
+	if (highest == o[7]) {
+		hsnottech = 4.5f - hsnottech;
+		CalcClamp(hsnottech, 0.f, 4.5f);
+		o[7] -= hsnottech;
+
+		jsnottech = 4.5f - jsnottech;
+		CalcClamp(jsnottech, 0.f, 4.5f);
+		o[7] -= jsnottech;
+	}
+
+	o[7] *= 1.025f;
+	if (!iscj)
+		o[6] *= 0.9f;
+
+	highest = 0.f;
+	o[0] = 0.f;
+	for (auto v : o) {
+		if (v > highest)
+			highest = v;
+	}
+	o[0] = highest;
+
+	return o;
+}
+
+// ugly jack stuff
+vector<float>
+Calc_OLD::JackStamAdjust(vector<float>& j, float x, bool jackstam)
+{
+	vector<float> o(j.size());
+	float floor = 1.f;
+	float mod = 1.f;
+	float ceil = 1.15f;
+	float fscale = 1750.f;
+	float prop = 0.75f;
+	float mag = 250.f;
+	float multstam = 1.f;
+	if (jackstam) {
+		multstam = 1.f;
+		prop = 0.55f;
+		ceil = 1.5f;
+		fscale = 1550.f;
+		mag = 750.f;
+	}
+
+	for (size_t i = 0; i < j.size(); i++) {
+		mod += ((j[i] * multstam / (prop * x)) - 1) / mag;
+		if (mod > 1.f)
+			floor += (mod - 1) / fscale;
+		CalcClamp(mod, 1.f, ceil * sqrt(floor));
+		o[i] = j[i] * mod;
+	}
+	return o;
+}
+
+float
+Calc_OLD::JackLoss(vector<float>& j, float x, bool jackstam)
+{
+	const vector<float>& v = JackStamAdjust(j, x, jackstam);
+	float o = 0.f;
+	for (size_t i = 0; i < v.size(); i++) {
+		if (x < v[i])
+			o += 7.f - (7.f * pow(x / (v[i] * 0.96f), 1.5f));
+	}
+	CalcClamp(o, 0.f, 10000.f);
+	return o;
+}
+
+JackSeq
+Calc_OLD::SequenceJack(const vector<NoteInfo>& NoteInfo, int t)
+{
+	vector<float> o;
+	float last = -5.f;
+	float mats1 = 0.f;
+	float mats2 = 0.f;
+	float mats3 = 0.f;
+	float timestamp = 0.f;
+	int track = 1 << t;
+
+	for (size_t i = 0; i < NoteInfo.size(); i++) {
+		float scaledtime = NoteInfo[i].rowTime / MusicRate;
+		if (NoteInfo[i].notes & track) {
+			mats1 = mats2;
+			mats2 = mats3;
+			mats3 = 1000.f * (scaledtime - last);
+			last = scaledtime;
+			timestamp = (mats1 + mats2 + mats3) / 3.f;
+
+			CalcClamp(timestamp, 25.f, mats3 * 1.4f);
+			float tmp = 1 / timestamp * 2800.f;
+			CalcClamp(tmp, 0.f, 50.f);
+			o.emplace_back(tmp);
+		}
+	}
+	return o;
+}
+
+int
+Calc_OLD::fastwalk(const vector<NoteInfo>& NoteInfo)
+{
+	int Interval = 0;
+	for (size_t i = 0; i < NoteInfo.size(); i++) {
+		if (NoteInfo[i].rowTime / MusicRate >= Interval * IntervalSpan)
+			++Interval;
+	}
+	return Interval;
+}
+
+void
+Calc_OLD::InitializeHands(const vector<NoteInfo>& NoteInfo, float ts)
+{
+	numitv = fastwalk(NoteInfo);
+
+	ProcessedFingers l;
+	ProcessedFingers r;
+	for (int i = 0; i < 4; i++) {
+		if (i <= numTracks / 2 - 1)
+			l.emplace_back(ProcessFinger(NoteInfo, i));
+		else
+			r.emplace_back(ProcessFinger(NoteInfo, i));
+	}
+
+	left_hand.InitHand(l[0], l[1], ts);
+	left_hand.ohjumpscale = OHJumpDownscaler(NoteInfo, 0, 1);
+	left_hand.anchorscale = Anchorscaler(NoteInfo, 0, 1);
+	left_hand.rollscale = RollDownscaler(l[0], l[1]);
+	left_hand.hsscale = HSDownscaler(NoteInfo);
+	left_hand.jumpscale = JumpDownscaler(NoteInfo);
+
+	right_hand.InitHand(r[0], r[1], ts);
+	right_hand.ohjumpscale = OHJumpDownscaler(NoteInfo, 2, 3);
+	right_hand.anchorscale = Anchorscaler(NoteInfo, 2, 3);
+	right_hand.rollscale = RollDownscaler(r[0], r[1]);
+	right_hand.hsscale = left_hand.hsscale;
+	right_hand.jumpscale = left_hand.jumpscale;
+
+	j0 = SequenceJack(NoteInfo, 0);
+	j1 = SequenceJack(NoteInfo, 1);
+	j2 = SequenceJack(NoteInfo, 2);
+	j3 = SequenceJack(NoteInfo, 3);
+
+	vector<Finger> ltmp;
+	vector<Finger> rtmp;
+	l.swap(ltmp);
+	r.swap(rtmp);
+
+	l.shrink_to_fit();
+	r.shrink_to_fit();
+}
+
+Finger
+Calc_OLD::ProcessFinger(const vector<NoteInfo>& NoteInfo, int t)
+{
+	int Interval = 1;
+	float last = -5.f;
+	Finger AllIntervals(numitv);
+	vector<float> CurrentInterval;
+	float Timestamp;
+	vector<int> itvnervtmp;
+	vector<vector<int>> itvnerv(numitv);
+
+	int left = 1;
+	int down = 1 << 1;
+	int up = 1 << 2;
+	int right = 1 << 3;
+
+	int column = 1 << t;
+	for (size_t i = 0; i < NoteInfo.size(); i++) {
+		float scaledtime = NoteInfo[i].rowTime / MusicRate;
+
+		if (scaledtime >= Interval * IntervalSpan) {
+			AllIntervals[Interval - 1] = CurrentInterval;
+			CurrentInterval.clear();
+
+			itvnerv[Interval - 1] = itvnervtmp;
+			itvnervtmp.clear();
+			++Interval;
+		}
+
+		if (NoteInfo[i].notes & column) {
+			Timestamp = 1000 * (scaledtime - last);
+			last = scaledtime;
+			CalcClamp(Timestamp, 40.f, 5000.f);
+			CurrentInterval.emplace_back(Timestamp);
+		}
+
+		if (t == 0 && (NoteInfo[i].notes & left || NoteInfo[i].notes & down ||
+					   NoteInfo[i].notes & up || NoteInfo[i].notes & right)) {
+			itvnervtmp.emplace_back(i);
+		}
+	}
+
+	if (t == 0)
+		nervIntervals = itvnerv;
+	return AllIntervals;
+}
+
+void
+Calc_OLD::TotalMaxPoints()
+{
+	for (size_t i = 0; i < left_hand.v_itvpoints.size(); i++)
+		MaxPoints +=
+		  static_cast<int>(left_hand.v_itvpoints[i] + right_hand.v_itvpoints[i]);
+}
+
+float
+Calc_OLD::Chisel(float pskill,
+			 float res,
+			 int iter,
+			 bool stam,
+			 bool jack,
+			 bool nps,
+			 bool js,
+			 bool hs)
+{
+	float gotpoints = 0.f;
+	do {
+		if (pskill > 100.f)
+			return pskill;
+		pskill += res;
+		if (jack) {
+			{
+				gotpoints = MaxPoints;
+				gotpoints -=
+				  JackLoss(j0, pskill, false) + JackLoss(j1, pskill, false) +
+				  JackLoss(j2, pskill, false) + JackLoss(j3, pskill, false);
+			}
+		} else
+			gotpoints = left_hand.CalcInternal(pskill, stam, nps, js, hs) +
+						right_hand.CalcInternal(pskill, stam, nps, js, hs);
+
+	} while (gotpoints / MaxPoints < Scoregoal);
+	if (iter == 7)
+		return pskill;
+	return Chisel(
+	  pskill - res, res / 2.f, iter + 1, stam, jack, nps, js, hs);
+}
+
+// Hand stuff
+void
+Hand_OLD::InitHand(Finger& f1, Finger& f2, float ts)
+{
+	SetTimingScale(ts);
+	InitDiff(f1, f2);
+	InitPoints(f1, f2);
+}
+
+float
+Hand_OLD::CalcMSEstimate(vector<float>& v)
+{
+	if (v.empty())
+		return 0.f;
+
+	sort(v.begin(), v.end());
+	float m = 0;
+	v[0] *= 1.066f;
+	size_t End = min(v.size(), static_cast<size_t>(6));
+	for (size_t i = 0; i < End; i++)
+		m += v[i];
+	return 1 / (m / (End)) * 1375;
+}
+
+void
+Hand_OLD::InitDiff(Finger& f1, Finger& f2)
+{
+	vector<float> tmpNPS(f1.size());
+	vector<float> tmpMS(f1.size());
+
+	for (size_t i = 0; i < f1.size(); i++) {
+		float nps = 1.6f * static_cast<float>(f1[i].size() +
+											  f2[i].size()); // intervalspan
+		float aa = CalcMSEstimate(f1[i]);
+		float bb = CalcMSEstimate(f2[i]);
+		float ms = max(aa, bb);
+		tmpNPS[i] = finalscaler * nps;
+		tmpMS[i] =
+		  finalscaler * (ms + ms + ms + ms + ms + nps + nps + nps + nps) / 9.f;
+	}
+	if (SmoothDifficulty)
+		DifficultyMSSmooth(tmpMS);
+
+	DifficultySmooth(tmpNPS);
+	v_itvNPSdiff = tmpNPS;
+	v_itvMSdiff = tmpMS;
+}
+
+void
+Hand_OLD::InitPoints(Finger& f1, Finger& f2)
+{
+	for (size_t i = 0; i < f1.size(); i++)
+		v_itvpoints.emplace_back(static_cast<int>(f1[i].size()) +
+								 static_cast<int>(f2[i].size()));
+}
+
+vector<float>
+Hand_OLD::StamAdjust(float x, vector<float> diff)
+{
+	vector<float> o(diff.size());
+	float floor = 1.f; // stamina multiplier min (increases as chart advances)
+	float mod = 1.f;   // mutliplier
+
+	float avs1 = 0.f;
+	float avs2 = 0.f;
+
+	for (size_t i = 0; i < diff.size(); i++) {
+		avs1 = avs2;
+		avs2 = diff[i];
+		float ebb = (avs1 + avs2) / 2;
+		mod += ((ebb / (prop * x)) - 1) / mag;
+		if (mod > 1.f)
+			floor += (mod - 1) / fscale;
+		CalcClamp(mod, floor, ceil);
+		o[i] = diff[i] * mod;
+	}
+	return o;
+}
+
+float
+Hand_OLD::CalcInternal(float x, bool stam, bool nps, bool js, bool hs)
+{
+	vector<float> diff;
+
+	if (nps)
+		diff = v_itvNPSdiff;
+	else
+		diff = v_itvMSdiff;
+
+	for (size_t i = 0; i < diff.size(); ++i) {
+		if (hs)
+			diff[i] = diff[i] * anchorscale[i] * sqrt(ohjumpscale[i]) *
+					  rollscale[i] * jumpscale[i];
+		else if (js)
+			diff[i] = diff[i] * pow(hsscale[i], 2) * anchorscale[i] *
+					  sqrt(ohjumpscale[i]) * rollscale[i] * jumpscale[i];
+		else if (nps)
+			diff[i] = diff[i] * pow(hsscale[i], 3) * anchorscale[i] *
+					  pow(ohjumpscale[i], 2) * rollscale[i] *
+					  pow(jumpscale[i], 2);
+		else
+			diff[i] =
+			  diff[i] * anchorscale[i] * sqrt(ohjumpscale[i]) * rollscale[i];
+	}
+
+	const vector<float>& v = stam ? StamAdjust(x, diff) : diff;
+	finalMSDvals = v; // bad bad bad bad bad bad bad bad bad bad
+	float output = 0.f;
+	std::vector<float> pointloss;
+	for (size_t i = 0; i < v.size(); i++) {
+		float gainedpoints = x > v[i]
+							   ? v_itvpoints[i]
+							   : v_itvpoints[i] * pow(x / v[i], 1.8f);
+
+		output += gainedpoints;
+		pointloss.push_back(v_itvpoints[i] - gainedpoints);
+	}
+	pointslost = pointloss; // to the bone
+	return output;
+}
+
+// pattern modifiers
+vector<float>
+Calc_OLD::OHJumpDownscaler(const vector<NoteInfo>& NoteInfo, int t1, int t2)
+{
+	vector<float> o(nervIntervals.size());
+	int firstNote = 1 << t1;
+	int secondNote = 1 << t2;
+
+	for (size_t i = 0; i < nervIntervals.size(); i++) {
+		if (nervIntervals[i].empty())
+			o[i] = 1.f;
+		else {
+			int taps = 0;
+			int jumptaps = 0;
+			for (size_t r = 0; r < nervIntervals[i].size(); r++) {
+				int row = nervIntervals[i][r];
+				if (NoteInfo[row].notes & firstNote) {
+					++taps;
+					if (NoteInfo[row].notes & secondNote) {
+						jumptaps += 2;
+						++taps;
+					}
+				}
+			}
+			o[i] = taps != 0 ? pow(1 - (static_cast<float>(jumptaps) /
+										static_cast<float>(taps) / 2.5f),
+								   0.25f)
+							 : 1.f;
+
+			if (logpatterns)
+				cout << "ohj " << o[i] << endl;
+		}
+	}
+
+	if (SmoothPatterns)
+		PatternSmooth(o);
+	return o;
+}
+
+// pattern modifiers
+vector<float>
+Calc_OLD::Anchorscaler(const vector<NoteInfo>& NoteInfo, int t1, int t2)
+{
+	vector<float> o(nervIntervals.size());
+	int firstNote = 1 << t1;
+	int secondNote = 1 << t2;
+
+	for (size_t i = 0; i < nervIntervals.size(); i++) {
+		if (nervIntervals[i].empty())
+			o[i] = 1.f;
+		else {
+			int lcol = 0;
+			int rcol = 0;
+			for (size_t r = 0; r < nervIntervals[i].size(); r++) {
+				int row = nervIntervals[i][r];
+				if (NoteInfo[row].notes & firstNote)
+					++lcol;
+				if (NoteInfo[row].notes & secondNote)
+					++rcol;
+			}
+			bool anyzero = lcol == 0 || rcol == 0;
+			o[i] = anyzero
+					 ? 1.f
+					 : sqrt(1 - (static_cast<float>(min(lcol, rcol)) /
+								 static_cast<float>(max(lcol, rcol)) / 4.45f));
+
+			float stupidthing = (static_cast<float>(max(lcol, rcol)) + 2.f) /
+								(static_cast<float>(min(lcol, rcol)) + 1.f);
+			dumbvalue += stupidthing;
+			++dumbcounter;
+
+			CalcClamp(o[i], 0.8f, 1.05f);
+
+			if (logpatterns)
+				cout << "an " << o[i] << endl;
+		}
+	}
+
+	if (SmoothPatterns)
+		PatternSmooth(o);
+	return o;
+}
+
+vector<float>
+Calc_OLD::HSDownscaler(const vector<NoteInfo>& NoteInfo)
+{
+	vector<float> o(nervIntervals.size());
+	int left = 1;
+	int down = 1 << 1;
+	int up = 1 << 2;
+	int right = 1 << 3;
+
+	for (size_t i = 0; i < nervIntervals.size(); i++) {
+		if (nervIntervals[i].empty())
+			o[i] = 1.f;
+		else {
+			int taps = 0;
+			int handtaps = 0;
+			for (size_t r = 0; r < nervIntervals[i].size(); r++) {
+				int row = nervIntervals[i][r];
+				int notes = (NoteInfo[row].notes & left ? 1 : 0) +
+							(NoteInfo[row].notes & down ? 1 : 0) +
+							(NoteInfo[row].notes & up ? 1 : 0) +
+							(NoteInfo[row].notes & right ? 1 : 0);
+				taps += notes;
+				if (notes == 3)
+					handtaps += notes;
+			}
+			o[i] = taps != 0 ? sqrt(sqrt(1 - (static_cast<float>(handtaps) /
+											  static_cast<float>(taps) / 3.f)))
+							 : 1.f;
+
+			if (logpatterns)
+				cout << "hs " << o[i] << endl;
+		}
+	}
+
+	if (SmoothPatterns)
+		PatternSmooth(o);
+	return o;
+}
+
+vector<float>
+Calc_OLD::JumpDownscaler(const vector<NoteInfo>& NoteInfo)
+{
+	vector<float> o(nervIntervals.size());
+	int left = 1;
+	int down = 1 << 1;
+	int up = 1 << 2;
+	int right = 1 << 3;
+
+	for (size_t i = 0; i < nervIntervals.size(); i++) {
+		if (nervIntervals[i].empty())
+			o[i] = 1.f;
+		else {
+			int taps = 0;
+			int jamps = 0;
+			for (size_t r = 0; r < nervIntervals[i].size(); r++) {
+				int row = nervIntervals[i][r];
+				int notes = (NoteInfo[row].notes & left ? 1 : 0) +
+							(NoteInfo[row].notes & down ? 1 : 0) +
+							(NoteInfo[row].notes & up ? 1 : 0) +
+							(NoteInfo[row].notes & right ? 1 : 0);
+				taps += notes;
+				if (notes == 2)
+					jamps += notes;
+			}
+			o[i] = taps != 0 ? sqrt(sqrt(1 - (static_cast<float>(jamps) /
+											  static_cast<float>(taps) / 6.f)))
+							 : 1.f;
+
+			if (logpatterns)
+				cout << "ju " << o[i] << endl;
+		}
+	}
+	if (SmoothPatterns)
+		PatternSmooth(o);
+	return o;
+}
+
+vector<float>
+Calc_OLD::RollDownscaler(Finger f1, Finger f2)
+{
+	vector<float> o(f1.size());
+	for (size_t i = 0; i < f1.size(); i++) {
+		if (f1[i].empty() && f2[i].empty())
+			o[i] = 1.f;
+		else {
+			vector<float> cvint;
+			for (size_t ii = 0; ii < f1[i].size(); ii++)
+				cvint.emplace_back(f1[i][ii]);
+			for (size_t ii = 0; ii < f2[i].size(); ii++)
+				cvint.emplace_back(f2[i][ii]);
+
+			float mmm = mean(cvint);
+
+			for (size_t i = 0; i < cvint.size(); ++i)
+				cvint[i] = mmm / cvint[i] < 0.6f ? mmm : cvint[i];
+
+			if (cvint.size() == 1) {
+				o[i] = 1.f;
+				continue;
+			}
+
+			float dacv = cv(cvint);
+			if (dacv >= 0.15)
+				o[i] = sqrt(sqrt(0.85f + dacv));
+			else
+				o[i] = pow(0.85f + dacv, 3);
+			CalcClamp(o[i], 0.f, 1.075f);
+
+			if (logpatterns)
+				cout << "ro " << o[i] << endl;
+		}
+	}
+
+	if (SmoothPatterns)
+		PatternSmooth(o);
+
+	return o;
+}
+
+void
+Calc_OLD::Purge()
+{
+	vector<float> tmp1;
+	vector<float> tmp2;
+	vector<float> tmp3;
+	vector<float> tmp4;
+
+	j0.swap(tmp1);
+	j1.swap(tmp2);
+	j2.swap(tmp3);
+	j3.swap(tmp4);
+
+	j0.shrink_to_fit();
+	j1.shrink_to_fit();
+	j2.shrink_to_fit();
+	j3.shrink_to_fit();
+
+	vector<float> l1;
+	vector<float> l2;
+	vector<float> l3;
+	vector<float> l4;
+	vector<float> l5;
+
+	left_hand.ohjumpscale.swap(l1);
+	left_hand.anchorscale.swap(l2);
+	left_hand.rollscale.swap(l3);
+	left_hand.hsscale.swap(l4);
+	left_hand.jumpscale.swap(l5);
+
+	left_hand.ohjumpscale.shrink_to_fit();
+	left_hand.anchorscale.shrink_to_fit();
+	left_hand.rollscale.shrink_to_fit();
+	left_hand.hsscale.shrink_to_fit();
+	left_hand.jumpscale.shrink_to_fit();
+
+	vector<float> r1;
+	vector<float> r2;
+	vector<float> r3;
+	vector<float> r4;
+	vector<float> r5;
+
+	right_hand.ohjumpscale.swap(l1);
+	right_hand.anchorscale.swap(l2);
+	right_hand.rollscale.swap(l3);
+	right_hand.hsscale.swap(l4);
+	right_hand.jumpscale.swap(l5);
+
+	right_hand.ohjumpscale.shrink_to_fit();
+	right_hand.anchorscale.shrink_to_fit();
+	right_hand.rollscale.shrink_to_fit();
+	right_hand.hsscale.shrink_to_fit();
+	right_hand.jumpscale.shrink_to_fit();
+}
+
+static const float ssrcap = 0.965f; // cap SSR at 96% so things don't get out of hand YES WE ACTUALLY NEED THIS FFS
+
+// Function to generate SSR rating
+vector<float>
+MinaSDCalc_OLD(const vector<NoteInfo>& NoteInfo,
+		   float musicrate,
+		   float goal)
+{
+	vector<float> o;
+
+	unique_ptr<Calc_OLD> doot = make_unique<Calc_OLD>();
+	doot->MusicRate = musicrate;
+	CalcClamp(
+	  goal, 0.f, ssrcap);
+	doot->Scoregoal = goal;
+	o = doot->CalcMain(NoteInfo, musicrate, min(goal, ssrcap));
+
+	doot->Purge();
+
+	return o;
+}
+
+// Wrap difficulty calculation for all standard rates
+MinaSD
+MinaSDCalc_OLD(const vector<NoteInfo>& NoteInfo)
+{
+
+	MinaSD allrates;
+
+	int rateCount = 21;
+
+	if (!NoteInfo.empty()) {
+		for (int i = 7; i < rateCount; i++) {
+			auto tempVal =
+				MinaSDCalc_OLD(NoteInfo, i / 10.f, 0.93f);
+			allrates.emplace_back(tempVal);
+		}
+	} else {
+		vector<float> o{ 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f, 0.f };
+
+		for (int i = 7; i < rateCount; i++) {
+			allrates.emplace_back(o);
+		}
+	}
+	return allrates;
+}
+
+int
+GetCalcVersion_OLD()
+{
+	return 263;
+}

--- a/src/Etterna/Globals/MinaCalcOld.h
+++ b/src/Etterna/Globals/MinaCalcOld.h
@@ -86,7 +86,7 @@ class Hand_OLD
 	float jumpstreamscaler = 0.975f;
 	float handstreamscaler = 0.92f;
 	float finalscaler = 2.564f * 1.05f * 1.1f * 1.10f * 1.10f *
-						1.025; // multiplier to standardize baselines
+						1.025f; // multiplier to standardize baselines
 
 	// Stamina Model params
 	const float ceil = 1.08f;	// stamina multiplier max

--- a/src/Etterna/Globals/MinaCalcOld.h
+++ b/src/Etterna/Globals/MinaCalcOld.h
@@ -1,0 +1,205 @@
+#pragma once
+#include "Etterna/Models/NoteData/NoteDataStructures.h"
+#include <vector>
+
+// EXISTS FOR AUTOMATED COMPARISONS AGAINST THE NEW CALC ONLY
+
+// For internal, must be preprocessor defined
+#if defined(MINADLL_COMPILE) && defined(_WIN32)
+#define MINACALC_API __declspec(dllexport)
+#endif
+
+// For Stepmania
+#ifndef MINACALC_API_OLD
+#define MINACALC_API_OLD
+#endif
+
+  typedef std::vector<float>
+	SDiffs;
+typedef std::vector<SDiffs> MinaSD;
+
+typedef std::vector<std::vector<float>> Finger;
+typedef std::vector<Finger> ProcessedFingers;
+typedef std::vector<float> JackSeq;
+
+/*	The difficulties of each hand tend to be independent from one another. This
+is not absolute, as in the case of polyrhythm trilling. However the goal of the
+calculator is to estimate the difficulty of a file given the physical properties
+of such, and not to evalute the difficulty of reading (which is much less
+quantifiable). It is both less accurate and logically incorrect to attempt to
+assert a single difficulty for both hands for a given interval of time in a
+file, so most of the internal calculator operations are done after splitting up
+each track of the chart into their respective phalangeal parents. */
+class Hand_OLD
+{
+  public:
+	/*	Spits out a rough estimate of difficulty based on the ms values within
+	the interval The std::vector passed to it is the std::vector of ms values within each
+	interval, and not the full std::vector of intervals. */
+	float CalcMSEstimate(std::vector<float>& v);
+
+	// Wraps the three prepatory functions below
+	void InitHand(Finger& f1, Finger& f2, float ts);
+
+	/*	Averages nps and ms estimates for difficulty to get a rough initial
+	value. This is relatively robust as patterns that get overrated by nps
+	estimates are underrated by ms estimates, and vice versa. Pattern modifiers
+	are used to adjust for circumstances in which this is not true. The result
+	is output to v_itvdiff. */
+	void InitDiff(Finger& f1, Finger& f2);
+
+	// Totals up the points available for each interval
+	void InitPoints(Finger& f1, Finger& f2);
+
+	// Self explanatory
+	void SetTimingScale(float ts) { timingscale = ts; }
+
+	/*	The stamina model works by asserting a minimum difficulty relative to
+	the supplied player skill level for which the player's stamina begins to
+	wane. Experience in both gameplay and algorithm testing has shown the
+	appropriate value to be around 0.8. The multiplier is scaled to the
+	proportionate difference in player skill. */
+	std::vector<float> StamAdjust(float x, std::vector<float> diff);
+
+	/*	For a given player skill level x, invokes the function used by wife
+	scoring to assert the average of the distribution of point gain for each
+	interval and then tallies up the result to produce an average total number
+	of points achieved by this hand. */
+	float CalcInternal(float x, bool stam, bool nps, bool js, bool hs);
+
+	std::vector<float> ohjumpscale;
+	std::vector<float> rollscale;
+	std::vector<float> hsscale;
+	std::vector<float> jumpscale;
+	std::vector<float> anchorscale;
+	std::vector<int> v_itvpoints;	// Point allotment for each interval
+	std::vector<float> v_itvNPSdiff; // Calculated difficulty for each interval
+	std::vector<float> v_itvMSdiff;  // Calculated difficulty for each interval
+	std::vector<float> debug;		 // debug info placement
+	std::vector<float> finalMSDvals; // cancer cancer cancer cancer
+	std::vector<float> pointslost;
+  private:
+	const bool SmoothDifficulty =
+	  true; // Do we moving average the difficulty intervals?
+
+	float timingscale; // Timingscale for use in the point proportion function
+	float jumpstreamscaler = 0.975f;
+	float handstreamscaler = 0.92f;
+	float finalscaler = 2.564f * 1.05f * 1.1f * 1.10f * 1.10f *
+						1.025; // multiplier to standardize baselines
+
+	// Stamina Model params
+	const float ceil = 1.08f;	// stamina multiplier max
+	const float mag = 355.f;	 // multiplier generation scaler
+	const float fscale = 2000.f; // how fast the floor rises (it's lava)
+	const float prop =
+	  0.75f; // proportion of player difficulty at which stamina tax begins
+};
+
+class Calc_OLD
+{
+  public:
+	/*	Primary calculator function that wraps everything else. Initializes the
+	hand objects and then runs the chisel function under varying circumstances
+	to estimate difficulty for each different skillset. Currently only
+	overall/stamina are being produced. */
+	std::vector<float> CalcMain(const std::vector<NoteInfo>& NoteInfo, float timingscale, float score_goal);
+
+	// redo these asap
+	std::vector<float> JackStamAdjust(std::vector<float>& j, float x, bool jackstam);
+	float JackLoss(std::vector<float>& j, float x, bool jackstam);
+	JackSeq SequenceJack(const std::vector<NoteInfo>& NoteInfo, int t);
+
+	int numitv;
+	int fastwalk(const std::vector<NoteInfo>& NoteInfo);
+
+	/*	Splits up the chart by each hand and calls ProcessFinger on each "track"
+	before passing
+	the results to the hand initialization functions. Also passes the input
+	timingscale value. */
+	void InitializeHands(const std::vector<NoteInfo>& NoteInfo, float ts);
+
+	/*	Slices the track into predefined intervals of time. All taps within each
+	interval have their ms values from the last note in the same column
+	calculated and the result is spit out
+	into a new Finger object, or std::vector of std::vectors of floats (ms from last note
+	in the track). */
+	Finger ProcessFinger(const std::vector<NoteInfo>& NoteInfo, int t);
+
+	// How many buttons do you press for this chart (currently hardcoded,
+	// clearly)
+	int numTracks = 4;
+
+	float vb = 0.f;
+	float vt = 0.f;
+
+	// Derivative calc params
+	float MusicRate = 1.f;
+	float MaxPoints = 0.f; // Total points achievable in the file
+	float Scoregoal =
+	  0.93f; // What proportion of the total points are we trying to get
+	const float toffset = 0.f;
+	void TotalMaxPoints(); // Counts up the total points and assigns it
+
+	/*	Recursive non-linear calculation function. A player skill is asserted
+	and the calcultor calls the calcinternal functions for each hand and adds up
+	the calculated average points attained per attempt at the given skill level
+	for the given chart. This function will iterate until the percentage
+	obtained is greater than or equal to the scoregoal variable. The output
+	accuracy resolution can be set by either reducing the initial increment or
+	by increasing the starting iteration. */
+	float Chisel(float pskill,
+				 float res,
+				 int iter,
+				 bool stam,
+				 bool jack,
+				 bool nps,
+				 bool js,
+				 bool hs);
+
+	std::vector<float> OHJumpDownscaler(const std::vector<NoteInfo>& NoteInfo,
+								   int t1,
+								   int t2);
+	std::vector<float> Anchorscaler(const std::vector<NoteInfo>& NoteInfo,
+							   int t1,
+							   int t2);
+	std::vector<float> HSDownscaler(const std::vector<NoteInfo>& NoteInfo);
+	std::vector<float> JumpDownscaler(const std::vector<NoteInfo>& NoteInfo);
+	std::vector<float> RollDownscaler(Finger f1, Finger f2);
+	void Purge();
+	float techscaler = 0.97f;
+
+	Hand_OLD left_hand;
+	Hand_OLD right_hand;
+  private:
+	std::vector<std::vector<int>> nervIntervals;
+
+	// Const calc params
+	const bool SmoothPatterns =
+	  true; // Do we moving average the pattern modifier intervals?
+	const float IntervalSpan = 0.5f; // Intervals of time we slice the chart at
+	const bool logpatterns = false;
+
+	float dumbvalue = 1.f;
+	int dumbcounter = 0;
+
+	JackSeq j0;
+	JackSeq j1;
+	JackSeq j2;
+	JackSeq j3;
+};
+
+MINACALC_API_OLD std::vector<float>
+MinaSDCalc_OLD(const std::vector<NoteInfo>& NoteInfo,
+		   float musicrate,
+		   float goal);
+MINACALC_API_OLD MinaSD
+MinaSDCalc_OLD(const std::vector<NoteInfo>& NoteInfo);
+MINACALC_API_OLD int
+GetCalcVersion_OLD();
+
+/*
+To get debug output:
+1. Turn off the built in showlog window
+2. Do StepMania.exe >> out.txt in cmd
+*/

--- a/src/Etterna/Models/Misc/GameConstantsAndTypes.cpp
+++ b/src/Etterna/Models/Misc/GameConstantsAndTypes.cpp
@@ -225,6 +225,24 @@ StringToSkillset(const RString& s)
 	return Skill_Overall;
 }
 
+static const char* CalcPatternModNames[] = {
+	"OHJump", "Anchor", "Roll", "HS", "Jump", "CJ",
+};
+XToString(CalcPatternMod);
+LuaXType(CalcPatternMod);
+
+static const char* CalcDebugMiscNames[] = {
+	"PtLoss", "StamMod",
+};
+XToString(CalcDebugMisc);
+LuaXType(CalcDebugMisc);
+
+static const char* CalcDiffValueNames[] = {
+	"BaseNPS", "BaseMS", "BaseMSD", "MSD",
+};
+XToString(CalcDiffValue);
+LuaXType(CalcDiffValue);
+
 static const char* ValidationKeyNames[] = {
 	"Brittle",
 	"Weak",

--- a/src/Etterna/Models/Misc/GameConstantsAndTypes.cpp
+++ b/src/Etterna/Models/Misc/GameConstantsAndTypes.cpp
@@ -231,17 +231,17 @@ static const char* CalcPatternModNames[] = {
 XToString(CalcPatternMod);
 LuaXType(CalcPatternMod);
 
-static const char* CalcDebugMiscNames[] = {
-	"PtLoss", "StamMod",
-};
-XToString(CalcDebugMisc);
-LuaXType(CalcDebugMisc);
-
 static const char* CalcDiffValueNames[] = {
 	"BaseNPS", "BaseMS", "BaseMSD", "MSD",
 };
 XToString(CalcDiffValue);
 LuaXType(CalcDiffValue);
+
+static const char* CalcDebugMiscNames[] = {
+	"PtLoss", "StamMod",
+};
+XToString(CalcDebugMisc);
+LuaXType(CalcDebugMisc);
 
 static const char* ValidationKeyNames[] = {
 	"Brittle",

--- a/src/Etterna/Models/Misc/GameConstantsAndTypes.cpp
+++ b/src/Etterna/Models/Misc/GameConstantsAndTypes.cpp
@@ -226,7 +226,7 @@ StringToSkillset(const RString& s)
 }
 
 static const char* CalcPatternModNames[] = { "OHJump", "Anchor", "Roll", "HS",
-											 "Jump",   "CJ",	 "StreamMod", "OHTrill", "Chaos" };
+											 "Jump",   "CJ",	 "StreamMod", "OHTrill", "Chaos" , "FlamJam"};
 XToString(CalcPatternMod);
 LuaXType(CalcPatternMod);
 

--- a/src/Etterna/Models/Misc/GameConstantsAndTypes.cpp
+++ b/src/Etterna/Models/Misc/GameConstantsAndTypes.cpp
@@ -225,9 +225,8 @@ StringToSkillset(const RString& s)
 	return Skill_Overall;
 }
 
-static const char* CalcPatternModNames[] = {
-	"OHJump", "Anchor", "Roll", "HS", "Jump", "CJ",
-};
+static const char* CalcPatternModNames[] = { "OHJump", "Anchor", "Roll", "HS",
+											 "Jump",   "CJ",	 "StreamMod", "OHTrill", "Chaos" };
 XToString(CalcPatternMod);
 LuaXType(CalcPatternMod);
 

--- a/src/Etterna/Models/Misc/GameConstantsAndTypes.h
+++ b/src/Etterna/Models/Misc/GameConstantsAndTypes.h
@@ -48,9 +48,9 @@ SkillsetToString(Skillset ss);
 const RString&
 CalcPatternModToString(CalcPatternMod);
 const RString&
-CalcDebugMiscToString(CalcDebugMisc);
-const RString&
 CalcDiffValueToString(CalcDiffValue);
+const RString&
+CalcDebugMiscToString(CalcDebugMisc);
 
 enum NSScoreBoardColumn
 {

--- a/src/Etterna/Models/Misc/GameConstantsAndTypes.h
+++ b/src/Etterna/Models/Misc/GameConstantsAndTypes.h
@@ -28,20 +28,6 @@ enum GameplayMode
 	GameplayMode_Invalid
 };
 
-enum Skillset
-{
-	Skill_Overall,
-	Skill_Stream,
-	Skill_Jumpstream,
-	Skill_Handstream,
-	Skill_Stamina,
-	Skill_JackSpeed,
-	Skill_Chordjack,
-	Skill_Technical,
-	NUM_Skillset,
-	Skillset_Invalid,
-};
-
 const RString&
 SkillsetToString(Skillset ss);
 

--- a/src/Etterna/Models/Misc/GameConstantsAndTypes.h
+++ b/src/Etterna/Models/Misc/GameConstantsAndTypes.h
@@ -5,6 +5,7 @@
 #define GAME_CONSTANTS_AND_TYPES_H
 
 #include "EnumHelper.h"
+#include "Etterna/Models/NoteData/NoteDataStructures.h"
 #include <cfloat> // need the max for default.
 
 // Note definitions
@@ -43,6 +44,13 @@ enum Skillset
 
 const RString&
 SkillsetToString(Skillset ss);
+
+const RString&
+CalcPatternModToString(CalcPatternMod);
+const RString&
+CalcDebugMiscToString(CalcDebugMisc);
+const RString&
+CalcDiffValueToString(CalcDiffValue);
 
 enum NSScoreBoardColumn
 {

--- a/src/Etterna/Models/Misc/NoteTypes.h
+++ b/src/Etterna/Models/Misc/NoteTypes.h
@@ -360,7 +360,7 @@ inline int   BeatToNoteRow( float fBeatNum )
 inline int
 BeatToNoteRow(float fBeatNum)
 {
-	return lround(fBeatNum * ROWS_PER_BEAT);
+	return lround(fBeatNum * 48.f);
 }
 /**
  * @brief Convert the note row to a beat.

--- a/src/Etterna/Models/NoteData/NoteData.cpp
+++ b/src/Etterna/Models/NoteData/NoteData.cpp
@@ -229,8 +229,8 @@ NoteData::SerializeNoteData2(TimingData* ts,
 				if (!res.second)
 					// already added, but last column wasn't
 					// actually a tap, start here
-					if (lal.at(r.first) != 128)
-						lal.at(r.first) == 1 << t;
+					if (lal.at(r.first) == 128)
+						lal.at(r.first) = 1 << t;
 					else
 						// already added and is a tap, update info
 						lal.at(r.first) |= 1 << t;

--- a/src/Etterna/Models/NoteData/NoteData.cpp
+++ b/src/Etterna/Models/NoteData/NoteData.cpp
@@ -228,7 +228,7 @@ NoteData::SerializeNoteData2(TimingData* ts,
 		const auto& tm = m_TapNotes[t];
 		for (const auto& r : tm)
 			if (r.second.IsNote()) {
-			auto& res = lal.emplace(r.first, 1 << t);
+			auto res = lal.emplace(r.first, 1 << t);
 			if (!res.second) // already added, update noteinfo
 				lal.at(r.first) |= 1 << t;
 		}

--- a/src/Etterna/Models/NoteData/NoteDataStructures.h
+++ b/src/Etterna/Models/NoteData/NoteDataStructures.h
@@ -39,15 +39,6 @@ enum CalcPatternMod
 	NUM_CalcPatternMod,
 	CalcPatternMod_Invalid,
 };
-
-enum CalcDebugMisc
-{
-	PtLoss, // expected points loss (not really a diff thing but w.e)
-	StamMod,// stam adjust (values between 1- ~1.15)
-	NUM_CalcDebugMisc,
-	CalcDebugMisc_Invalid,
-};
-
 enum CalcDiffValue
 {
 	BaseNPS, // unadjusted base nps difficulty
@@ -56,6 +47,13 @@ enum CalcDiffValue
 	MSD,	 // pattern and stam adjusted difficulty values
 	NUM_CalcDiffValue,
 	CalcDiffValue_Invalid,
+};
+enum CalcDebugMisc
+{
+	PtLoss, // expected points loss (not really a diff thing but w.e)
+	StamMod,// stam adjust (values between 1- ~1.15)
+	NUM_CalcDebugMisc,
+	CalcDebugMisc_Invalid,
 };
 
 #endif

--- a/src/Etterna/Models/NoteData/NoteDataStructures.h
+++ b/src/Etterna/Models/NoteData/NoteDataStructures.h
@@ -39,6 +39,7 @@ enum CalcPatternMod
 	StreamMod,
 	OHTrill,
 	Chaos,
+	FlamJam,
 	NUM_CalcPatternMod,
 	CalcPatternMod_Invalid,
 };

--- a/src/Etterna/Models/NoteData/NoteDataStructures.h
+++ b/src/Etterna/Models/NoteData/NoteDataStructures.h
@@ -36,6 +36,9 @@ enum CalcPatternMod
 	HS,		// pattern mod (values between 0-1)
 	Jump,   // pattern mod (values between 0-1)
 	CJ,		// pattern mod (values between 0-1)
+	StreamMod,
+	OHTrill,
+	Chaos,
 	NUM_CalcPatternMod,
 	CalcPatternMod_Invalid,
 };

--- a/src/Etterna/Models/NoteData/NoteDataStructures.h
+++ b/src/Etterna/Models/NoteData/NoteDataStructures.h
@@ -27,23 +27,35 @@ struct DifficultyRating
 	float technical;
 };
 
-
-enum CalcDebugValue
+// we do actually want to register these with lua i guess
+enum CalcPatternMod
 {
-	OHJump,  // pattern mod (% values between 0-1)
-	Anchor,  // pattern mod (% values between 0-1)
-	Roll,	// pattern mod (% values between 0-1)
-	HS,		 // pattern mod (% values between 0-1)
-	Jump,	// pattern mod (% values between 0-1)
-	CJ,
+	OHJump, // pattern mod (values between 0-1)
+	Anchor, // pattern mod (values between 0.9 - ~ 1.1)
+	Roll,   // pattern mod (values between 0-1)
+	HS,		// pattern mod (values between 0-1)
+	Jump,   // pattern mod (values between 0-1)
+	CJ,		// pattern mod (values between 0-1)
+	NUM_CalcPatternMod,
+	CalcPatternMod_Invalid,
+};
+
+enum CalcDebugMisc
+{
+	PtLoss, // expected points loss (not really a diff thing but w.e)
+	StamMod,// stam adjust (values between 1- ~1.15)
+	NUM_CalcDebugMisc,
+	CalcDebugMisc_Invalid,
+};
+
+enum CalcDiffValue
+{
 	BaseNPS, // unadjusted base nps difficulty
 	BaseMS,  // unadjusted base ms difficulty
 	BaseMSD, // unadjusted weighted values
 	MSD,	 // pattern and stam adjusted difficulty values
-	PtLoss,  // expected points lost
-	StamMod, // stam adjustment value (% values between 1-ciel)
-	DebugCount,
-	None
+	NUM_CalcDiffValue,
+	CalcDiffValue_Invalid,
 };
 
 #endif

--- a/src/Etterna/Models/NoteData/NoteDataStructures.h
+++ b/src/Etterna/Models/NoteData/NoteDataStructures.h
@@ -27,6 +27,20 @@ struct DifficultyRating
 	float technical;
 };
 
+enum Skillset
+{
+	Skill_Overall,
+	Skill_Stream,
+	Skill_Jumpstream,
+	Skill_Handstream,
+	Skill_Stamina,
+	Skill_JackSpeed,
+	Skill_Chordjack,
+	Skill_Technical,
+	NUM_Skillset,
+	Skillset_Invalid,
+};
+
 // we do actually want to register these with lua i guess
 enum CalcPatternMod
 {

--- a/src/Etterna/Models/StepsAndStyles/Steps.cpp
+++ b/src/Etterna/Models/StepsAndStyles/Steps.cpp
@@ -15,6 +15,7 @@
 #include "Etterna/Singletons/GameManager.h"
 #include "Etterna/Singletons/GameState.h"
 #include "Etterna/Globals/MinaCalc.h"
+#include "Etterna/Globals/MinaCalcOld.h"
 #include "Etterna/Models/NoteData/NoteData.h"
 #include "Etterna/Models/NoteData/NoteDataUtil.h"
 #include "Etterna/Models/NoteLoaders/NotesLoaderBMS.h"
@@ -32,47 +33,6 @@
 #include <algorithm>
 #include <thread>
 #include "Etterna/Models/NoteData/NoteDataStructures.h"
-
-// AUTOMATED CALC TEST STUFF FIND BETTER PLACE TO PUT
-// chart key and rough desired output value
-unordered_map<std::string, float> beepboop = {
-	// js garbo
-	{ "X75012d7a17a174681beb31ce3858d1c9f726dddb", 30.f },	// cos nb4, this is our baseline js 30
-	{ "X6a0c2fb0b567cdbc85e9eac3dbae40a6e66c7091", 25.f },	// glorious crown fennec
-	{ "X11698acb2346ed45032768120064f24d3e1d282d", 23.5f }, // mmm nb5
-	{ "X2ed2aa7681f1f85119abae49985130bdc420e388", 26.5f }, // invisible hand hi19 3
-
-	// speed garbo
-	{ "Xf0fbf2b1f5f1583f7f9faadb89f149c25d2ab8f3", 30.f },	// reflec streams, att 1
-	{ "X984f26aacbe104976dfd80b002556c722163ba35", 21.f },	// chipwrecked hi19 5
-	{ "X3ecb1e6f7e1334218f0f71ff0ff3bea483210f86", 28.f },	// amber starlight nb5
-	{ "X6be11ac59dcd2ef950bb28fec8cf0b05945c93ec", 27.f },	// tunak tunak hi19 4
-	{ "Xe4e68826a3d00062e163f3a29b42350f86089b26", 25.f },	// hallelujah minty 1
-	{ "X50e58103750092785dd9a4722477cc6ed1fea54e", 25.5f }, // lofty's ending minty 1
-	{ "X8a7310367a2479daa48888b15b8be724452c4616", 29.f },	// veda minty 1
-	{ "X24085a6e074ca3bd89c91b748d9b42061863e9c1", 25.f },	// electricity tim1
-
-	// stam garbo
-	{ "Xdd74f464e7acbab921b91a2b5100901af24b3054", 25.5f }, // ttatf icy x
-	{ "X30acaf360a0e56bcc1376d36a98d24090a65074d", 23.5f }, // magic cycles nb4
-	{ "X9cd21dc241d821b69967a0058ccadcedf3cc9545", 30.5f }, // battle of arcane might skwid 6
-
-	// jack garbo
-	{ "Xcee78c72ba6ba436ba9325f030c482bf13843376", 17.5f }, // F odi 2
-	{ "X85e5db71c00c154dc2c58cf1a87f9fb5a6393b99", 26.f },	// vital vitriol skwid 7
-
-	// technical garbo
-	{ "X87bc96672f47c365a12c7226b895d5535e5f1a60", 20.f },	// timepiece phase ii hi19 4
-	{ "Xaab20a4cb1634a23ad6f077c4cb6fef755769e6e", 17.f },	// luna clock odi 2
-	{ "Xecbb9d26ff2e40424d3c09e2bfe405149b954e2b", 22.5f }, // azul beg odi 2
-	{ "X7071eca33dfbb4850059bb6b8718f0cf65e46168", 20.f },  // usatei edit odi 2
-	{ "X0b685f34b530af918de78b98f3a80890df324926", 27.f },	// do you feel it minty 1
-	{ "X3e6a2f7e924b9b2cc784aa02c02ad2772cf77ea9", 25.5f }, // runaway minty 1
-	
-
-	// too lazy to classify
-	
-};
 
 /* register DisplayBPM with StringConversion */
 #include "Etterna/Models/Misc/EnumHelper.h"
@@ -451,6 +411,31 @@ Steps::CalcEtternaMetadata()
 	m_pNoteData->UnsetSerializedNoteData();
 	GetTimingData()->UnsetEtaner();
 }
+
+float
+Steps::DoATestThing(float ev, Skillset ss)
+{
+	Decompress();
+	const vector<int>& nerv = m_pNoteData->BuildAndGetNerv();
+	const vector<float>& etaner = GetTimingData()->BuildAndGetEtaner(nerv);
+	const vector<NoteInfo>& cereal = m_pNoteData->SerializeNoteData(etaner);
+
+	auto newcalc = MinaSDCalc(cereal, 1.f, 0.93f);
+	auto oldcalc = MinaSDCalc_OLD(cereal, 1.f, 0.93f);
+	LOG->Trace("%s : %f : %f",
+			   m_pSong->GetMainTitle().c_str(),
+			   newcalc[0] - ev,
+			   newcalc[0] - oldcalc[0]);
+
+	
+
+	m_pNoteData->UnsetNerv();
+	m_pNoteData->UnsetSerializedNoteData();
+	GetTimingData()->UnsetEtaner();
+	Compress();
+	return newcalc[0] - ev;
+}
+
 
 void
 Steps::GetCalcDebugOutput()

--- a/src/Etterna/Models/StepsAndStyles/Steps.cpp
+++ b/src/Etterna/Models/StepsAndStyles/Steps.cpp
@@ -426,7 +426,7 @@ Steps::DoATestThing(float ev, Skillset ss)
 			   newcalc[0] - ev,
 			   (newcalc[0] - ev) / ev * 100.f,
 			   newcalc[0] - oldcalc[0],
-	  m_pSong->GetMainTitle().c_str());
+			   m_pSong->GetMainTitle().c_str());
 
 	m_pNoteData->UnsetNerv();
 	m_pNoteData->UnsetSerializedNoteData();
@@ -434,7 +434,6 @@ Steps::DoATestThing(float ev, Skillset ss)
 	Compress();
 	return newcalc[0] - ev;
 }
-
 
 void
 Steps::GetCalcDebugOutput()
@@ -447,9 +446,10 @@ Steps::GetCalcDebugOutput()
 	const vector<float>& etaner = GetTimingData()->BuildAndGetEtaner(nerv);
 	const vector<NoteInfo>& cereal = m_pNoteData->SerializeNoteData(etaner);
 
-	MinaSDCalcDebug(cereal, GAMESTATE->m_SongOptions.GetSong().m_fMusicRate,
-						0.93f,
-						calcdebugoutput);
+	MinaSDCalcDebug(cereal,
+					GAMESTATE->m_SongOptions.GetSong().m_fMusicRate,
+					0.93f,
+					calcdebugoutput);
 
 	m_pNoteData->UnsetNerv();
 	m_pNoteData->UnsetSerializedNoteData();
@@ -994,17 +994,44 @@ class LunaSteps : public Luna<Steps>
 		p->GetCalcDebugOutput();
 		int lazy = 1;
 		lua_newtable(L);
-		for (int i = 0; i < DebugCount; ++i) {
-			vector<float> poop = p->calcdebugoutput[0][i];
-			LuaHelpers::CreateTableFromArray(poop, L);
-			lua_rawseti(L, -2, lazy);
-			++lazy;
 
-			poop = p->calcdebugoutput[1][i];
-			LuaHelpers::CreateTableFromArray(poop, L);
-			lua_rawseti(L, -2, lazy);
+		
+		for (int i = 0; i < NUM_CalcPatternMod; ++i) {
+			lua_pushstring(
+			  L, CalcPatternModToString(static_cast<CalcPatternMod>(i)));
+			lua_createtable(L, 0, 2);
+			for (int j = 0; j < 2; ++j) {
+				vector<float> poop = p->calcdebugoutput[j][i];
+				LuaHelpers::CreateTableFromArray(poop, L);
+				lua_rawseti(L, -2, j + 1);
+			}
+			lua_rawset(L, -3);
+		}
+		
+	
+		return 1;
+
+		for (int i = 0; i < NUM_CalcPatternMod; ++i) {
+			lua_pushstring(
+			  L, CalcPatternModToString(static_cast<CalcPatternMod>(i)));
+			for (int j = 0; j < 2; ++j) {
+				lua_createtable(L, 0, 2);
+				lua_pushnumber(L, i);
+				lua_rawseti(L, -4, 1);
+				lua_pushnumber(L, i * 1000);
+				lua_rawseti(L, -4, 2);
+				lua_rawset(L, -3);
+			}
+
+			// lua_rawseti(L, -2, lazy);
 			++lazy;
 		}
+
+		/* vector<float>& poop = p->calcdebugoutput[0][i];
+			lua_pushstring(
+			  L, CalcPatternModToString(static_cast<CalcPatternMod>(i)));
+			LuaHelpers::CreateTableFromArray(poop, L);
+			*/
 		return 1;
 	}
 	LunaSteps()

--- a/src/Etterna/Models/StepsAndStyles/Steps.cpp
+++ b/src/Etterna/Models/StepsAndStyles/Steps.cpp
@@ -993,9 +993,10 @@ class LunaSteps : public Luna<Steps>
 	{
 		p->GetCalcDebugOutput();
 		int lazy = 1;
-		lua_newtable(L);
 
-		
+		lua_newtable(L);
+		lua_pushstring(L, RString("CalcPatternMod"));
+		lua_createtable(L, 0, NUM_CalcPatternMod);
 		for (int i = 0; i < NUM_CalcPatternMod; ++i) {
 			lua_pushstring(
 			  L, CalcPatternModToString(static_cast<CalcPatternMod>(i)));
@@ -1007,31 +1008,37 @@ class LunaSteps : public Luna<Steps>
 			}
 			lua_rawset(L, -3);
 		}
-		
-	
-		return 1;
+		lua_rawset(L, -3);
 
-		for (int i = 0; i < NUM_CalcPatternMod; ++i) {
+		lua_pushstring(L, RString("CalcDebugMisc"));
+		lua_createtable(L, 0, NUM_CalcDebugMisc);
+		for (int i = 0; i < NUM_CalcDebugMisc; ++i) {
 			lua_pushstring(
-			  L, CalcPatternModToString(static_cast<CalcPatternMod>(i)));
+			  L, CalcDebugMiscToString(static_cast<CalcDebugMisc>(i)));
+			lua_createtable(L, 0, 2);
 			for (int j = 0; j < 2; ++j) {
-				lua_createtable(L, 0, 2);
-				lua_pushnumber(L, i);
-				lua_rawseti(L, -4, 1);
-				lua_pushnumber(L, i * 1000);
-				lua_rawseti(L, -4, 2);
-				lua_rawset(L, -3);
+				vector<float> poop = p->calcdebugoutput[j][i];
+				LuaHelpers::CreateTableFromArray(poop, L);
+				lua_rawseti(L, -2, j + 1);
 			}
-
-			// lua_rawseti(L, -2, lazy);
-			++lazy;
+			lua_rawset(L, -3);
 		}
+		lua_rawset(L, -3);
 
-		/* vector<float>& poop = p->calcdebugoutput[0][i];
+		lua_pushstring(L, RString("CalcDiffValue"));
+		lua_createtable(L, 0, NUM_CalcDiffValue);
+		for (int i = 0; i < NUM_CalcDiffValue; ++i) {
 			lua_pushstring(
-			  L, CalcPatternModToString(static_cast<CalcPatternMod>(i)));
-			LuaHelpers::CreateTableFromArray(poop, L);
-			*/
+			  L, CalcDiffValueToString(static_cast<CalcDiffValue>(i)));
+			lua_createtable(L, 0, 2);
+			for (int j = 0; j < 2; ++j) {
+				vector<float> poop = p->calcdebugoutput[j][i];
+				LuaHelpers::CreateTableFromArray(poop, L);
+				lua_rawseti(L, -2, j + 1);
+			}
+			lua_rawset(L, -3);
+		}
+		lua_rawset(L, -3);
 		return 1;
 	}
 	LunaSteps()

--- a/src/Etterna/Models/StepsAndStyles/Steps.cpp
+++ b/src/Etterna/Models/StepsAndStyles/Steps.cpp
@@ -992,8 +992,6 @@ class LunaSteps : public Luna<Steps>
 	static int GetCalcDebugOutput(T* p, lua_State* L)
 	{
 		p->GetCalcDebugOutput();
-		int lazy = 1;
-
 		lua_newtable(L);
 		lua_pushstring(L, RString("CalcPatternMod"));
 		lua_createtable(L, 0, NUM_CalcPatternMod);

--- a/src/Etterna/Models/StepsAndStyles/Steps.cpp
+++ b/src/Etterna/Models/StepsAndStyles/Steps.cpp
@@ -451,12 +451,10 @@ Steps::GetCalcDebugOutput()
 	const vector<NoteInfo>& cereal =
 	  m_pNoteData->SerializeNoteData2(GetTimingData());
 
-	if (modType < CalcPatternMod::ModCount && modType >= 0)
-		MinaSDCalcDebug(cereal,
-						GAMESTATE->m_SongOptions.GetSong().m_fMusicRate,
-						0.93f,
-						dumbthings,
-						static_cast<CalcPatternMod>(modType));
+	MinaSDCalcDebug(cereal,
+					GAMESTATE->m_SongOptions.GetSong().m_fMusicRate,
+					0.93f,
+					calcdebugoutput);
   
 	m_pNoteData->UnsetNerv();
 	m_pNoteData->UnsetSerializedNoteData();
@@ -467,8 +465,8 @@ Steps::GetCalcDebugOutput()
 void
 Steps::UnloadCalcDebugOutput()
 {
-	dumbthings.clear();
-	dumbthings.shrink_to_fit();
+	calcdebugoutput.clear();
+	calcdebugoutput.shrink_to_fit();
 }
 
 RString

--- a/src/Etterna/Models/StepsAndStyles/Steps.cpp
+++ b/src/Etterna/Models/StepsAndStyles/Steps.cpp
@@ -447,7 +447,7 @@ Steps::GetCalcDebugOutput()
 	//	return;
 	calcdebugoutput.clear();
 	// function is responsible for producing debug output
-	// Decompress();
+	Decompress();
 	const vector<NoteInfo>& cereal =
 	  m_pNoteData->SerializeNoteData2(GetTimingData());
 

--- a/src/Etterna/Models/StepsAndStyles/Steps.cpp
+++ b/src/Etterna/Models/StepsAndStyles/Steps.cpp
@@ -422,12 +422,11 @@ Steps::DoATestThing(float ev, Skillset ss)
 
 	auto newcalc = MinaSDCalc(cereal, 1.f, 0.93f);
 	auto oldcalc = MinaSDCalc_OLD(cereal, 1.f, 0.93f);
-	LOG->Trace("%s : %f : %f",
-			   m_pSong->GetMainTitle().c_str(),
+	LOG->Trace("%+0.2f (%+06.2f%%): %+0.2f %s",
 			   newcalc[0] - ev,
-			   newcalc[0] - oldcalc[0]);
-
-	
+			   (newcalc[0] - ev) / ev * 100.f,
+			   newcalc[0] - oldcalc[0],
+	  m_pSong->GetMainTitle().c_str());
 
 	m_pNoteData->UnsetNerv();
 	m_pNoteData->UnsetSerializedNoteData();

--- a/src/Etterna/Models/StepsAndStyles/Steps.cpp
+++ b/src/Etterna/Models/StepsAndStyles/Steps.cpp
@@ -438,8 +438,12 @@ Steps::DoATestThing(float ev, Skillset ss)
 void
 Steps::GetCalcDebugOutput()
 {
-	if (!calcdebugoutput.empty())
-		return;
+	// makes calc display not update with rate changes
+	// don't feel like making this fancy and it's fast
+	// enough now i guess
+	//if (!calcdebugoutput.empty())
+	//	return;
+	calcdebugoutput.clear();
 	// function is responsible for producing debug output
 	Decompress();
 	const vector<int>& nerv = m_pNoteData->BuildAndGetNerv();

--- a/src/Etterna/Models/StepsAndStyles/Steps.cpp
+++ b/src/Etterna/Models/StepsAndStyles/Steps.cpp
@@ -33,6 +33,47 @@
 #include <thread>
 #include "Etterna/Models/NoteData/NoteDataStructures.h"
 
+// AUTOMATED CALC TEST STUFF FIND BETTER PLACE TO PUT
+// chart key and rough desired output value
+unordered_map<std::string, float> beepboop = {
+	// js garbo
+	{ "X75012d7a17a174681beb31ce3858d1c9f726dddb", 30.f },	// cos nb4, this is our baseline js 30
+	{ "X6a0c2fb0b567cdbc85e9eac3dbae40a6e66c7091", 25.f },	// glorious crown fennec
+	{ "X11698acb2346ed45032768120064f24d3e1d282d", 23.5f }, // mmm nb5
+	{ "X2ed2aa7681f1f85119abae49985130bdc420e388", 26.5f }, // invisible hand hi19 3
+
+	// speed garbo
+	{ "Xf0fbf2b1f5f1583f7f9faadb89f149c25d2ab8f3", 30.f },	// reflec streams, att 1
+	{ "X984f26aacbe104976dfd80b002556c722163ba35", 21.f },	// chipwrecked hi19 5
+	{ "X3ecb1e6f7e1334218f0f71ff0ff3bea483210f86", 28.f },	// amber starlight nb5
+	{ "X6be11ac59dcd2ef950bb28fec8cf0b05945c93ec", 27.f },	// tunak tunak hi19 4
+	{ "Xe4e68826a3d00062e163f3a29b42350f86089b26", 25.f },	// hallelujah minty 1
+	{ "X50e58103750092785dd9a4722477cc6ed1fea54e", 25.5f }, // lofty's ending minty 1
+	{ "X8a7310367a2479daa48888b15b8be724452c4616", 29.f },	// veda minty 1
+	{ "X24085a6e074ca3bd89c91b748d9b42061863e9c1", 25.f },	// electricity tim1
+
+	// stam garbo
+	{ "Xdd74f464e7acbab921b91a2b5100901af24b3054", 25.5f }, // ttatf icy x
+	{ "X30acaf360a0e56bcc1376d36a98d24090a65074d", 23.5f }, // magic cycles nb4
+	{ "X9cd21dc241d821b69967a0058ccadcedf3cc9545", 30.5f }, // battle of arcane might skwid 6
+
+	// jack garbo
+	{ "Xcee78c72ba6ba436ba9325f030c482bf13843376", 17.5f }, // F odi 2
+	{ "X85e5db71c00c154dc2c58cf1a87f9fb5a6393b99", 26.f },	// vital vitriol skwid 7
+
+	// technical garbo
+	{ "X87bc96672f47c365a12c7226b895d5535e5f1a60", 20.f },	// timepiece phase ii hi19 4
+	{ "Xaab20a4cb1634a23ad6f077c4cb6fef755769e6e", 17.f },	// luna clock odi 2
+	{ "Xecbb9d26ff2e40424d3c09e2bfe405149b954e2b", 22.5f }, // azul beg odi 2
+	{ "X7071eca33dfbb4850059bb6b8718f0cf65e46168", 20.f },  // usatei edit odi 2
+	{ "X0b685f34b530af918de78b98f3a80890df324926", 27.f },	// do you feel it minty 1
+	{ "X3e6a2f7e924b9b2cc784aa02c02ad2772cf77ea9", 25.5f }, // runaway minty 1
+	
+
+	// too lazy to classify
+	
+};
+
 /* register DisplayBPM with StringConversion */
 #include "Etterna/Models/Misc/EnumHelper.h"
 

--- a/src/Etterna/Models/StepsAndStyles/Steps.cpp
+++ b/src/Etterna/Models/StepsAndStyles/Steps.cpp
@@ -1002,22 +1002,7 @@ class LunaSteps : public Luna<Steps>
 			  L, CalcPatternModToString(static_cast<CalcPatternMod>(i)));
 			lua_createtable(L, 0, 2);
 			for (int j = 0; j < 2; ++j) {
-				vector<float> poop = p->calcdebugoutput[j][i];
-				LuaHelpers::CreateTableFromArray(poop, L);
-				lua_rawseti(L, -2, j + 1);
-			}
-			lua_rawset(L, -3);
-		}
-		lua_rawset(L, -3);
-
-		lua_pushstring(L, RString("CalcDebugMisc"));
-		lua_createtable(L, 0, NUM_CalcDebugMisc);
-		for (int i = 0; i < NUM_CalcDebugMisc; ++i) {
-			lua_pushstring(
-			  L, CalcDebugMiscToString(static_cast<CalcDebugMisc>(i)));
-			lua_createtable(L, 0, 2);
-			for (int j = 0; j < 2; ++j) {
-				vector<float> poop = p->calcdebugoutput[j][i];
+				vector<float> poop = p->calcdebugoutput[j][0][i];
 				LuaHelpers::CreateTableFromArray(poop, L);
 				lua_rawseti(L, -2, j + 1);
 			}
@@ -1032,7 +1017,22 @@ class LunaSteps : public Luna<Steps>
 			  L, CalcDiffValueToString(static_cast<CalcDiffValue>(i)));
 			lua_createtable(L, 0, 2);
 			for (int j = 0; j < 2; ++j) {
-				vector<float> poop = p->calcdebugoutput[j][i];
+				vector<float> poop = p->calcdebugoutput[j][1][i];
+				LuaHelpers::CreateTableFromArray(poop, L);
+				lua_rawseti(L, -2, j + 1);
+			}
+			lua_rawset(L, -3);
+		}
+		lua_rawset(L, -3);
+
+		lua_pushstring(L, RString("CalcDebugMisc"));
+		lua_createtable(L, 0, NUM_CalcDebugMisc);
+		for (int i = 0; i < NUM_CalcDebugMisc; ++i) {
+			lua_pushstring(
+			  L, CalcDebugMiscToString(static_cast<CalcDebugMisc>(i)));
+			lua_createtable(L, 0, 2);
+			for (int j = 0; j < 2; ++j) {
+				vector<float> poop = p->calcdebugoutput[j][2][i];
 				LuaHelpers::CreateTableFromArray(poop, L);
 				lua_rawseti(L, -2, j + 1);
 			}

--- a/src/Etterna/Models/StepsAndStyles/Steps.h
+++ b/src/Etterna/Models/StepsAndStyles/Steps.h
@@ -209,10 +209,13 @@ class Steps
 	map<float, Skillset> SortSkillsetsAtRate(float x, bool includeoverall);
 
 	void CalcEtternaMetadata();
+	float DoATestThing(float ev, Skillset ss);
 	void GetCalcDebugOutput();	// now spits out everything with 1 calc call
 	vector<vector<vector<float>>> calcdebugoutput; // probably should clear this periodically
-	bool test_me = false;
-	float expected_overall_difficulty = 0.f;
+
+	string GenerateBustedChartKey(NoteData& nd, TimingData* td, int cores);
+	vector<string> bustedkeys;
+	void MakeBustedKeys();
 
 	// you are all idiots for not just doing this in the first place -mina
 	float firstsecond = 0.f;

--- a/src/Etterna/Models/StepsAndStyles/Steps.h
+++ b/src/Etterna/Models/StepsAndStyles/Steps.h
@@ -211,10 +211,8 @@ class Steps
 	void CalcEtternaMetadata();
 	void GetCalcDebugOutput();	// now spits out everything with 1 calc call
 	vector<vector<vector<float>>> calcdebugoutput; // probably should clear this periodically
-
-	string GenerateBustedChartKey(NoteData& nd, TimingData* td, int cores);
-	vector<string> bustedkeys;
-	void MakeBustedKeys();
+	bool test_me = false;
+	float expected_overall_difficulty = 0.f;
 
 	// you are all idiots for not just doing this in the first place -mina
 	float firstsecond = 0.f;

--- a/src/Etterna/Models/StepsAndStyles/Steps.h
+++ b/src/Etterna/Models/StepsAndStyles/Steps.h
@@ -211,7 +211,7 @@ class Steps
 	void CalcEtternaMetadata();
 	float DoATestThing(float ev, Skillset ss);
 	void GetCalcDebugOutput();	// now spits out everything with 1 calc call
-	vector<vector<vector<float>>> calcdebugoutput; // probably should clear this periodically
+	vector<vector<vector<vector<float>>>> calcdebugoutput; // probably should clear this periodically
 
 	string GenerateBustedChartKey(NoteData& nd, TimingData* td, int cores);
 	vector<string> bustedkeys;

--- a/src/Etterna/Singletons/SongManager.cpp
+++ b/src/Etterna/Singletons/SongManager.cpp
@@ -66,6 +66,8 @@ static unordered_map<std::string, float> stream_test = {
 	{ "X3b87b6ac44151291b29e3fe2e8b047f6af28000e", 29.f },  // veda minty 1
 	{ "X8a7310367a2479daa48888b15b8be724452c4616", 29.5f }, // voodoo mon amour
 	{ "X24085a6e074ca3bd89c91b748d9b42061863e9c1", 25.f },  // electricity tim1
+	{ "Sc702a9b178552a1ee4deb1f9def89ffd58e4437a", 24.5f }, // bon-bon skwid6
+	
 };
 
 static unordered_map<std::string, float> stam_test = {

--- a/src/Etterna/Singletons/SongManager.cpp
+++ b/src/Etterna/Singletons/SongManager.cpp
@@ -429,63 +429,26 @@ SongManager::InitSongsFromDisk(LoadingWindow* ld)
 
 	// TESTING TESTING STUFF STUFF
 	vector<float> test_vals[NUM_Skillset];
-	for (auto& s : StepsByKey) {
-		if (stream_test.count(s.first)) {
-			test_vals[Skill_Stream].emplace_back(
-			  s.second->DoATestThing(stream_test.at(s.first), Skill_Stream));
-			continue;
-		}
+	unordered_map<std::string, float> test_charts[NUM_Skillset];
+	test_charts[Skill_Stream] = stream_test;
+	test_charts[Skill_Jumpstream] = js_test;
+	test_charts[Skill_Stamina] = stam_test;
+	test_charts[Skill_Technical] = tech_test;
+	test_charts[Skill_JackSpeed] = jack_test;
 
-		if (js_test.count(s.first)) {
-			test_vals[Skill_Jumpstream].emplace_back(s.second->DoATestThing(
-			  js_test.at(s.first), Skill_Jumpstream));
-			continue;
-		}
+	FOREACH_ENUM(Skillset, ss)
+	for (auto& t : test_charts[ss])
+		if (StepsByKey.count(t.first))
+			test_vals[ss].emplace_back(StepsByKey[t.first]->DoATestThing(
+			  test_charts[ss].at(t.first), ss));
 
-		if (stam_test.count(s.first)) {
-			test_vals[Skill_Stamina].emplace_back(
-			  s.second->DoATestThing(stam_test.at(s.first), Skill_Stamina));
-			continue;
-		}
-
-		if (tech_test.count(s.first)) {
-			test_vals[Skill_Technical].emplace_back(
-			  s.second->DoATestThing(tech_test.at(s.first), Skill_Technical));
-			continue;
-		}
-
-		if (jack_test.count(s.first)) {
-			test_vals[Skill_JackSpeed].emplace_back(
-			  s.second->DoATestThing(jack_test.at(s.first), Skill_JackSpeed));
-			continue;
-		}
-	}
-
-	LOG->Trace("Test stream avg differential %f",
-			   std::accumulate(begin(test_vals[Skill_Stream]),
-							   end(test_vals[Skill_Stream]),
-							   0.f) /
-				 test_vals[Skill_Stream].size());
-	LOG->Trace("Test js avg differential %f",
-			   std::accumulate(begin(test_vals[Skill_Jumpstream]),
-							   end(test_vals[Skill_Jumpstream]),
-							   0.f) /
-				 test_vals[Skill_Jumpstream].size());
-	LOG->Trace("Test stam avg differential %f",
-			   std::accumulate(begin(test_vals[Skill_Stamina]),
-							   end(test_vals[Skill_Stamina]),
-							   0.f) /
-				 test_vals[Skill_Stamina].size());
-	LOG->Trace("Test tech avg differential %f",
-			   std::accumulate(begin(test_vals[Skill_Technical]),
-							   end(test_vals[Skill_Technical]),
-							   0.f) /
-				 test_vals[Skill_Technical].size());
-	LOG->Trace("Test jack avg differential %f",
-			   std::accumulate(begin(test_vals[Skill_JackSpeed]),
-							   end(test_vals[Skill_JackSpeed]),
-							   0.f) /
-				 test_vals[Skill_JackSpeed].size());
+	FOREACH_ENUM(Skillset, ss)
+	if (!test_vals[ss].empty())
+		LOG->Trace(
+		  "%+0.2f avg delta for test group %s",
+		  std::accumulate(begin(test_vals[ss]), end(test_vals[ss]), 0.f) /
+			test_vals[ss].size(),
+		  SkillsetToString(ss).c_str());
 	cache.clear();
 }
 

--- a/src/Etterna/Singletons/SongManager.cpp
+++ b/src/Etterna/Singletons/SongManager.cpp
@@ -37,6 +37,63 @@
 #include "arch/LoadingWindow/LoadingWindow.h"
 #include "ScreenManager.h"
 #include "NetworkSyncManager.h"
+#include <numeric>
+
+// AUTOMATED CALC TEST STUFF FIND BETTER PLACE TO PUT
+// chart key and rough desired output value
+static unordered_map<std::string, float> js_test = {
+	// js garbo
+	{ "X75012d7a17a174681beb31ce3858d1c9f726dddb",
+	  30.f }, // cos nb4, this is our baseline js 30
+	{ "X6a0c2fb0b567cdbc85e9eac3dbae40a6e66c7091",
+	  25.f }, // glorious crown fennec
+	{ "X11698acb2346ed45032768120064f24d3e1d282d", 23.5f }, // mmm nb5
+	{ "X2ed2aa7681f1f85119abae49985130bdc420e388",
+	  26.5f }, // invisible hand hi19 3
+};
+
+static unordered_map<std::string, float> stream_test = {
+	// speed garbo
+	{ "Xf0fbf2b1f5f1583f7f9faadb89f149c25d2ab8f3",
+	  30.f }, // reflec streams, att 1
+	{ "X984f26aacbe104976dfd80b002556c722163ba35", 21.f }, // chipwrecked hi19 5
+	{ "X3ecb1e6f7e1334218f0f71ff0ff3bea483210f86",
+	  28.f }, // amber starlight nb5
+	{ "X6be11ac59dcd2ef950bb28fec8cf0b05945c93ec", 27.f }, // tunak tunak hi19 4
+	{ "Xe4e68826a3d00062e163f3a29b42350f86089b26", 25.f }, // hallelujah minty 1
+	{ "X50e58103750092785dd9a4722477cc6ed1fea54e",
+	  25.5f }, // lofty's ending minty 1
+	{ "X3b87b6ac44151291b29e3fe2e8b047f6af28000e", 29.f },  // veda minty 1
+	{ "X8a7310367a2479daa48888b15b8be724452c4616", 29.5f }, // voodoo mon amour
+	{ "X24085a6e074ca3bd89c91b748d9b42061863e9c1", 25.f },  // electricity tim1
+};
+
+static unordered_map<std::string, float> stam_test = {
+	// stam garbo
+	{ "Xdd74f464e7acbab921b91a2b5100901af24b3054", 25.5f }, // ttatf icy x
+	{ "X30acaf360a0e56bcc1376d36a98d24090a65074d", 23.5f }, // magic cycles nb4
+	{ "X9cd21dc241d821b69967a0058ccadcedf3cc9545",
+	  30.5f }, // battle of arcane might skwid 6
+};
+
+static unordered_map<std::string, float> jack_test = {
+	// jack garbo
+	{ "Xcee78c72ba6ba436ba9325f030c482bf13843376", 17.5f }, // F odi 2
+	{ "X85e5db71c00c154dc2c58cf1a87f9fb5a6393b99",
+	  26.f }, // vital vitriol skwid 7
+};
+
+static unordered_map<std::string, float> tech_test = {
+	// technical garbo
+	{ "X87bc96672f47c365a12c7226b895d5535e5f1a60",
+	  20.f }, // timepiece phase ii hi19 4
+	{ "Xaab20a4cb1634a23ad6f077c4cb6fef755769e6e", 17.f },  // luna clock odi 2
+	{ "Xecbb9d26ff2e40424d3c09e2bfe405149b954e2b", 22.5f }, // azul beg odi 2
+	{ "X7071eca33dfbb4850059bb6b8718f0cf65e46168", 20.f },  // usatei edit odi 2
+	{ "X0b685f34b530af918de78b98f3a80890df324926",
+	  27.f }, // do you feel it minty 1
+	{ "X3e6a2f7e924b9b2cc784aa02c02ad2772cf77ea9", 25.5f }, // runaway minty 1
+};
 
 typedef RString SongDir;
 struct Group
@@ -369,6 +426,66 @@ SongManager::InitSongsFromDisk(LoadingWindow* ld)
 				   tm.GetDeltaTime());
 	for (auto& pair : cache)
 		delete pair;
+
+	// TESTING TESTING STUFF STUFF
+	vector<float> test_vals[NUM_Skillset];
+	for (auto& s : StepsByKey) {
+		if (stream_test.count(s.first)) {
+			test_vals[Skill_Stream].emplace_back(
+			  s.second->DoATestThing(stream_test.at(s.first), Skill_Stream));
+			continue;
+		}
+
+		if (js_test.count(s.first)) {
+			test_vals[Skill_Jumpstream].emplace_back(s.second->DoATestThing(
+			  js_test.at(s.first), Skill_Jumpstream));
+			continue;
+		}
+
+		if (stam_test.count(s.first)) {
+			test_vals[Skill_Stamina].emplace_back(
+			  s.second->DoATestThing(stam_test.at(s.first), Skill_Stamina));
+			continue;
+		}
+
+		if (tech_test.count(s.first)) {
+			test_vals[Skill_Technical].emplace_back(
+			  s.second->DoATestThing(tech_test.at(s.first), Skill_Technical));
+			continue;
+		}
+
+		if (jack_test.count(s.first)) {
+			test_vals[Skill_JackSpeed].emplace_back(
+			  s.second->DoATestThing(jack_test.at(s.first), Skill_JackSpeed));
+			continue;
+		}
+	}
+
+	LOG->Trace("Test stream avg differential %f",
+			   std::accumulate(begin(test_vals[Skill_Stream]),
+							   end(test_vals[Skill_Stream]),
+							   0.f) /
+				 test_vals[Skill_Stream].size());
+	LOG->Trace("Test js avg differential %f",
+			   std::accumulate(begin(test_vals[Skill_Jumpstream]),
+							   end(test_vals[Skill_Jumpstream]),
+							   0.f) /
+				 test_vals[Skill_Jumpstream].size());
+	LOG->Trace("Test stam avg differential %f",
+			   std::accumulate(begin(test_vals[Skill_Stamina]),
+							   end(test_vals[Skill_Stamina]),
+							   0.f) /
+				 test_vals[Skill_Stamina].size());
+	LOG->Trace("Test tech avg differential %f",
+			   std::accumulate(begin(test_vals[Skill_Technical]),
+							   end(test_vals[Skill_Technical]),
+							   0.f) /
+				 test_vals[Skill_Technical].size());
+	LOG->Trace("Test jack avg differential %f",
+			   std::accumulate(begin(test_vals[Skill_JackSpeed]),
+							   end(test_vals[Skill_JackSpeed]),
+							   0.f) /
+				 test_vals[Skill_JackSpeed].size());
 	cache.clear();
 }
 

--- a/src/RageUtil/Utils/RageUtil.h
+++ b/src/RageUtil/Utils/RageUtil.h
@@ -800,14 +800,14 @@ FindIndex(T1 begin, T1 end, const T2* p)
 /* Useful for objects with no operator-, eg. map::iterator (more convenient than
  * advance). */
 template<class T>
-T
+inline T
 Increment(T a)
 {
 	++a;
 	return a;
 }
 template<class T>
-T
+inline T
 Decrement(T a)
 {
 	--a;


### PR DESCRIPTION
calc:
- back to refactored calc after fixing most of the bugs and verifying output outside of normalizer removal is the same
- normalizers removed, this means mods are probably going to need to push up and down, not just down
- enum'd pattern mods and some other stuff for easy iteration and debug output
- completely rewrote the roll detection/ohjump detection; both are now sequential
- added some pattern mods with rough implementations that will probably be needed in the future, or maybe not and then they'd just be place holders for something else
- redid all the debug output to be done in one pass, it's much faster now
- general ratings not tuned yet
- added basic automated testing that needs more cases before its really that useful, but the support is there and can be expanded to psuedo unit tests for specific patterns
- added a bunch of comments on stuff so it's more accessible 
- added back the old calc as a separate entity for instant comparison to 263 for when you know, i care about having that
- fixed a bug with serializenotedata2 which should probably not have been here but also oh well

calcdisplay:
- redid all the lua to match new debug output structure, it's more confusing and somehow less readable and also really annoying but it's probably more scalable
- disabled the ssr plots for the moment because they will probably need a new graph entirely