### PR TITLE
Refactor MusicWheel::FilterBySkillsets to fix several bugs and make it easier to mantain in the future

### DIFF
--- a/src/Etterna/Actor/Menus/MusicWheel.cpp
+++ b/src/Etterna/Actor/Menus/MusicWheel.cpp
@@ -732,10 +732,8 @@ MusicWheel::FilterBySkillsets(vector<Song*>& inv)
 			float ub = FILTERMAN->SSFilterUpperBounds[ss];
 			//If either bound is active, continue to evaluation
 			if (lb > 0.f || ub > 0.f) {
-				float currate = FILTERMAN->MaxFilterRate + 0.1f;
-				float minrate = FILTERMAN->m_pPlayerState->wtFFF;
-				do {
-					currate = currate - 0.1f;
+				for(float currate = FILTERMAN->MaxFilterRate;
+					currate < FILTERMAN->m_pPlayerState->wtFFF; currate -= 0.1f) {
 					if (!FILTERMAN->ExclusiveFilter) { //Non-Exclusive filter
 						if (FILTERMAN->HighestSkillsetsOnly)
 							if (!song->IsSkillsetHighestOfAnySteps(
@@ -771,8 +769,7 @@ MusicWheel::FilterBySkillsets(vector<Song*>& inv)
 							addsong=true;
 						}
 					}
-					
-				} while (currate > minrate);
+				}
 			}
 		}
 		// only add the song if it's cleared the gauntlet

--- a/src/Etterna/Actor/Menus/MusicWheel.cpp
+++ b/src/Etterna/Actor/Menus/MusicWheel.cpp
@@ -728,8 +728,7 @@ MusicWheel::FilterBySkillsets(vector<Song*>& inv)
 								 * The .01f delta is because floating points
 								 * don't like exact equivalency*/
 			if (song->MatchesFilter(currate)) {
-				// TODO: Check only relevant chart type. Currently we search
-				// all.
+				// TODO: Check only relevant chart type. (Dance, solo, etc...)
 				addsong = true;
 				break; // We don't need to keep checking rates
 			}

--- a/src/Etterna/Actor/Menus/MusicWheel.cpp
+++ b/src/Etterna/Actor/Menus/MusicWheel.cpp
@@ -727,62 +727,8 @@ MusicWheel::FilterBySkillsets(vector<Song*>& inv)
 			 currate -= 0.1f) { /* Iterate over all possible rates.
 								 * The .01f delta is because floating points
 								 * don't like exact equivalency*/
-
-			bool addsong_this_rate = FILTERMAN->ExclusiveFilter;
-			/* The default behaviour of an exclusive filter is to accept
-			 * by default, (i.e. addsong_this_rate=true) and reject if any
-			 * filters fail. The default behaviour of a non-exclusive filter is
-			 * the exact opposite: reject by default (i.e.
-			 * addsong_this_rate=false), and accept if any filters match.
-			 */
-			for (int ss = 0; ss < NUM_Skillset + 1; ss++) {
-				float lb = FILTERMAN->SSFilterLowerBounds[ss];
-				float ub = FILTERMAN->SSFilterUpperBounds[ss];
-
-				if (lb > 0.f ||
-					ub > 0.f) { // If either bound is active, continue
-
-					if (!FILTERMAN->ExclusiveFilter) { // Non-Exclusive filter
-						if (FILTERMAN->HighestSkillsetsOnly)
-							if (!song->IsSkillsetHighestOfAnySteps(
-								  static_cast<Skillset>(ss), currate) &&
-								ss < NUM_Skillset) // The current skill is not
-												   // in highest in the chart
-								continue;
-					}
-					float val;
-					if (ss < NUM_Skillset)
-						val = song->GetHighestOfSkillsetAllSteps(ss, currate);
-					else {
-						TimingData* td =
-						  song->GetAllSteps()[0]->GetTimingData();
-						val =
-						  (td->GetElapsedTimeFromBeat(song->GetLastBeat()) -
-						   td->GetElapsedTimeFromBeat(song->GetFirstBeat()));
-					}
-					if (FILTERMAN->ExclusiveFilter) {
-						/* Our behaviour is to accept by default,
-						 * but reject if any filters don't match.*/
-						if ((val < lb && lb > 0.f) || (val > ub && ub > 0.f)) {
-							/* If we're below the lower bound and it's set,
-							 * or above the upper bound and it's set*/
-							addsong_this_rate = false;
-							break;
-						}
-					} else { // Non-Exclusive Filter
-						/* Our behaviour is to reject by default,
-						 * but accept if any filters match.*/
-						if ((val > lb || !(lb > 0.f)) &&
-							(val < ub || !(ub > 0.f))) {
-							/* If we're above the lower bound or it's not set
-							 * and also below the upper bound or it isn't set*/
-							addsong_this_rate = true;
-							break;
-						}
-					}
-				}
-			}
-			if (addsong_this_rate) {
+			if (song->MatchesFilter(currate)) {
+				//TODO: Check only relevant chart type. Currently we search all.
 				addsong = true;
 				break; // We don't need to keep checking rates
 			}

--- a/src/Etterna/Actor/Menus/MusicWheel.cpp
+++ b/src/Etterna/Actor/Menus/MusicWheel.cpp
@@ -719,72 +719,76 @@ void
 MusicWheel::FilterBySkillsets(vector<Song*>& inv)
 {
 	vector<Song*> tmp;
-	
+
 	for (auto song : inv) {
-		bool addsong=false;
-		for(float currate = FILTERMAN->MaxFilterRate;
-			currate > FILTERMAN->m_pPlayerState->wtFFF - .01f; currate -= 0.1f
-		) { /* Iterate over all possible rates.
-			 * The .01f delta is because floating points don't like exact equivalency*/
-			
+		bool addsong = false;
+		for (float currate = FILTERMAN->MaxFilterRate;
+			 currate > FILTERMAN->m_pPlayerState->wtFFF - .01f;
+			 currate -= 0.1f) { /* Iterate over all possible rates.
+								 * The .01f delta is because floating points
+								 * don't like exact equivalency*/
+
 			bool addsong_this_rate = FILTERMAN->ExclusiveFilter;
 			/* The default behaviour of an exclusive filter is to accept
-			* by default, (i.e. addsong_this_rate=true) and reject if any filters fail.
-			* The default behaviour of a non-exclusive filter is the exact opposite:
-			* reject by default (i.e. addsong_this_rate=false), and accept if any filters match.
-			*/
+			 * by default, (i.e. addsong_this_rate=true) and reject if any
+			 * filters fail. The default behaviour of a non-exclusive filter is
+			 * the exact opposite: reject by default (i.e.
+			 * addsong_this_rate=false), and accept if any filters match.
+			 */
 			for (int ss = 0; ss < NUM_Skillset + 1; ss++) {
 				float lb = FILTERMAN->SSFilterLowerBounds[ss];
 				float ub = FILTERMAN->SSFilterUpperBounds[ss];
-				
-				if (lb > 0.f || ub > 0.f) { //If either bound is active, continue
-					
-					if (!FILTERMAN->ExclusiveFilter) { //Non-Exclusive filter
+
+				if (lb > 0.f ||
+					ub > 0.f) { // If either bound is active, continue
+
+					if (!FILTERMAN->ExclusiveFilter) { // Non-Exclusive filter
 						if (FILTERMAN->HighestSkillsetsOnly)
 							if (!song->IsSkillsetHighestOfAnySteps(
 								  static_cast<Skillset>(ss), currate) &&
-								  ss < NUM_Skillset
-								) //The current skill is not in highest in the chart
-									continue;
-							
+								ss < NUM_Skillset) // The current skill is not
+												   // in highest in the chart
+								continue;
 					}
 					float val;
 					if (ss < NUM_Skillset)
 						val = song->GetHighestOfSkillsetAllSteps(ss, currate);
 					else {
-						TimingData* td = song->GetAllSteps()[0]->GetTimingData();
-						val = (td->GetElapsedTimeFromBeat(
-								 song->GetLastBeat()) -
-							   td->GetElapsedTimeFromBeat(
-								 song->GetFirstBeat()));
+						TimingData* td =
+						  song->GetAllSteps()[0]->GetTimingData();
+						val =
+						  (td->GetElapsedTimeFromBeat(song->GetLastBeat()) -
+						   td->GetElapsedTimeFromBeat(song->GetFirstBeat()));
 					}
-					if(FILTERMAN->ExclusiveFilter){
+					if (FILTERMAN->ExclusiveFilter) {
 						/* Our behaviour is to accept by default,
 						 * but reject if any filters don't match.*/
 						if ((val < lb && lb > 0.f) || (val > ub && ub > 0.f)) {
 							/* If we're below the lower bound and it's set,
 							 * or above the upper bound and it's set*/
-							addsong_this_rate=false;
+							addsong_this_rate = false;
 							break;
 						}
-					}else{ //Non-Exclusive Filter
+					} else { // Non-Exclusive Filter
 						/* Our behaviour is to reject by default,
 						 * but accept if any filters match.*/
-						if ((val > lb || !(lb > 0.f)) && (val < ub || !(ub > 0.f))) {
-							/* If we're above the lower bound or it's not set and also
-							 * below the upper bound or it isn't set*/
-							addsong_this_rate=true;
+						if ((val > lb || !(lb > 0.f)) &&
+							(val < ub || !(ub > 0.f))) {
+							/* If we're above the lower bound or it's not set
+							 * and also below the upper bound or it isn't set*/
+							addsong_this_rate = true;
 							break;
 						}
 					}
 				}
 			}
-			if(addsong_this_rate){
-				addsong=true;
-				break; // We don't need to keep checking through this song's rates
+			if (addsong_this_rate) {
+				addsong = true;
+				break; // We don't need to keep checking rates
 			}
 		}
-		if (addsong) tmp.emplace_back(song);
+		if (addsong)
+			tmp.emplace_back(song);
 	}
 	inv.swap(tmp);
 }

--- a/src/Etterna/Actor/Menus/MusicWheel.cpp
+++ b/src/Etterna/Actor/Menus/MusicWheel.cpp
@@ -22,6 +22,8 @@
 #include "Etterna/Models/StepsAndStyles/Style.h"
 #include "Etterna/Singletons/ThemeManager.h"
 
+#include <optional>
+
 #define NUM_WHEEL_ITEMS (static_cast<int>(ceil(NUM_WHEEL_ITEMS_TO_DRAW + 2)))
 #define WHEEL_TEXT(s)                                                          \
 	THEME->GetString("MusicWheel", ssprintf("%sText", s.c_str()));
@@ -727,8 +729,10 @@ MusicWheel::FilterBySkillsets(vector<Song*>& inv)
 			 currate -= 0.1f) { /* Iterate over all possible rates.
 								 * The .01f delta is because floating points
 								 * don't like exact equivalency*/
-			if (song->MatchesFilter(currate)) {
-				// TODO: Check only relevant chart type. (Dance, solo, etc...)
+			std::vector<StepsType> types;
+			GAMEMAN->GetStepsTypesForGame(GAMESTATE->m_pCurGame, types);
+			// Only consider the current game chart types as possible options.
+			if (song->MatchesFilter(currate, std::make_optional(types))) {
 				addsong = true;
 				break; // We don't need to keep checking rates
 			}

--- a/src/Etterna/Actor/Menus/MusicWheel.cpp
+++ b/src/Etterna/Actor/Menus/MusicWheel.cpp
@@ -720,9 +720,9 @@ MusicWheel::FilterBySkillsets(vector<Song*>& inv)
 {
 	vector<Song*> tmp;
 	
-	for (size_t i = 0; i < inv.size(); i++) {
-		/* The default behaviour of an exclusive filter, where every filter has to match
-		 * is to accept by default, (i.e. addsong=true) and reject if any filters fail.
+	for (auto song : inv) {
+		/* The default behaviour of an exclusive filter is to accept
+		 * by default, (i.e. addsong=true) and reject if any filters fail.
 		 * The default behaviour of a non-exclusive filter is the exact opposite:
 		 * reject by default (i.e. addsong=false), and accept if any filters match.
 		 */
@@ -738,7 +738,7 @@ MusicWheel::FilterBySkillsets(vector<Song*>& inv)
 					currate = currate - 0.1f;
 					if (!FILTERMAN->ExclusiveFilter) { //Non-Exclusive filter
 						if (FILTERMAN->HighestSkillsetsOnly)
-							if (!inv[i]->IsSkillsetHighestOfAnySteps(
+							if (!song->IsSkillsetHighestOfAnySteps(
 								  static_cast<Skillset>(ss), currate) &&
 								  ss < NUM_Skillset
 								) //The current skill is not in highest in the chart
@@ -746,15 +746,13 @@ MusicWheel::FilterBySkillsets(vector<Song*>& inv)
 					}
 					float val;
 					if (ss < NUM_Skillset)
-						val =
-						  inv[i]->GetHighestOfSkillsetAllSteps(ss, currate);
+						val = song->GetHighestOfSkillsetAllSteps(ss, currate);
 					else {
-						TimingData* td =
-						  inv[i]->GetAllSteps()[0]->GetTimingData();
+						TimingData* td = song->GetAllSteps()[0]->GetTimingData();
 						val = (td->GetElapsedTimeFromBeat(
-								 inv[i]->GetLastBeat()) -
+								 song->GetLastBeat()) -
 							   td->GetElapsedTimeFromBeat(
-								 inv[i]->GetFirstBeat()));
+								 song->GetFirstBeat()));
 					}
 					if(FILTERMAN->ExclusiveFilter){
 						/* Our behaviour is to accept by default,
@@ -779,7 +777,7 @@ MusicWheel::FilterBySkillsets(vector<Song*>& inv)
 		}
 		// only add the song if it's cleared the gauntlet
 		if (addsong)
-			tmp.emplace_back(inv[i]);
+			tmp.emplace_back(song);
 	}
 	inv.swap(tmp);
 }

--- a/src/Etterna/Actor/Menus/MusicWheel.cpp
+++ b/src/Etterna/Actor/Menus/MusicWheel.cpp
@@ -21,7 +21,7 @@
 #include "Etterna/Models/Songs/SongUtil.h"
 #include "Etterna/Models/StepsAndStyles/Style.h"
 #include "Etterna/Singletons/ThemeManager.h"
-#include <iostream> //Remove me!
+
 #define NUM_WHEEL_ITEMS (static_cast<int>(ceil(NUM_WHEEL_ITEMS_TO_DRAW + 2)))
 #define WHEEL_TEXT(s)                                                          \
 	THEME->GetString("MusicWheel", ssprintf("%sText", s.c_str()));

--- a/src/Etterna/Actor/Menus/MusicWheel.cpp
+++ b/src/Etterna/Actor/Menus/MusicWheel.cpp
@@ -748,22 +748,11 @@ MusicWheel::FilterBySkillsets(vector<Song*>& inv)
 								   td->GetElapsedTimeFromBeat(
 									 inv[i]->GetFirstBeat()));
 						}
-
-						bool isrange =
-						  lb > 0.f && ub > 0.f; // both bounds are active and
-												// create an explicit range
-						if (isrange) {
-							if (val > lb && val < ub) // if dealing with an
-													  // explicit range evaluate
-													  // as such
-								addsong = addsong || true;
-						} else {
-							if (lb > 0.f && val > lb) // must be a nicer way to
-													  // handle this but im
-													  // tired
-								addsong = addsong || true;
-							if (ub > 0.f && val < ub)
-								addsong = addsong || true;
+						
+						if((val > lb || !(lb > 0.f)) && (val < ub || !(ub > 0.f))){
+							/* If we're above the lower bound or it's not set and also
+							 * below the upper bound or it isn't set*/
+							addsong=true;
 						}
 					} while (currate > minrate);
 				}
@@ -776,16 +765,14 @@ MusicWheel::FilterBySkillsets(vector<Song*>& inv)
 		for (size_t i = 0; i < inv.size(); i++) {
 			bool addsong = true;
 			for (int ss = 0; ss < NUM_Skillset + 1; ss++) {
-				bool pineapple = true;
+				/* Iterate through all skill filters. If any are *not* met, set
+				 * addsong to false*/
 				float lb = FILTERMAN->SSFilterLowerBounds[ss];
 				float ub = FILTERMAN->SSFilterUpperBounds[ss];
 				if (lb > 0.f || ub > 0.f) {
-					bool localaddsong;
 					float currate = FILTERMAN->MaxFilterRate + 0.1f;
 					float minrate = FILTERMAN->m_pPlayerState->wtFFF;
-					bool toiletpaper = false;
 					do {
-						localaddsong = true;
 						currate = currate - 0.1f;
 						float val;
 						if (ss < NUM_Skillset)
@@ -799,21 +786,14 @@ MusicWheel::FilterBySkillsets(vector<Song*>& inv)
 								   td->GetElapsedTimeFromBeat(
 									 inv[i]->GetFirstBeat()));
 						}
-						bool isrange = lb > 0.f && ub > 0.f;
-						if (isrange) {
-							if (val < lb || val > ub)
-								localaddsong = false;
-						} else {
-							if (lb > 0.f && val < lb)
-								localaddsong = false;
-							if (ub > 0.f && val > ub)
-								localaddsong = false;
+						
+						if((val < lb && lb > 0.f) || (val > ub && ub > 0.f)){
+							/* If we're below the lower bound and it's set,
+							 * or above the upper bound and it's set*/
+							addsong=false;
 						}
-						toiletpaper = localaddsong || toiletpaper;
 					} while (currate > minrate);
-					pineapple = pineapple && toiletpaper;
 				}
-				addsong = addsong && pineapple;
 			}
 			if (addsong)
 				tmp.emplace_back(inv[i]);

--- a/src/Etterna/Actor/Menus/MusicWheel.cpp
+++ b/src/Etterna/Actor/Menus/MusicWheel.cpp
@@ -728,7 +728,8 @@ MusicWheel::FilterBySkillsets(vector<Song*>& inv)
 								 * The .01f delta is because floating points
 								 * don't like exact equivalency*/
 			if (song->MatchesFilter(currate)) {
-				//TODO: Check only relevant chart type. Currently we search all.
+				// TODO: Check only relevant chart type. Currently we search
+				// all.
 				addsong = true;
 				break; // We don't need to keep checking rates
 			}

--- a/src/Etterna/Models/Songs/Song.cpp
+++ b/src/Etterna/Models/Songs/Song.cpp
@@ -1702,7 +1702,7 @@ Song::IsSkillsetHighestOfAnySteps(Skillset ss, float rate)
 	vector<Steps*> vsteps = GetAllSteps();
 	FOREACH(Steps*, vsteps, steps)
 	{
-		auto sortedstuffs = (*steps)->SortSkillsetsAtRate(rate, true);
+		auto sortedstuffs = (*steps)->SortSkillsetsAtRate(rate, false);
 		if (sortedstuffs[0].first == ss)
 			return true;
 	}

--- a/src/Etterna/Models/Songs/Song.cpp
+++ b/src/Etterna/Models/Songs/Song.cpp
@@ -1712,14 +1712,21 @@ Song::IsSkillsetHighestOfAnySteps(Skillset ss, float rate) const
 }
 
 bool
-Song::MatchesFilter(const float rate,
-					const std::optional<const StepsType> type) const
+Song::MatchesFilter(
+  const float rate,
+  const std::optional<const std::vector<StepsType>> types) const
 {
 	vector<Steps*> steps;
-	if (type)
-		steps = GetStepsByStepsType(*type);
-	else
+	if (types) {
+		for (auto type : *types) {
+			vector<Steps*> tmp =
+			  GetStepsByStepsType(type); // Get all charts of type "type"
+			steps.insert(
+			  steps.end(), tmp.begin(), tmp.end()); // Append them to the list
+		}
+	} else {
 		steps = GetAllSteps();
+	}
 
 	for (const auto step : steps) {
 		// Iterate over all maps of the given type

--- a/src/Etterna/Models/Songs/Song.cpp
+++ b/src/Etterna/Models/Songs/Song.cpp
@@ -1738,6 +1738,8 @@ Song::MatchesFilter(
 		 * addsong=false), and accept if any filters match.
 		 */
 		for (int ss = 0; ss < NUM_Skillset + 1; ss++) {
+			// Iterate over all skillsets, up to and
+			// including the placeholder NUM_Skillset
 			float lb = FILTERMAN->SSFilterLowerBounds[ss];
 			float ub = FILTERMAN->SSFilterUpperBounds[ss];
 			if (lb > 0.f || ub > 0.f) { // If either bound is active, continue
@@ -1754,6 +1756,8 @@ Song::MatchesFilter(
 				if (ss < NUM_Skillset)
 					val = step->GetMSD(rate, ss);
 				else {
+					// If we are on the placeholder skillset, look at song
+					// length instead of a skill
 					TimingData* td = step->GetTimingData();
 					val = (td->GetElapsedTimeFromBeat(GetLastBeat()) -
 						   td->GetElapsedTimeFromBeat(GetFirstBeat())) /

--- a/src/Etterna/Models/Songs/Song.cpp
+++ b/src/Etterna/Models/Songs/Song.cpp
@@ -34,6 +34,7 @@
 #include "Etterna/Actor/Base/ActorUtil.h"
 #include "Etterna/Models/Misc/CommonMetrics.h"
 #include "Etterna/Singletons/GameSoundManager.h"
+#include "Etterna/Singletons/FilterManager.h"
 
 #include "Etterna/Singletons/GameState.h"
 #include <cfloat>
@@ -1697,7 +1698,7 @@ Song::GetHighestOfSkillsetAllSteps(int x, float rate) const
 }
 
 bool
-Song::IsSkillsetHighestOfAnySteps(Skillset ss, float rate)
+Song::IsSkillsetHighestOfAnySteps(Skillset ss, float rate) const
 {
 	vector<Steps*> vsteps = GetAllSteps();
 	FOREACH(Steps*, vsteps, steps)
@@ -1709,6 +1710,68 @@ Song::IsSkillsetHighestOfAnySteps(Skillset ss, float rate)
 
 	return false;
 }
+
+bool Song::MatchesFilter(const float rate,const StepsType type) const{
+	vector<Steps*> steps;
+	if(type!=StepsType_Invalid) steps=GetStepsByStepsType(type);
+	else steps=GetAllSteps();
+	
+	for(const auto step : steps){
+		//Iterate over all maps of the given type
+		bool addsong = FILTERMAN->ExclusiveFilter;
+		/* The default behaviour of an exclusive filter is to accept
+		 * by default, (i.e. addsong=true) and reject if any
+		 * filters fail. The default behaviour of a non-exclusive filter is
+		 * the exact opposite: reject by default (i.e.
+		 * addsong=false), and accept if any filters match.
+		 */
+		for (int ss = 0; ss < NUM_Skillset + 1; ss++) {
+			float lb = FILTERMAN->SSFilterLowerBounds[ss];
+			float ub = FILTERMAN->SSFilterUpperBounds[ss];
+			if (lb > 0.f || ub > 0.f) { // If either bound is active, continue
+				
+				if (!FILTERMAN->ExclusiveFilter) { // Non-Exclusive filter
+					if (FILTERMAN->HighestSkillsetsOnly)
+						if (!IsSkillsetHighestOfAnySteps(static_cast<Skillset>(ss), rate) && ss < NUM_Skillset) // The current skill is not
+											      // in highest in the chart
+								continue;
+				}
+				float val;
+				if (ss < NUM_Skillset)
+					val = step->GetMSD(rate,ss);
+				else {
+					TimingData* td = step->GetTimingData();
+					val = (td->GetElapsedTimeFromBeat(GetLastBeat()) -
+					   td->GetElapsedTimeFromBeat(GetFirstBeat())) / rate;
+					//Rates modify the song length.
+				}
+				if (FILTERMAN->ExclusiveFilter) {
+					/* Our behaviour is to accept by default,
+					 * but reject if any filters don't match.*/
+					if ((val < lb && lb > 0.f) || (val > ub && ub > 0.f)) {
+						/* If we're below the lower bound and it's set,
+						 * or above the upper bound and it's set*/
+						addsong = false;
+						break;
+					}
+				} else { // Non-Exclusive Filter
+					/* Our behaviour is to reject by default,
+					 * but accept if any filters match.*/
+					if ((val > lb || !(lb > 0.f)) &&
+						(val < ub || !(ub > 0.f))) {
+						/* If we're above the lower bound or it's not set
+						 * and also below the upper bound or it isn't set*/
+						addsong = true;
+						break;
+					}
+				}
+			}
+		}
+		if(addsong) return true;
+	}
+	return false;
+}
+
 
 bool
 Song::HasChartByHash(const string& hash)

--- a/src/Etterna/Models/Songs/Song.cpp
+++ b/src/Etterna/Models/Songs/Song.cpp
@@ -1712,11 +1712,12 @@ Song::IsSkillsetHighestOfAnySteps(Skillset ss, float rate) const
 }
 
 bool
-Song::MatchesFilter(const float rate, const StepsType type) const
+Song::MatchesFilter(const float rate,
+					const std::optional<const StepsType> type) const
 {
 	vector<Steps*> steps;
-	if (type != StepsType_Invalid)
-		steps = GetStepsByStepsType(type);
+	if (type)
+		steps = GetStepsByStepsType(*type);
 	else
 		steps = GetAllSteps();
 

--- a/src/Etterna/Models/Songs/Song.cpp
+++ b/src/Etterna/Models/Songs/Song.cpp
@@ -1711,13 +1711,17 @@ Song::IsSkillsetHighestOfAnySteps(Skillset ss, float rate) const
 	return false;
 }
 
-bool Song::MatchesFilter(const float rate,const StepsType type) const{
+bool
+Song::MatchesFilter(const float rate, const StepsType type) const
+{
 	vector<Steps*> steps;
-	if(type!=StepsType_Invalid) steps=GetStepsByStepsType(type);
-	else steps=GetAllSteps();
-	
-	for(const auto step : steps){
-		//Iterate over all maps of the given type
+	if (type != StepsType_Invalid)
+		steps = GetStepsByStepsType(type);
+	else
+		steps = GetAllSteps();
+
+	for (const auto step : steps) {
+		// Iterate over all maps of the given type
 		bool addsong = FILTERMAN->ExclusiveFilter;
 		/* The default behaviour of an exclusive filter is to accept
 		 * by default, (i.e. addsong=true) and reject if any
@@ -1729,21 +1733,24 @@ bool Song::MatchesFilter(const float rate,const StepsType type) const{
 			float lb = FILTERMAN->SSFilterLowerBounds[ss];
 			float ub = FILTERMAN->SSFilterUpperBounds[ss];
 			if (lb > 0.f || ub > 0.f) { // If either bound is active, continue
-				
+
 				if (!FILTERMAN->ExclusiveFilter) { // Non-Exclusive filter
 					if (FILTERMAN->HighestSkillsetsOnly)
-						if (!IsSkillsetHighestOfAnySteps(static_cast<Skillset>(ss), rate) && ss < NUM_Skillset) // The current skill is not
-											      // in highest in the chart
-								continue;
+						if (!IsSkillsetHighestOfAnySteps(
+							  static_cast<Skillset>(ss), rate) &&
+							ss < NUM_Skillset) // The current skill is not
+											   // in highest in the chart
+							continue;
 				}
 				float val;
 				if (ss < NUM_Skillset)
-					val = step->GetMSD(rate,ss);
+					val = step->GetMSD(rate, ss);
 				else {
 					TimingData* td = step->GetTimingData();
 					val = (td->GetElapsedTimeFromBeat(GetLastBeat()) -
-					   td->GetElapsedTimeFromBeat(GetFirstBeat())) / rate;
-					//Rates modify the song length.
+						   td->GetElapsedTimeFromBeat(GetFirstBeat())) /
+						  rate;
+					// Rates modify the song length.
 				}
 				if (FILTERMAN->ExclusiveFilter) {
 					/* Our behaviour is to accept by default,
@@ -1767,11 +1774,11 @@ bool Song::MatchesFilter(const float rate,const StepsType type) const{
 				}
 			}
 		}
-		if(addsong) return true;
+		if (addsong)
+			return true;
 	}
 	return false;
 }
-
 
 bool
 Song::HasChartByHash(const string& hash)
@@ -1956,7 +1963,7 @@ Song::UnloadAllCalcDebugOutput()
 {
 	for (auto s : m_vpSteps)
 		s->UnloadCalcDebugOutput();
-	}
+}
 
 bool
 Song::AnyChartUsesSplitTiming() const

--- a/src/Etterna/Models/Songs/Song.h
+++ b/src/Etterna/Models/Songs/Song.h
@@ -302,7 +302,10 @@ class Song
 	// Get the highest value for a specific skillset across all the steps
 	// objects for the song at a given rate
 	float GetHighestOfSkillsetAllSteps(int x, float rate) const;
-	bool IsSkillsetHighestOfAnySteps(Skillset ss, float rate);
+	bool IsSkillsetHighestOfAnySteps(Skillset ss, float rate) const;
+	/** @brief This functions returns whether it has any chart of the given type with the given rate.
+		@details If no type is given, or the type given is StepsType_Invalid, it checks all types.*/
+	bool MatchesFilter(const float rate,const StepsType type=StepsType_Invalid) const;
 
 	bool HasChartByHash(const string& hash);
 

--- a/src/Etterna/Models/Songs/Song.h
+++ b/src/Etterna/Models/Songs/Song.h
@@ -62,8 +62,8 @@ StringToInstrumentTrack(const RString& s);
 struct LyricSegment
 {
 	float m_fStartTime; /** @brief When does the lyric show up? */
-	RString m_sLyric;   /** @brief The lyrics themselves. */
-	RageColor m_Color;  /** @brief The color of the lyrics. */
+	RString m_sLyric;	/** @brief The lyrics themselves. */
+	RageColor m_Color;	/** @brief The color of the lyrics. */
 };
 
 /** @brief Holds all music metadata and steps for one song. */
@@ -79,7 +79,7 @@ class Song
 	enum SelectionDisplay
 	{
 		SHOW_ALWAYS, /**< always show on the wheel. */
-		SHOW_NEVER   /**< never show on the wheel (unless song hiding is turned
+		SHOW_NEVER	 /**< never show on the wheel (unless song hiding is turned
 						off). */
 	} m_SelectionDisplay;
 
@@ -258,7 +258,7 @@ class Song
 
 	RString m_sBannerFile; // typically a 16:5 ratio graphic (e.g. 256x80)
 	RString m_sJacketFile; // typically square (e.g. 192x192, 256x256)
-	RString m_sCDFile;	 // square (e.g. 128x128 [DDR 1st-3rd])
+	RString m_sCDFile;	   // square (e.g. 128x128 [DDR 1st-3rd])
 	RString m_sDiscFile;   // rectangular (e.g. 256x192 [Pump], 200x150 [MGD3])
 	RString m_sLyricsFile;
 	RString m_sBackgroundFile;
@@ -270,8 +270,8 @@ class Song
 	string m_sInstrumentTrackPath[NUM_InstrumentTrack];
 	string m_sBannerPath; // typically a 16:5 ratio graphic (e.g. 256x80)
 	string m_sJacketPath; // typically square (e.g. 192x192, 256x256)
-	string m_sCDPath;	 // square (e.g. 128x128 [DDR 1st-3rd])
-	string m_sDiscPath;   // rectangular (e.g. 256x192 [Pump], 200x150 [MGD3])
+	string m_sCDPath;	  // square (e.g. 128x128 [DDR 1st-3rd])
+	string m_sDiscPath;	  // rectangular (e.g. 256x192 [Pump], 200x150 [MGD3])
 	string m_sLyricsPath;
 	string m_sBackgroundPath;
 	string m_sCDTitlePath;
@@ -303,9 +303,12 @@ class Song
 	// objects for the song at a given rate
 	float GetHighestOfSkillsetAllSteps(int x, float rate) const;
 	bool IsSkillsetHighestOfAnySteps(Skillset ss, float rate) const;
-	/** @brief This functions returns whether it has any chart of the given type with the given rate.
-		@details If no type is given, or the type given is StepsType_Invalid, it checks all types.*/
-	bool MatchesFilter(const float rate,const StepsType type=StepsType_Invalid) const;
+	/** @brief This functions returns whether it has any chart of the given type
+	   with the given rate.
+		@details If no type is given, or the type given is StepsType_Invalid, it
+	   checks all types.*/
+	bool MatchesFilter(const float rate,
+					   const StepsType type = StepsType_Invalid) const;
 
 	bool HasChartByHash(const string& hash);
 

--- a/src/Etterna/Models/Songs/Song.h
+++ b/src/Etterna/Models/Songs/Song.h
@@ -304,11 +304,11 @@ class Song
 	// objects for the song at a given rate
 	float GetHighestOfSkillsetAllSteps(int x, float rate) const;
 	bool IsSkillsetHighestOfAnySteps(Skillset ss, float rate) const;
-	/** @brief This functions returns whether it has any chart of the given type
-	   with the given rate. If no type is given  it checks all types.*/
-	bool MatchesFilter(
-	  const float rate,
-	  const std::optional<const StepsType> type = std::nullopt) const;
+	/** @brief This functions returns whether it has any chart of the given
+	   types with the given rate. If no type is given  it checks all charts.*/
+	bool MatchesFilter(const float rate,
+					   const std::optional<const std::vector<StepsType>> types =
+						 std::nullopt) const;
 
 	bool HasChartByHash(const string& hash);
 

--- a/src/Etterna/Models/Songs/Song.h
+++ b/src/Etterna/Models/Songs/Song.h
@@ -9,6 +9,7 @@
 #include "Etterna/Models/StepsAndStyles/Steps.h"
 #include "Etterna/Models/Misc/TimingData.h"
 #include <set>
+#include <optional>
 using std::string;
 
 class Style;
@@ -304,11 +305,10 @@ class Song
 	float GetHighestOfSkillsetAllSteps(int x, float rate) const;
 	bool IsSkillsetHighestOfAnySteps(Skillset ss, float rate) const;
 	/** @brief This functions returns whether it has any chart of the given type
-	   with the given rate.
-		@details If no type is given, or the type given is StepsType_Invalid, it
-	   checks all types.*/
-	bool MatchesFilter(const float rate,
-					   const StepsType type = StepsType_Invalid) const;
+	   with the given rate. If no type is given  it checks all types.*/
+	bool MatchesFilter(
+	  const float rate,
+	  const std::optional<const StepsType> type = std::nullopt) const;
 
 	bool HasChartByHash(const string& hash);
 


### PR DESCRIPTION
This refactor accomplishes many things:
1) Filter logic has been cleaned up and duplicate code has been condensed.
This should make it significantly easier to modify filter logic in the future to fix issues.
2) Highest Skillset should now work as intended with filters.
Earlier, there were two issues. First, in the old code, the continue statement after  
after checking if a given skill was the highest in a chart would continue the ratemod loop, not the skillset loop.
Secondly, in `Song::IsSkillsetHighestOfAnySteps`,
 "Overall" was included as a result, which would always (naturally) be the highest. 
By setting a boolean flag inside the function to exclude "Overall" as an option in a sub-function, 'Highest Overall' now works as intended.
(Prior, 'Highest Overall' only worked if "Overall" was the only filter active)
3) Filter logic has been moved into a new function Song::MatchesFilter, which allows filters to easily look through all charts of a song and also only sort through certain chart types (currently unimplemented). This fixes #794.
4) Filters only consider charts that have the styles of the current game mode. 
(Using `GAMEMAN->GetStepsTypesForGame`). This fixes #781.

Close: #794
Close: #781

Note: People other than me should check to make sure that there aren't any (new) filter bugs 
from this PR. I'm fairly certain that there aren't, and I've done extensive testing without issues, but I have rather significantly modified the internals of the filter.

Other Note: It made sense to me to put the filter logic into a Song function. However, this could instead easily be a subfunction of MusicWheel. I think the logic makes more sense to be under Song, since it's directly relating to the logic of a song and not the MusicWheel itself, but this could be moved if desired.