### PR TITLE
Make Highest-Only mode work correctly in filters

### DIFF
--- a/src/Etterna/Models/Songs/Song.cpp
+++ b/src/Etterna/Models/Songs/Song.cpp
@@ -1649,16 +1649,10 @@ Song::HighestMSDOfSkillset(Skillset skill, float rate) const
 }
 
 bool
-Song::IsSkillsetHighestOfAnySteps(Skillset ss, float rate) const
+Song::IsSkillsetHighestOfChart(Steps* chart, Skillset skill, float rate) const
 {
-	auto vsteps = GetAllSteps();
-	for (auto& steps : vsteps) {
-		auto sortedstuffs = steps->SortSkillsetsAtRate(rate, false);
-		if (sortedstuffs[0].first == ss)
-			return true;
-	}
-
-	return false;
+	auto sorted_skills = chart->SortSkillsetsAtRate(rate, false);
+	return (sorted_skills[0].first == skill);
 }
 
 bool
@@ -1684,8 +1678,8 @@ Song::MatchesFilter(const float rate) const
 
 				if (!FILTERMAN->ExclusiveFilter) { // Non-Exclusive filter
 					if (FILTERMAN->HighestSkillsetsOnly)
-						if (!IsSkillsetHighestOfAnySteps(
-							  static_cast<Skillset>(ss), rate) &&
+						if (!IsSkillsetHighestOfChart(
+							  chart, static_cast<Skillset>(ss), rate) &&
 							ss < NUM_Skillset) // The current skill is not
 											   // in highest in the chart
 							continue;

--- a/src/Etterna/Models/Songs/Song.h
+++ b/src/Etterna/Models/Songs/Song.h
@@ -341,8 +341,9 @@ class Song
 	// objects for the song at a given rate
 	[[nodiscard]] auto HighestMSDOfSkillset(Skillset x, float rate) const
 	  -> float;
-	[[nodiscard]] auto IsSkillsetHighestOfAnySteps(Skillset ss,
-												   float rate) const -> bool;
+	[[nodiscard]] auto IsSkillsetHighestOfChart(Steps* chart,
+												Skillset skill,
+												float rate) const -> bool;
 	/** @brief This functions returns whether it has any chart of the given
 	   types with the given rate. If no type is given  it checks all charts.*/
 	[[nodiscard]] auto MatchesFilter(float rate) const -> bool;


### PR DESCRIPTION
Earlier, highest-only mode would allow songs that had a particular skillset
as the highest in any of its charts to be included, even if the chart
that did so did not meet other filter criteria.

This commit changes the IsSkillsetHighestOfAnySteps function into a new
IsSkillsetHighestOfChart function, which takes in a Steps* as a parameter.