### PR TITLE
Fix a crash dereferencing m_ReplaySnapshotMap.rbegin()

### DIFF
--- a/src/Etterna/Models/Misc/PlayerAI.cpp
+++ b/src/Etterna/Models/Misc/PlayerAI.cpp
@@ -515,7 +515,8 @@ PlayerAI::SetUpSnapshotMap(NoteData* pNoteData,
 
 		} else {
 			// If the current row is after the last recorded row, make a new one
-			if (m_ReplaySnapshotMap.rbegin()->first < row) {
+			if (m_ReplaySnapshotMap.empty() ||
+				m_ReplaySnapshotMap.rbegin()->first < row) {
 				ReplaySnapshot rs;
 				FOREACH_ENUM(TapNoteScore, tns)
 				rs.judgments[tns] = tempJudgments[tns];


### PR DESCRIPTION
I don't know why this crash happens, but I can consistently trigger it by pressing "up" on the evaluation screen. This patch at least fixes the crash, if not the underlying root cause.

(I suspect there's something more deeply wrong with my game -- it refuses to save any replay files, which I suspect is related.)