### PR TITLE
Fix Github Action for Coverity Scan 

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -17,7 +17,7 @@ jobs:
           path: main
 
       - name: Install apt dependencies
-        run: sudo apt-get install ninja-build
+        run: sudo apt-get install ninja-build nasm libglew-dev libxrandr-dev libxtst-dev libpulse-dev libasound-dev libogg-dev libvorbis-dev
 
       - name: Download Coverity Build Tool
         run: |


### PR DESCRIPTION
Libraries needed to build game are being installed by the CI.