### PR TITLE
Fix minor bug when sorting songs by skillset or overall MSD (Fix: 801)

### DIFF
--- a/src/Etterna/Actor/Menus/MusicWheel.cpp
+++ b/src/Etterna/Actor/Menus/MusicWheel.cpp
@@ -22,8 +22,6 @@
 #include "Etterna/Models/StepsAndStyles/Style.h"
 #include "Etterna/Singletons/ThemeManager.h"
 
-#include <optional>
-
 #define NUM_WHEEL_ITEMS (static_cast<int>(ceil(NUM_WHEEL_ITEMS_TO_DRAW + 2)))
 #define WHEEL_TEXT(s)                                                          \
 	THEME->GetString("MusicWheel", ssprintf("%sText", s.c_str()));
@@ -729,10 +727,7 @@ MusicWheel::FilterBySkillsets(vector<Song*>& inv)
 			 currate -= 0.1f) { /* Iterate over all possible rates.
 								 * The .01f delta is because floating points
 								 * don't like exact equivalency*/
-			std::vector<StepsType> types;
-			GAMEMAN->GetStepsTypesForGame(GAMESTATE->m_pCurGame, types);
-			// Only consider the current game chart types as possible options.
-			if (song->MatchesFilter(currate, std::make_optional(types))) {
+			if (song->MatchesFilter(currate)) {
 				addsong = true;
 				break; // We don't need to keep checking rates
 			}

--- a/src/Etterna/Models/Songs/Song.cpp
+++ b/src/Etterna/Models/Songs/Song.cpp
@@ -1607,16 +1607,35 @@ Song::GetPreviewStartSeconds() const
 	return 0.0f;
 }
 
+const vector<Steps*>
+Song::GetStepsOfCurrentGameMode() const
+{
+	std::vector<StepsType> types;
+	GAMEMAN->GetStepsTypesForGame(GAMESTATE->m_pCurGame, types);
+
+	vector<Steps*> steps;
+	for (auto type : types) {
+		vector<Steps*> tmp = GetStepsByStepsType(type);
+		steps.insert(steps.end(), tmp.begin(), tmp.end());
+	}
+	return steps;
+}
+
 float
-Song::GetHighestOfSkillsetAllSteps(int x, float rate) const
+Song::HighestMSDOfSkillset(Skillset skill, float rate) const
 {
 	CLAMP(rate, 0.7f, 2.f);
-	float o = 0.f;
-	vector<Steps*> vsteps = GetAllSteps();
-	FOREACH(Steps*, vsteps, steps)
-	if ((*steps)->GetMSD(rate, x) > o)
-		o = (*steps)->GetMSD(rate, x);
-	return o;
+	float highest = 0.f;
+
+	const vector<Steps*> steps = GetStepsOfCurrentGameMode();
+
+	for (auto step : steps) {
+		float current = step->GetMSD(rate, skill);
+		if (current > highest)
+			highest = current;
+	}
+
+	return highest;
 }
 
 bool
@@ -1634,21 +1653,9 @@ Song::IsSkillsetHighestOfAnySteps(Skillset ss, float rate) const
 }
 
 bool
-Song::MatchesFilter(
-  const float rate,
-  const std::optional<const std::vector<StepsType>> types) const
+Song::MatchesFilter(const float rate) const
 {
-	vector<Steps*> steps;
-	if (types) {
-		for (auto type : *types) {
-			vector<Steps*> tmp =
-			  GetStepsByStepsType(type); // Get all charts of type "type"
-			steps.insert(
-			  steps.end(), tmp.begin(), tmp.end()); // Append them to the list
-		}
-	} else {
-		steps = GetAllSteps();
-	}
+	vector<Steps*> steps = GetStepsOfCurrentGameMode();
 
 	for (const auto step : steps) {
 		// Iterate over all maps of the given type

--- a/src/Etterna/Models/Songs/Song.h
+++ b/src/Etterna/Models/Songs/Song.h
@@ -8,7 +8,6 @@
 #include "Etterna/Models/StepsAndStyles/Steps.h"
 #include "Etterna/Models/Misc/TimingData.h"
 #include <set>
-#include <optional>
 
 class Style;
 class StepsID;
@@ -298,15 +297,14 @@ class Song
 
 	// how have i not jammed anything here yet - mina
 
-	// Get the highest value for a specific skillset across all the steps
-	// objects for the song at a given rate
-	float GetHighestOfSkillsetAllSteps(int x, float rate) const;
+	/** @brief Get the highest value for a specific skillset for the song at a
+	 given rate, within the step types of the current game mode. */
+	float HighestMSDOfSkillset(Skillset skill, float rate) const;
 	bool IsSkillsetHighestOfAnySteps(Skillset ss, float rate) const;
-	/** @brief This functions returns whether it has any chart of the given
-	   types with the given rate. If no type is given  it checks all charts.*/
-	bool MatchesFilter(const float rate,
-					   const std::optional<const std::vector<StepsType>> types =
-						 std::nullopt) const;
+	/** @brief This functions returns whether the song has a chart within the
+	 current game mode and of the given rate that matches the current
+	 filter.*/
+	bool MatchesFilter(const float rate) const;
 
 	bool HasChartByHash(const std::string& hash);
 
@@ -415,6 +413,8 @@ class Song
 	{
 		return m_vpStepsByType[st];
 	}
+	/** @brief Get the steps of all types within the current game mode */
+	const vector<Steps*> GetStepsOfCurrentGameMode() const;
 	bool HasEdits(StepsType st) const;
 
 	bool IsFavorited() { return isfavorited; }

--- a/src/Etterna/Models/Songs/SongUtil.cpp
+++ b/src/Etterna/Models/Songs/SongUtil.cpp
@@ -381,12 +381,10 @@ static bool
 CompareSongPointersByMSD(const Song* pSong1, const Song* pSong2, Skillset ss)
 {
 	// Prefer transliterations to full titles
-	float msd1 = pSong1->GetHighestOfSkillsetAllSteps(
-	  static_cast<int>(ss),
-	  GAMESTATE->m_SongOptions.Get(ModsLevel_Current).m_fMusicRate);
-	float msd2 = pSong2->GetHighestOfSkillsetAllSteps(
-	  static_cast<int>(ss),
-	  GAMESTATE->m_SongOptions.Get(ModsLevel_Current).m_fMusicRate);
+	float msd1 = pSong1->HighestMSDOfSkillset(
+	  ss, GAMESTATE->m_SongOptions.Get(ModsLevel_Current).m_fMusicRate);
+	float msd2 = pSong2->HighestMSDOfSkillset(
+	  ss, GAMESTATE->m_SongOptions.Get(ModsLevel_Current).m_fMusicRate);
 
 	if (msd1 < msd2)
 		return true;


### PR DESCRIPTION
The function that found the highest MSD of a given skillset across the charts of a song incorrectly looked at charts from different game modes than the current one. This could lead to songs being incorrectly placed too high relative to others.

This PR modifies that function to make it return the highest MSD only from within the current game mode's chart types.

Close: #801