### PR TITLE
Fix #718 - macOS black screen

### DIFF
--- a/src/arch/Threads/Threads_Pthreads.cpp
+++ b/src/arch/Threads/Threads_Pthreads.cpp
@@ -340,11 +340,10 @@ EventImpl_Pthreads::Wait(RageTimer* pTimeout)
 		/* If we support condattr_setclock, we'll set the condition to use
 		 * the same clock as RageTimer and can use it directly. If the
 		 * clock is CLOCK_REALTIME, that's the default anyway. */
-		uint64_t usec = pTimeout->c_dur.count();
-		unsigned sec = floor(usec / 1000000);
-		unsigned nsec = (usec - sec * 1000000) * 1000;
-		abstime.tv_sec = sec;
-		abstime.tv_nsec = nsec;
+		auto nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(pTimeout->c_dur);
+		nsec -= std::chrono::duration_cast<std::chrono::seconds>(pTimeout->c_dur);
+		abstime.tv_sec = pTimeout->c_dur.count();
+		abstime.tv_nsec = nsec.count();
 	} else {
 		// The RageTimer clock is different than the wait clock; convert it.
 		timeval tv;
@@ -355,11 +354,10 @@ EventImpl_Pthreads::Wait(RageTimer* pTimeout)
 		float fSecondsInFuture = -pTimeout->Ago();
 		timeofday += fSecondsInFuture;
 
-		uint64_t usec = timeofday.c_dur.count();
-		unsigned sec = floor(usec / 1000000);
-		unsigned nsec = (usec - sec * 1000000) * 1000;
-		abstime.tv_sec = sec;
-		abstime.tv_nsec = nsec;
+		auto nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(timeofday.c_dur);
+		nsec -= std::chrono::duration_cast<std::chrono::seconds>(timeofday.c_dur);
+		abstime.tv_sec = pTimeout->c_dur.count();
+		abstime.tv_nsec = nsec.count();
 	}
 
 	int iRet = pthread_cond_timedwait(&m_Cond, &m_pParent->mutex, &abstime);


### PR DESCRIPTION
Due to previous changes to RageTimer, a macOS thread wait function calculated the time incorrectly. This PR fixes #719, the black screen issue when loading the game screen.