### PR TITLE
Refactor SONGMAN from a singleton into a namespace

### DIFF
--- a/Themes/_fallback/Scripts/00 init.lua
+++ b/Themes/_fallback/Scripts/00 init.lua
@@ -25,6 +25,13 @@ Warn = lua.Warn
 -- @function print
 print = Trace
 
+--- alias for all Singletons for backwards compatibility
+--- moving to namespaces broke these, so this should allow them to function mostly the same.
+SONGMAN = {}
+for k,v in pairs(SongManager) do
+	SONGMAN[k] = function(_, ...) return v(...) end
+end
+
 -- Use MersenneTwister in place of math.random and math.randomseed.
 if MersenneTwister then
 	math.random = MersenneTwister.Random

--- a/src/Etterna/Actor/Menus/MusicWheel.cpp
+++ b/src/Etterna/Actor/Menus/MusicWheel.cpp
@@ -99,7 +99,7 @@ MusicWheel::Load(const string& sType)
 	/* Sort SONGMAN's songs by CompareSongPointersByTitle, so we can do other
 	 * sorts (with stable_sort) from its output, and title will be the secondary
 	 * sort, without having to re-sort by title each time. */
-	SONGMAN::SortSongs();
+	SongManager::SortSongs();
 
 	FOREACH_ENUM(SortOrder, so) { m_WheelItemDatasStatus[so] = INVALID; }
 }
@@ -161,7 +161,7 @@ MusicWheel::BeginScreen()
 		// gameplay or your last round song (profiles) is not the first one in
 		// the group.
 		for (unsigned idx = 0; idx < m_viWheelPositions.size(); idx++) {
-			if (m_sExpandedSectionName == SONGMAN::GetSongGroupByIndex(idx)) {
+			if (m_sExpandedSectionName == SongManager::GetSongGroupByIndex(idx)) {
 				m_viWheelPositions[idx] = m_iSelection;
 			}
 		}
@@ -319,7 +319,7 @@ MusicWheel::SelectSong(const Song* p) -> bool
 			SetOpenSection(from[i]->m_sText);
 
 			// skip any playlist groups
-			if (SONGMAN::GetPlaylists().count(GetExpandedSectionName()) == 0u) {
+			if (SongManager::GetPlaylists().count(GetExpandedSectionName()) == 0u) {
 				break;
 			}
 		}
@@ -382,7 +382,7 @@ MusicWheel::GetSongList(std::vector<Song*>& arraySongs,
 	std::vector<Song*> apAllSongs;
 	switch (so) {
 		case SORT_FAVORITES:
-			SONGMAN::GetFavoriteSongs(apAllSongs);
+			SongManager::GetFavoriteSongs(apAllSongs);
 			break;
 		case SORT_GROUP:
 			// if we're not using sections with a preferred song group, and
@@ -390,12 +390,12 @@ MusicWheel::GetSongList(std::vector<Song*>& arraySongs,
 			if (GAMESTATE->m_sPreferredSongGroup != GROUP_ALL &&
 				!USE_SECTIONS_WITH_PREFERRED_GROUP) {
 				apAllSongs =
-				  SONGMAN::GetSongs(GAMESTATE->m_sPreferredSongGroup);
+				  SongManager::GetSongs(GAMESTATE->m_sPreferredSongGroup);
 				break;
 			}
 			// otherwise fall through
 		default:
-			apAllSongs = SONGMAN::GetAllSongs();
+			apAllSongs = SongManager::GetAllSongs();
 			break;
 	}
 
@@ -709,7 +709,7 @@ MusicWheel::FilterByStepKeys(vector<Song*>& inv)
 auto
 MusicWheel::SearchGroupNames(const std::string& findme) -> bool
 {
-	const auto& grps = SONGMAN::GetSongGroupNames();
+	const auto& grps = SongManager::GetSongGroupNames();
 	for (const auto& grp : grps) {
 		auto lc = make_lower(std::string(grp));
 		const auto droop = lc.find(findme);
@@ -958,7 +958,7 @@ MusicWheel::BuildWheelItemDatas(
 						// todo: preferred sort section color handling? -aj
 						auto colorSection =
 						  (so == SORT_GROUP)
-							? SONGMAN::GetSongGroupColor(pSong->m_sGroupName)
+							? SongManager::GetSongGroupColor(pSong->m_sGroupName)
 							: SECTION_COLORS.GetValue(iSectionColorIndex);
 						iSectionColorIndex =
 						  (iSectionColorIndex + 1) % NUM_SECTION_COLORS;
@@ -975,7 +975,7 @@ MusicWheel::BuildWheelItemDatas(
 				  new MusicWheelItemData(WheelItemDataType_Song,
 										 pSong,
 										 sLastSection,
-										 SONGMAN::GetSongColor(pSong),
+										 SongManager::GetSongColor(pSong),
 										 0));
 			}
 		} else {
@@ -989,7 +989,7 @@ MusicWheel::BuildWheelItemDatas(
 				hurp.emplace(a);
 			}
 
-			auto& groups = SONGMAN::groupderps;
+			auto& groups = SongManager::groupderps;
 
 			std::map<std::string, std::string> shitterstrats;
 			for (auto& n : groups) {
@@ -1001,7 +1001,7 @@ MusicWheel::BuildWheelItemDatas(
 				auto& gname = n.second;
 				auto& gsongs = groups[n.second];
 
-				auto colorSection = SONGMAN::GetSongGroupColor(gname);
+				auto colorSection = SongManager::GetSongGroupColor(gname);
 				iSectionColorIndex =
 				  (iSectionColorIndex + 1) % NUM_SECTION_COLORS;
 				arrayWheelItemDatas.emplace_back(
@@ -1019,7 +1019,7 @@ MusicWheel::BuildWheelItemDatas(
 						  new MusicWheelItemData(WheelItemDataType_Song,
 												 s,
 												 gname,
-												 SONGMAN::GetSongColor(s),
+												 SongManager::GetSongColor(s),
 												 0));
 						if (allSongsByGroupFiltered.count(gname) != 0u) {
 							allSongsByGroupFiltered[gname].emplace_back(s);
@@ -1268,7 +1268,7 @@ MusicWheel::ChangeMusic(int iDist)
 	if (REMIND_WHEEL_POSITIONS && HIDE_INACTIVE_SECTIONS) {
 		// store the group song index
 		for (unsigned idx = 0; idx < m_viWheelPositions.size(); idx++) {
-			if (m_sExpandedSectionName == SONGMAN::GetSongGroupByIndex(idx)) {
+			if (m_sExpandedSectionName == SongManager::GetSongGroupByIndex(idx)) {
 				m_viWheelPositions[idx] = m_iSelection;
 			}
 		}
@@ -1427,7 +1427,7 @@ MusicWheel::SetOpenSection(const std::string& group)
 
 	// wheel positions = num song groups
 	if (REMIND_WHEEL_POSITIONS && HIDE_INACTIVE_SECTIONS) {
-		m_viWheelPositions.resize(SONGMAN::GetNumSongGroups());
+		m_viWheelPositions.resize(SongManager::GetNumSongGroups());
 	}
 
 	const WheelItemBaseData* old = nullptr;
@@ -1473,7 +1473,7 @@ MusicWheel::SetOpenSection(const std::string& group)
 	// restore the past group song index
 	if (REMIND_WHEEL_POSITIONS && HIDE_INACTIVE_SECTIONS) {
 		for (auto idx = 0; idx < (int)m_viWheelPositions.size(); ++idx) {
-			if (m_sExpandedSectionName == SONGMAN::GetSongGroupByIndex(idx)) {
+			if (m_sExpandedSectionName == SongManager::GetSongGroupByIndex(idx)) {
 				m_iSelection = m_viWheelPositions[idx];
 			}
 		}
@@ -1499,15 +1499,15 @@ MusicWheel::JumpToNextGroup() -> std::string
 	// Thanks to Juanelote for this logic:
 	if (HIDE_INACTIVE_SECTIONS) {
 		// todo: make it work with other sort types
-		const unsigned iNumGroups = SONGMAN::GetNumSongGroups();
+		const unsigned iNumGroups = SongManager::GetNumSongGroups();
 
 		for (unsigned i = 0; i < iNumGroups; i++) {
-			if (m_sExpandedSectionName == SONGMAN::GetSongGroupByIndex(i)) {
+			if (m_sExpandedSectionName == SongManager::GetSongGroupByIndex(i)) {
 				if (i < iNumGroups - 1) {
-					return SONGMAN::GetSongGroupByIndex(i + 1);
+					return SongManager::GetSongGroupByIndex(i + 1);
 				}
 				// i = 0;
-				return SONGMAN::GetSongGroupByIndex(0);
+				return SongManager::GetSongGroupByIndex(0);
 			}
 		}
 	} else {
@@ -1539,15 +1539,15 @@ auto
 MusicWheel::JumpToPrevGroup() -> std::string
 {
 	if (HIDE_INACTIVE_SECTIONS) {
-		const unsigned iNumGroups = SONGMAN::GetNumSongGroups();
+		const unsigned iNumGroups = SongManager::GetNumSongGroups();
 
 		for (unsigned i = 0; i < iNumGroups; i++) {
-			if (m_sExpandedSectionName == SONGMAN::GetSongGroupByIndex(i)) {
+			if (m_sExpandedSectionName == SongManager::GetSongGroupByIndex(i)) {
 				if (i > 0) {
-					return SONGMAN::GetSongGroupByIndex(i - 1);
+					return SongManager::GetSongGroupByIndex(i - 1);
 				}
 				// i = iNumGroups - 1;
-				return SONGMAN::GetSongGroupByIndex(iNumGroups - 1);
+				return SongManager::GetSongGroupByIndex(iNumGroups - 1);
 			}
 		}
 	} else {

--- a/src/Etterna/Actor/Menus/MusicWheel.cpp
+++ b/src/Etterna/Actor/Menus/MusicWheel.cpp
@@ -99,7 +99,7 @@ MusicWheel::Load(const string& sType)
 	/* Sort SONGMAN's songs by CompareSongPointersByTitle, so we can do other
 	 * sorts (with stable_sort) from its output, and title will be the secondary
 	 * sort, without having to re-sort by title each time. */
-	SONGMAN->SortSongs();
+	SONGMAN::SortSongs();
 
 	FOREACH_ENUM(SortOrder, so) { m_WheelItemDatasStatus[so] = INVALID; }
 }
@@ -161,7 +161,7 @@ MusicWheel::BeginScreen()
 		// gameplay or your last round song (profiles) is not the first one in
 		// the group.
 		for (unsigned idx = 0; idx < m_viWheelPositions.size(); idx++) {
-			if (m_sExpandedSectionName == SONGMAN->GetSongGroupByIndex(idx)) {
+			if (m_sExpandedSectionName == SONGMAN::GetSongGroupByIndex(idx)) {
 				m_viWheelPositions[idx] = m_iSelection;
 			}
 		}
@@ -319,8 +319,7 @@ MusicWheel::SelectSong(const Song* p) -> bool
 			SetOpenSection(from[i]->m_sText);
 
 			// skip any playlist groups
-			if (SongManager::GetPlaylists().count(GetExpandedSectionName()) ==
-				0u) {
+			if (SONGMAN::GetPlaylists().count(GetExpandedSectionName()) == 0u) {
 				break;
 			}
 		}
@@ -383,7 +382,7 @@ MusicWheel::GetSongList(std::vector<Song*>& arraySongs,
 	std::vector<Song*> apAllSongs;
 	switch (so) {
 		case SORT_FAVORITES:
-			SONGMAN->GetFavoriteSongs(apAllSongs);
+			SONGMAN::GetFavoriteSongs(apAllSongs);
 			break;
 		case SORT_GROUP:
 			// if we're not using sections with a preferred song group, and
@@ -391,12 +390,12 @@ MusicWheel::GetSongList(std::vector<Song*>& arraySongs,
 			if (GAMESTATE->m_sPreferredSongGroup != GROUP_ALL &&
 				!USE_SECTIONS_WITH_PREFERRED_GROUP) {
 				apAllSongs =
-				  SONGMAN->GetSongs(GAMESTATE->m_sPreferredSongGroup);
+				  SONGMAN::GetSongs(GAMESTATE->m_sPreferredSongGroup);
 				break;
 			}
 			// otherwise fall through
 		default:
-			apAllSongs = SONGMAN->GetAllSongs();
+			apAllSongs = SONGMAN::GetAllSongs();
 			break;
 	}
 
@@ -710,7 +709,7 @@ MusicWheel::FilterByStepKeys(vector<Song*>& inv)
 auto
 MusicWheel::SearchGroupNames(const std::string& findme) -> bool
 {
-	const auto& grps = SONGMAN->GetSongGroupNames();
+	const auto& grps = SONGMAN::GetSongGroupNames();
 	for (const auto& grp : grps) {
 		auto lc = make_lower(std::string(grp));
 		const auto droop = lc.find(findme);
@@ -959,7 +958,7 @@ MusicWheel::BuildWheelItemDatas(
 						// todo: preferred sort section color handling? -aj
 						auto colorSection =
 						  (so == SORT_GROUP)
-							? SONGMAN->GetSongGroupColor(pSong->m_sGroupName)
+							? SONGMAN::GetSongGroupColor(pSong->m_sGroupName)
 							: SECTION_COLORS.GetValue(iSectionColorIndex);
 						iSectionColorIndex =
 						  (iSectionColorIndex + 1) % NUM_SECTION_COLORS;
@@ -976,7 +975,7 @@ MusicWheel::BuildWheelItemDatas(
 				  new MusicWheelItemData(WheelItemDataType_Song,
 										 pSong,
 										 sLastSection,
-										 SONGMAN->GetSongColor(pSong),
+										 SONGMAN::GetSongColor(pSong),
 										 0));
 			}
 		} else {
@@ -990,7 +989,7 @@ MusicWheel::BuildWheelItemDatas(
 				hurp.emplace(a);
 			}
 
-			auto& groups = SONGMAN->groupderps;
+			auto& groups = SONGMAN::groupderps;
 
 			std::map<std::string, std::string> shitterstrats;
 			for (auto& n : groups) {
@@ -1002,7 +1001,7 @@ MusicWheel::BuildWheelItemDatas(
 				auto& gname = n.second;
 				auto& gsongs = groups[n.second];
 
-				auto colorSection = SONGMAN->GetSongGroupColor(gname);
+				auto colorSection = SONGMAN::GetSongGroupColor(gname);
 				iSectionColorIndex =
 				  (iSectionColorIndex + 1) % NUM_SECTION_COLORS;
 				arrayWheelItemDatas.emplace_back(
@@ -1020,7 +1019,7 @@ MusicWheel::BuildWheelItemDatas(
 						  new MusicWheelItemData(WheelItemDataType_Song,
 												 s,
 												 gname,
-												 SONGMAN->GetSongColor(s),
+												 SONGMAN::GetSongColor(s),
 												 0));
 						if (allSongsByGroupFiltered.count(gname) != 0u) {
 							allSongsByGroupFiltered[gname].emplace_back(s);
@@ -1269,7 +1268,7 @@ MusicWheel::ChangeMusic(int iDist)
 	if (REMIND_WHEEL_POSITIONS && HIDE_INACTIVE_SECTIONS) {
 		// store the group song index
 		for (unsigned idx = 0; idx < m_viWheelPositions.size(); idx++) {
-			if (m_sExpandedSectionName == SONGMAN->GetSongGroupByIndex(idx)) {
+			if (m_sExpandedSectionName == SONGMAN::GetSongGroupByIndex(idx)) {
 				m_viWheelPositions[idx] = m_iSelection;
 			}
 		}
@@ -1428,7 +1427,7 @@ MusicWheel::SetOpenSection(const std::string& group)
 
 	// wheel positions = num song groups
 	if (REMIND_WHEEL_POSITIONS && HIDE_INACTIVE_SECTIONS) {
-		m_viWheelPositions.resize(SONGMAN->GetNumSongGroups());
+		m_viWheelPositions.resize(SONGMAN::GetNumSongGroups());
 	}
 
 	const WheelItemBaseData* old = nullptr;
@@ -1474,7 +1473,7 @@ MusicWheel::SetOpenSection(const std::string& group)
 	// restore the past group song index
 	if (REMIND_WHEEL_POSITIONS && HIDE_INACTIVE_SECTIONS) {
 		for (auto idx = 0; idx < (int)m_viWheelPositions.size(); ++idx) {
-			if (m_sExpandedSectionName == SONGMAN->GetSongGroupByIndex(idx)) {
+			if (m_sExpandedSectionName == SONGMAN::GetSongGroupByIndex(idx)) {
 				m_iSelection = m_viWheelPositions[idx];
 			}
 		}
@@ -1500,15 +1499,15 @@ MusicWheel::JumpToNextGroup() -> std::string
 	// Thanks to Juanelote for this logic:
 	if (HIDE_INACTIVE_SECTIONS) {
 		// todo: make it work with other sort types
-		const unsigned iNumGroups = SONGMAN->GetNumSongGroups();
+		const unsigned iNumGroups = SONGMAN::GetNumSongGroups();
 
 		for (unsigned i = 0; i < iNumGroups; i++) {
-			if (m_sExpandedSectionName == SONGMAN->GetSongGroupByIndex(i)) {
+			if (m_sExpandedSectionName == SONGMAN::GetSongGroupByIndex(i)) {
 				if (i < iNumGroups - 1) {
-					return SONGMAN->GetSongGroupByIndex(i + 1);
+					return SONGMAN::GetSongGroupByIndex(i + 1);
 				}
 				// i = 0;
-				return SONGMAN->GetSongGroupByIndex(0);
+				return SONGMAN::GetSongGroupByIndex(0);
 			}
 		}
 	} else {
@@ -1540,15 +1539,15 @@ auto
 MusicWheel::JumpToPrevGroup() -> std::string
 {
 	if (HIDE_INACTIVE_SECTIONS) {
-		const unsigned iNumGroups = SONGMAN->GetNumSongGroups();
+		const unsigned iNumGroups = SONGMAN::GetNumSongGroups();
 
 		for (unsigned i = 0; i < iNumGroups; i++) {
-			if (m_sExpandedSectionName == SONGMAN->GetSongGroupByIndex(i)) {
+			if (m_sExpandedSectionName == SONGMAN::GetSongGroupByIndex(i)) {
 				if (i > 0) {
-					return SONGMAN->GetSongGroupByIndex(i - 1);
+					return SONGMAN::GetSongGroupByIndex(i - 1);
 				}
 				// i = iNumGroups - 1;
-				return SONGMAN->GetSongGroupByIndex(iNumGroups - 1);
+				return SONGMAN::GetSongGroupByIndex(iNumGroups - 1);
 			}
 		}
 	} else {

--- a/src/Etterna/Actor/Menus/MusicWheelItem.cpp
+++ b/src/Etterna/Actor/Menus/MusicWheelItem.cpp
@@ -189,7 +189,7 @@ MusicWheelItem::LoadFromWheelItemData(const WheelItemBaseData* pData,
 			RefreshGrades();
 			break;
 		case WheelItemDataType_Section: {
-			sDisplayName = SONGMAN::ShortenGroupName(pWID->m_sText);
+			sDisplayName = SongManager::ShortenGroupName(pWID->m_sText);
 
 			if (GAMESTATE->sExpandedSectionName == pWID->m_sText)
 				type = MusicWheelItemType_SectionExpanded;

--- a/src/Etterna/Actor/Menus/MusicWheelItem.cpp
+++ b/src/Etterna/Actor/Menus/MusicWheelItem.cpp
@@ -189,7 +189,7 @@ MusicWheelItem::LoadFromWheelItemData(const WheelItemBaseData* pData,
 			RefreshGrades();
 			break;
 		case WheelItemDataType_Section: {
-			sDisplayName = SONGMAN->ShortenGroupName(pWID->m_sText);
+			sDisplayName = SONGMAN::ShortenGroupName(pWID->m_sText);
 
 			if (GAMESTATE->sExpandedSectionName == pWID->m_sText)
 				type = MusicWheelItemType_SectionExpanded;

--- a/src/Etterna/Globals/StepMania.cpp
+++ b/src/Etterna/Globals/StepMania.cpp
@@ -292,7 +292,7 @@ ShutdownGame()
 	SAFE_DELETE(MODELMAN);
 	SAFE_DELETE(PROFILEMAN); // PROFILEMAN needs the songs still loaded
 	SAFE_DELETE(CRYPTMAN);
-	SONGMAN::End(); // Equivalent to old destructor
+	SongManager::End(); // Equivalent to old destructor
 	SAFE_DELETE(IMAGECACHE);
 	SAFE_DELETE(SONGINDEX);
 	SAFE_DELETE(SOUND); // uses GAMESTATE, PREFSMAN
@@ -1217,9 +1217,9 @@ sm_main(int argc, char* argv[])
 	IMAGECACHE = new ImageCache;
 
 	// depends on SONGINDEX:
-	SONGMAN::Init();
+	SongManager::Init();
 	SONGINDEX->StartTransaction();
-	SONGMAN::InitAll(pLoadingWindow); // this takes a long time
+	SongManager::InitAll(pLoadingWindow); // this takes a long time
 	SONGINDEX->FinishTransaction();
 	CRYPTMAN = new CryptManager; // need to do this before ProfileMan
 	if (PREFSMAN->m_bSignProfileData)
@@ -1227,7 +1227,7 @@ sm_main(int argc, char* argv[])
 	SCOREMAN = new ScoreManager;
 	PROFILEMAN = new ProfileManager;
 	PROFILEMAN->Init(pLoadingWindow); // must load after SONGMAN
-	SONGMAN::CalcTestStuff();		  // must be after profileman init
+	SongManager::CalcTestStuff();		  // must be after profileman init
 
 	NSMAN = new NetworkSyncManager(pLoadingWindow);
 	STATSMAN = new StatsManager;

--- a/src/Etterna/Globals/StepMania.cpp
+++ b/src/Etterna/Globals/StepMania.cpp
@@ -292,7 +292,7 @@ ShutdownGame()
 	SAFE_DELETE(MODELMAN);
 	SAFE_DELETE(PROFILEMAN); // PROFILEMAN needs the songs still loaded
 	SAFE_DELETE(CRYPTMAN);
-	SAFE_DELETE(SONGMAN);
+	SONGMAN::End(); // Equivalent to old destructor
 	SAFE_DELETE(IMAGECACHE);
 	SAFE_DELETE(SONGINDEX);
 	SAFE_DELETE(SOUND); // uses GAMESTATE, PREFSMAN
@@ -1217,7 +1217,7 @@ sm_main(int argc, char* argv[])
 	IMAGECACHE = new ImageCache;
 
 	// depends on SONGINDEX:
-	// SONGMAN = new SongManager; TODO: Call SONGMAN "constructor" here
+	SONGMAN::Init();
 	SONGINDEX->StartTransaction();
 	SONGMAN::InitAll(pLoadingWindow); // this takes a long time
 	SONGINDEX->FinishTransaction();

--- a/src/Etterna/Globals/StepMania.cpp
+++ b/src/Etterna/Globals/StepMania.cpp
@@ -1217,9 +1217,9 @@ sm_main(int argc, char* argv[])
 	IMAGECACHE = new ImageCache;
 
 	// depends on SONGINDEX:
-	SONGMAN = new SongManager;
+	// SONGMAN = new SongManager; TODO: Call SONGMAN "constructor" here
 	SONGINDEX->StartTransaction();
-	SONGMAN->InitAll(pLoadingWindow); // this takes a long time
+	SONGMAN::InitAll(pLoadingWindow); // this takes a long time
 	SONGINDEX->FinishTransaction();
 	CRYPTMAN = new CryptManager; // need to do this before ProfileMan
 	if (PREFSMAN->m_bSignProfileData)
@@ -1227,7 +1227,7 @@ sm_main(int argc, char* argv[])
 	SCOREMAN = new ScoreManager;
 	PROFILEMAN = new ProfileManager;
 	PROFILEMAN->Init(pLoadingWindow); // must load after SONGMAN
-	SONGMAN->CalcTestStuff();		  // must be after profileman init
+	SONGMAN::CalcTestStuff();		  // must be after profileman init
 
 	NSMAN = new NetworkSyncManager(pLoadingWindow);
 	STATSMAN = new StatsManager;

--- a/src/Etterna/Models/Misc/DBProfile.cpp
+++ b/src/Etterna/Models/Misc/DBProfile.cpp
@@ -142,8 +142,8 @@ DBProfile::LoadFavourites(SQLite::Database* db)
 		const char* key = query.getColumn(0);
 		loadingProfile->FavoritedCharts.emplace(key);
 	}
-	SONGMAN->SetFavoritedStatus(loadingProfile->FavoritedCharts);
-	SONGMAN->MakePlaylistFromFavorites(loadingProfile->FavoritedCharts);
+	SONGMAN::SetFavoritedStatus(loadingProfile->FavoritedCharts);
+	SONGMAN::MakePlaylistFromFavorites(loadingProfile->FavoritedCharts);
 }
 
 void
@@ -219,7 +219,7 @@ DBProfile::LoadPlayLists(SQLite::Database* db)
 
 	pls.emplace(tmp->name, *tmp);
 	delete tmp;
-	SONGMAN->activeplaylist = tmp->name;
+	SONGMAN::activeplaylist = tmp->name;
 	// Now read courseruns
 
 	SQLite::Statement courseRunsQuery(
@@ -416,7 +416,7 @@ DBProfile::LoadPermaMirrors(SQLite::Database* db)
 		const char* key = query.getColumn(0);
 		loadingProfile->PermaMirrorCharts.emplace(key);
 	}
-	SONGMAN->SetPermaMirroredStatus(loadingProfile->PermaMirrorCharts);
+	SONGMAN::SetPermaMirroredStatus(loadingProfile->PermaMirrorCharts);
 }
 void
 DBProfile::LoadScoreGoals(SQLite::Database* db)

--- a/src/Etterna/Models/Misc/DBProfile.cpp
+++ b/src/Etterna/Models/Misc/DBProfile.cpp
@@ -142,8 +142,8 @@ DBProfile::LoadFavourites(SQLite::Database* db)
 		const char* key = query.getColumn(0);
 		loadingProfile->FavoritedCharts.emplace(key);
 	}
-	SONGMAN::SetFavoritedStatus(loadingProfile->FavoritedCharts);
-	SONGMAN::MakePlaylistFromFavorites(loadingProfile->FavoritedCharts);
+	SongManager::SetFavoritedStatus(loadingProfile->FavoritedCharts);
+	SongManager::MakePlaylistFromFavorites(loadingProfile->FavoritedCharts);
 }
 
 void
@@ -219,7 +219,7 @@ DBProfile::LoadPlayLists(SQLite::Database* db)
 
 	pls.emplace(tmp->name, *tmp);
 	delete tmp;
-	SONGMAN::activeplaylist = tmp->name;
+	SongManager::activeplaylist = tmp->name;
 	// Now read courseruns
 
 	SQLite::Statement courseRunsQuery(
@@ -416,7 +416,7 @@ DBProfile::LoadPermaMirrors(SQLite::Database* db)
 		const char* key = query.getColumn(0);
 		loadingProfile->PermaMirrorCharts.emplace(key);
 	}
-	SONGMAN::SetPermaMirroredStatus(loadingProfile->PermaMirrorCharts);
+	SongManager::SetPermaMirroredStatus(loadingProfile->PermaMirrorCharts);
 }
 void
 DBProfile::LoadScoreGoals(SQLite::Database* db)

--- a/src/Etterna/Models/Misc/GameCommand.cpp
+++ b/src/Etterna/Models/Misc/GameCommand.cpp
@@ -282,7 +282,7 @@ GameCommand::LoadOne(const Command& cmd)
 	else if (sName == "songgroup") {
 		CHECK_INVALID_COND(m_sSongGroup,
 						   sValue,
-						   (!SONGMAN->DoesSongGroupExist(sValue)),
+						   (!SONGMAN::DoesSongGroupExist(sValue)),
 						   ("Song group \"" + sValue + "\" does not exist."));
 	}
 
@@ -370,7 +370,7 @@ GameCommand::IsPlayable(std::string* why) const
 	}
 
 	if (!CompareNoCase(m_sScreen, "ScreenEditMenu")) {
-		if (SONGMAN->GetNumSongs() == 0) {
+		if (SONGMAN::GetNumSongs() == 0) {
 			if (why)
 				*why = "No songs are installed";
 			return false;

--- a/src/Etterna/Models/Misc/GameCommand.cpp
+++ b/src/Etterna/Models/Misc/GameCommand.cpp
@@ -282,7 +282,7 @@ GameCommand::LoadOne(const Command& cmd)
 	else if (sName == "songgroup") {
 		CHECK_INVALID_COND(m_sSongGroup,
 						   sValue,
-						   (!SONGMAN::DoesSongGroupExist(sValue)),
+						   (!SongManager::DoesSongGroupExist(sValue)),
 						   ("Song group \"" + sValue + "\" does not exist."));
 	}
 
@@ -370,7 +370,7 @@ GameCommand::IsPlayable(std::string* why) const
 	}
 
 	if (!CompareNoCase(m_sScreen, "ScreenEditMenu")) {
-		if (SONGMAN::GetNumSongs() == 0) {
+		if (SongManager::GetNumSongs() == 0) {
 			if (why)
 				*why = "No songs are installed";
 			return false;

--- a/src/Etterna/Models/Misc/OptionRowHandler.cpp
+++ b/src/Etterna/Models/Misc/OptionRowHandler.cpp
@@ -677,7 +677,7 @@ class OptionRowHandlerListGroups : public OptionRowHandlerList
 		m_Default.m_sSongGroup = GROUP_ALL;
 
 		vector<std::string> vSongGroups;
-		SONGMAN->GetSongGroupNames(vSongGroups);
+		SONGMAN::GetSongGroupNames(vSongGroups);
 		ASSERT(!vSongGroups.empty());
 
 		{
@@ -739,7 +739,7 @@ class OptionRowHandlerListSongsInCurrentSongGroup : public OptionRowHandlerList
 	bool LoadInternal(const Commands&) override
 	{
 		const auto& vpSongs =
-		  SONGMAN->GetSongs(GAMESTATE->m_sPreferredSongGroup);
+		  SONGMAN::GetSongs(GAMESTATE->m_sPreferredSongGroup);
 
 		if (GAMESTATE->m_pCurSong == nullptr)
 			GAMESTATE->m_pCurSong.Set(vpSongs[0]);

--- a/src/Etterna/Models/Misc/OptionRowHandler.cpp
+++ b/src/Etterna/Models/Misc/OptionRowHandler.cpp
@@ -677,7 +677,7 @@ class OptionRowHandlerListGroups : public OptionRowHandlerList
 		m_Default.m_sSongGroup = GROUP_ALL;
 
 		vector<std::string> vSongGroups;
-		SONGMAN::GetSongGroupNames(vSongGroups);
+		SongManager::GetSongGroupNames(vSongGroups);
 		ASSERT(!vSongGroups.empty());
 
 		{
@@ -739,7 +739,7 @@ class OptionRowHandlerListSongsInCurrentSongGroup : public OptionRowHandlerList
 	bool LoadInternal(const Commands&) override
 	{
 		const auto& vpSongs =
-		  SONGMAN::GetSongs(GAMESTATE->m_sPreferredSongGroup);
+		  SongManager::GetSongs(GAMESTATE->m_sPreferredSongGroup);
 
 		if (GAMESTATE->m_pCurSong == nullptr)
 			GAMESTATE->m_pCurSong.Set(vpSongs[0]);

--- a/src/Etterna/Models/Misc/PlayerStageStats.cpp
+++ b/src/Etterna/Models/Misc/PlayerStageStats.cpp
@@ -348,7 +348,7 @@ PlayerStageStats::CalcSSR(float ssrpercent) const
 	// 4k
 	if (steps->m_StepsType == StepsType_dance_single) {
 		return MinaSDCalc(
-		  serializednd, musicrate, ssrpercent, SONGMAN->calc.get());
+		  serializednd, musicrate, ssrpercent, SONGMAN::calc.get());
 	}
 
 	// solo calc

--- a/src/Etterna/Models/Misc/PlayerStageStats.cpp
+++ b/src/Etterna/Models/Misc/PlayerStageStats.cpp
@@ -348,7 +348,7 @@ PlayerStageStats::CalcSSR(float ssrpercent) const
 	// 4k
 	if (steps->m_StepsType == StepsType_dance_single) {
 		return MinaSDCalc(
-		  serializednd, musicrate, ssrpercent, SONGMAN::calc.get());
+		  serializednd, musicrate, ssrpercent, SongManager::calc.get());
 	}
 
 	// solo calc

--- a/src/Etterna/Models/Misc/Profile.cpp
+++ b/src/Etterna/Models/Misc/Profile.cpp
@@ -514,7 +514,7 @@ Profile::FillGoalTable()
 	goaltable.clear();
 	for (auto& sgv : goalmap)
 		for (auto& sg : sgv.second.goals)
-			if (SONGMAN->GetStepsByChartkey(sg.chartkey))
+			if (SONGMAN::GetStepsByChartkey(sg.chartkey))
 				goaltable.emplace_back(&sg);
 
 	auto comp = [](ScoreGoal* a, ScoreGoal* b) {
@@ -960,9 +960,9 @@ class LunaProfile : public Luna<Profile>
 		if (p->sortmode == 3)
 			if (p->asc) {
 				auto comp = [](ScoreGoal* a, ScoreGoal* b) {
-					return make_lower(SONGMAN->GetSongByChartkey(a->chartkey)
+					return make_lower(SONGMAN::GetSongByChartkey(a->chartkey)
 										->GetDisplayMainTitle()) >
-						   make_lower(SONGMAN->GetSongByChartkey(b->chartkey)
+						   make_lower(SONGMAN::GetSongByChartkey(b->chartkey)
 										->GetDisplayMainTitle());
 				}; // custom operators?
 				sort(p->goaltable.begin(), p->goaltable.end(), comp);
@@ -970,9 +970,9 @@ class LunaProfile : public Luna<Profile>
 				return 0;
 			}
 		auto comp = [](ScoreGoal* a, ScoreGoal* b) {
-			return make_lower(SONGMAN->GetSongByChartkey(a->chartkey)
+			return make_lower(SONGMAN::GetSongByChartkey(a->chartkey)
 								->GetDisplayMainTitle()) <
-				   make_lower(SONGMAN->GetSongByChartkey(b->chartkey)
+				   make_lower(SONGMAN::GetSongByChartkey(b->chartkey)
 								->GetDisplayMainTitle());
 		};
 		sort(p->goaltable.begin(), p->goaltable.end(), comp);
@@ -1006,9 +1006,9 @@ class LunaProfile : public Luna<Profile>
 		if (p->sortmode == 5)
 			if (p->asc) {
 				auto comp = [](ScoreGoal* a, ScoreGoal* b) {
-					return SONGMAN->GetStepsByChartkey(a->chartkey)
+					return SONGMAN::GetStepsByChartkey(a->chartkey)
 							 ->GetMSD(a->rate, 0) <
-						   SONGMAN->GetStepsByChartkey(b->chartkey)
+						   SONGMAN::GetStepsByChartkey(b->chartkey)
 							 ->GetMSD(b->rate, 0);
 				};
 				sort(p->goaltable.begin(), p->goaltable.end(), comp);
@@ -1016,9 +1016,9 @@ class LunaProfile : public Luna<Profile>
 				return 0;
 			}
 		auto comp = [](ScoreGoal* a, ScoreGoal* b) {
-			return SONGMAN->GetStepsByChartkey(a->chartkey)
+			return SONGMAN::GetStepsByChartkey(a->chartkey)
 					 ->GetMSD(a->rate, 0) >
-				   SONGMAN->GetStepsByChartkey(b->chartkey)->GetMSD(b->rate, 0);
+				   SONGMAN::GetStepsByChartkey(b->chartkey)->GetMSD(b->rate, 0);
 		};
 		sort(p->goaltable.begin(), p->goaltable.end(), comp);
 		p->sortmode = 5;

--- a/src/Etterna/Models/Misc/Profile.cpp
+++ b/src/Etterna/Models/Misc/Profile.cpp
@@ -514,7 +514,7 @@ Profile::FillGoalTable()
 	goaltable.clear();
 	for (auto& sgv : goalmap)
 		for (auto& sg : sgv.second.goals)
-			if (SONGMAN::GetStepsByChartkey(sg.chartkey))
+			if (SongManager::GetStepsByChartkey(sg.chartkey))
 				goaltable.emplace_back(&sg);
 
 	auto comp = [](ScoreGoal* a, ScoreGoal* b) {
@@ -960,9 +960,9 @@ class LunaProfile : public Luna<Profile>
 		if (p->sortmode == 3)
 			if (p->asc) {
 				auto comp = [](ScoreGoal* a, ScoreGoal* b) {
-					return make_lower(SONGMAN::GetSongByChartkey(a->chartkey)
+					return make_lower(SongManager::GetSongByChartkey(a->chartkey)
 										->GetDisplayMainTitle()) >
-						   make_lower(SONGMAN::GetSongByChartkey(b->chartkey)
+						   make_lower(SongManager::GetSongByChartkey(b->chartkey)
 										->GetDisplayMainTitle());
 				}; // custom operators?
 				sort(p->goaltable.begin(), p->goaltable.end(), comp);
@@ -970,9 +970,9 @@ class LunaProfile : public Luna<Profile>
 				return 0;
 			}
 		auto comp = [](ScoreGoal* a, ScoreGoal* b) {
-			return make_lower(SONGMAN::GetSongByChartkey(a->chartkey)
+			return make_lower(SongManager::GetSongByChartkey(a->chartkey)
 								->GetDisplayMainTitle()) <
-				   make_lower(SONGMAN::GetSongByChartkey(b->chartkey)
+				   make_lower(SongManager::GetSongByChartkey(b->chartkey)
 								->GetDisplayMainTitle());
 		};
 		sort(p->goaltable.begin(), p->goaltable.end(), comp);
@@ -1006,9 +1006,9 @@ class LunaProfile : public Luna<Profile>
 		if (p->sortmode == 5)
 			if (p->asc) {
 				auto comp = [](ScoreGoal* a, ScoreGoal* b) {
-					return SONGMAN::GetStepsByChartkey(a->chartkey)
+					return SongManager::GetStepsByChartkey(a->chartkey)
 							 ->GetMSD(a->rate, 0) <
-						   SONGMAN::GetStepsByChartkey(b->chartkey)
+						   SongManager::GetStepsByChartkey(b->chartkey)
 							 ->GetMSD(b->rate, 0);
 				};
 				sort(p->goaltable.begin(), p->goaltable.end(), comp);
@@ -1016,9 +1016,9 @@ class LunaProfile : public Luna<Profile>
 				return 0;
 			}
 		auto comp = [](ScoreGoal* a, ScoreGoal* b) {
-			return SONGMAN::GetStepsByChartkey(a->chartkey)
+			return SongManager::GetStepsByChartkey(a->chartkey)
 					 ->GetMSD(a->rate, 0) >
-				   SONGMAN::GetStepsByChartkey(b->chartkey)->GetMSD(b->rate, 0);
+				   SongManager::GetStepsByChartkey(b->chartkey)->GetMSD(b->rate, 0);
 		};
 		sort(p->goaltable.begin(), p->goaltable.end(), comp);
 		p->sortmode = 5;

--- a/src/Etterna/Models/Misc/StageStats.cpp
+++ b/src/Etterna/Models/Misc/StageStats.cpp
@@ -692,7 +692,7 @@ StageStats::FinalizeScores(bool bSummary)
 	if (DLMAN->ShouldUploadScores() && !AdjustSync::IsSyncDataChanged()) {
 		CHECKPOINT_M("Uploading score with replaydata.");
 		hs.SetTopScore(istop2); // ayy i did it --lurker
-		auto* steps = SONGMAN::GetStepsByChartkey(hs.GetChartKey());
+		auto* steps = SongManager::GetStepsByChartkey(hs.GetChartKey());
 		auto* td = steps->GetTimingData();
 		hs.timeStamps = td->ConvertReplayNoteRowsToTimestamps(
 		  m_player.GetNoteRowVector(), hs.GetMusicRate());

--- a/src/Etterna/Models/Misc/StageStats.cpp
+++ b/src/Etterna/Models/Misc/StageStats.cpp
@@ -692,7 +692,7 @@ StageStats::FinalizeScores(bool bSummary)
 	if (DLMAN->ShouldUploadScores() && !AdjustSync::IsSyncDataChanged()) {
 		CHECKPOINT_M("Uploading score with replaydata.");
 		hs.SetTopScore(istop2); // ayy i did it --lurker
-		auto* steps = SONGMAN->GetStepsByChartkey(hs.GetChartKey());
+		auto* steps = SONGMAN::GetStepsByChartkey(hs.GetChartKey());
 		auto* td = steps->GetTimingData();
 		hs.timeStamps = td->ConvertReplayNoteRowsToTimestamps(
 		  m_player.GetNoteRowVector(), hs.GetMusicRate());

--- a/src/Etterna/Models/Misc/XMLProfile.cpp
+++ b/src/Etterna/Models/Misc/XMLProfile.cpp
@@ -215,8 +215,8 @@ XMLProfile::LoadFavoritesFromNode(const XNode* pNode)
 
 	FOREACH_CONST_Child(pNode, ck)
 	  loadingProfile->FavoritedCharts.emplace(ck->GetName());
-	SONGMAN->SetFavoritedStatus(loadingProfile->FavoritedCharts);
-	SONGMAN->MakePlaylistFromFavorites(loadingProfile->FavoritedCharts,
+	SONGMAN::SetFavoritedStatus(loadingProfile->FavoritedCharts);
+	SONGMAN::MakePlaylistFromFavorites(loadingProfile->FavoritedCharts,
 									   loadingProfile->allplaylists);
 }
 
@@ -227,7 +227,7 @@ XMLProfile::LoadPermaMirrorFromNode(const XNode* pNode)
 
 	FOREACH_CONST_Child(pNode, ck)
 	  loadingProfile->PermaMirrorCharts.emplace(ck->GetName());
-	SONGMAN->SetPermaMirroredStatus(loadingProfile->PermaMirrorCharts);
+	SONGMAN::SetPermaMirroredStatus(loadingProfile->PermaMirrorCharts);
 }
 
 void
@@ -274,7 +274,7 @@ XMLProfile::LoadPlaylistsFromNode(const XNode* pNode)
 		Playlist tmp;
 		tmp.LoadFromNode(pl);
 		pls.emplace(tmp.name, tmp);
-		SONGMAN->activeplaylist = tmp.name;
+		SONGMAN::activeplaylist = tmp.name;
 	}
 }
 

--- a/src/Etterna/Models/Misc/XMLProfile.cpp
+++ b/src/Etterna/Models/Misc/XMLProfile.cpp
@@ -215,8 +215,8 @@ XMLProfile::LoadFavoritesFromNode(const XNode* pNode)
 
 	FOREACH_CONST_Child(pNode, ck)
 	  loadingProfile->FavoritedCharts.emplace(ck->GetName());
-	SONGMAN::SetFavoritedStatus(loadingProfile->FavoritedCharts);
-	SONGMAN::MakePlaylistFromFavorites(loadingProfile->FavoritedCharts,
+	SongManager::SetFavoritedStatus(loadingProfile->FavoritedCharts);
+	SongManager::MakePlaylistFromFavorites(loadingProfile->FavoritedCharts,
 									   loadingProfile->allplaylists);
 }
 
@@ -227,7 +227,7 @@ XMLProfile::LoadPermaMirrorFromNode(const XNode* pNode)
 
 	FOREACH_CONST_Child(pNode, ck)
 	  loadingProfile->PermaMirrorCharts.emplace(ck->GetName());
-	SONGMAN::SetPermaMirroredStatus(loadingProfile->PermaMirrorCharts);
+	SongManager::SetPermaMirroredStatus(loadingProfile->PermaMirrorCharts);
 }
 
 void
@@ -274,7 +274,7 @@ XMLProfile::LoadPlaylistsFromNode(const XNode* pNode)
 		Playlist tmp;
 		tmp.LoadFromNode(pl);
 		pls.emplace(tmp.name, tmp);
-		SONGMAN::activeplaylist = tmp.name;
+		SongManager::activeplaylist = tmp.name;
 	}
 }
 

--- a/src/Etterna/Models/Songs/Song.cpp
+++ b/src/Etterna/Models/Songs/Song.cpp
@@ -1216,7 +1216,7 @@ Song::SaveToSSCFile(const std::string& sPath, bool bSavingCache)
 	if (!bSavingCache)
 		for (auto* s : vpStepsToSave) {
 			s->Decompress();
-			s->CalcEtternaMetadata(SONGMAN->calc.get());
+			s->CalcEtternaMetadata(SONGMAN::calc.get());
 			s->SetFilename(path);
 		}
 	if (bSavingCache) {
@@ -1317,7 +1317,7 @@ Song::SaveToETTFile(const std::string& sPath, bool bSavingCache)
 bool
 Song::SaveToCacheFile()
 {
-	if (SONGMAN->IsGroupNeverCached(m_sGroupName)) {
+	if (SONGMAN::IsGroupNeverCached(m_sGroupName)) {
 		return true;
 	}
 	return SONGINDEX->CacheSong(*this, m_sSongDir);
@@ -1656,7 +1656,8 @@ Song::IsSkillsetHighestOfChart(Steps* chart, Skillset skill, float rate) const
 }
 
 bool
-Song::MatchesFilter(const float rate, std::vector<Steps*>* vMatchingStepsOut) const
+Song::MatchesFilter(const float rate,
+					std::vector<Steps*>* vMatchingStepsOut) const
 {
 	auto charts = GetChartsOfCurrentGameMode();
 

--- a/src/Etterna/Models/Songs/Song.cpp
+++ b/src/Etterna/Models/Songs/Song.cpp
@@ -1216,7 +1216,7 @@ Song::SaveToSSCFile(const std::string& sPath, bool bSavingCache)
 	if (!bSavingCache)
 		for (auto* s : vpStepsToSave) {
 			s->Decompress();
-			s->CalcEtternaMetadata(SONGMAN::calc.get());
+			s->CalcEtternaMetadata(SongManager::calc.get());
 			s->SetFilename(path);
 		}
 	if (bSavingCache) {
@@ -1317,7 +1317,7 @@ Song::SaveToETTFile(const std::string& sPath, bool bSavingCache)
 bool
 Song::SaveToCacheFile()
 {
-	if (SONGMAN::IsGroupNeverCached(m_sGroupName)) {
+	if (SongManager::IsGroupNeverCached(m_sGroupName)) {
 		return true;
 	}
 	return SONGINDEX->CacheSong(*this, m_sSongDir);

--- a/src/Etterna/Models/Songs/SongUtil.cpp
+++ b/src/Etterna/Models/Songs/SongUtil.cpp
@@ -996,7 +996,7 @@ void
 SongUtil::GetAllSongGenres(vector<std::string>& vsOut)
 {
 	set<std::string> genres;
-	for (const auto& song : SONGMAN->GetAllSongs()) {
+	for (const auto& song : SONGMAN::GetAllSongs()) {
 		if (!song->m_sGenre.empty())
 			genres.insert(song->m_sGenre);
 	}
@@ -1040,7 +1040,9 @@ SongUtil::GetPlayableStepsTypes(const Song* pSong, set<StepsType>& vOut)
 }
 
 void
-SongUtil::GetPlayableSteps(const Song* pSong, vector<Steps*>& vOut, bool filteringSteps)
+SongUtil::GetPlayableSteps(const Song* pSong,
+						   vector<Steps*>& vOut,
+						   bool filteringSteps)
 {
 	set<StepsType> vStepsType;
 	GetPlayableStepsTypes(pSong, vStepsType);
@@ -1125,7 +1127,7 @@ SongID::ToSong() const
 			if (sDir2.front() != '/') {
 				sDir2 = "/" + sDir2;
 			}
-			pRet = SONGMAN->GetSongFromDir(sDir2);
+			pRet = SONGMAN::GetSongFromDir(sDir2);
 		}
 		m_Cache.Set(pRet);
 	}

--- a/src/Etterna/Models/Songs/SongUtil.cpp
+++ b/src/Etterna/Models/Songs/SongUtil.cpp
@@ -996,7 +996,7 @@ void
 SongUtil::GetAllSongGenres(vector<std::string>& vsOut)
 {
 	set<std::string> genres;
-	for (const auto& song : SONGMAN::GetAllSongs()) {
+	for (const auto& song : SongManager::GetAllSongs()) {
 		if (!song->m_sGenre.empty())
 			genres.insert(song->m_sGenre);
 	}
@@ -1127,7 +1127,7 @@ SongID::ToSong() const
 			if (sDir2.front() != '/') {
 				sDir2 = "/" + sDir2;
 			}
-			pRet = SONGMAN::GetSongFromDir(sDir2);
+			pRet = SongManager::GetSongFromDir(sDir2);
 		}
 		m_Cache.Set(pRet);
 	}

--- a/src/Etterna/Models/StepsAndStyles/Steps.cpp
+++ b/src/Etterna/Models/StepsAndStyles/Steps.cpp
@@ -483,7 +483,7 @@ Steps::CalcEtternaMetadata(Calc* calc)
 	} else if (m_StepsType == StepsType_dance_single) {
 		if (calc == nullptr) {
 			// reloading at music select
-			diffByRate = MinaSDCalc(cereal, SONGMAN->calc.get());
+			diffByRate = MinaSDCalc(cereal, SONGMAN::calc.get());
 		} else {
 			diffByRate = MinaSDCalc(cereal, calc);
 		}
@@ -511,7 +511,7 @@ Steps::DoATestThing(float ev, Skillset ss, float rate, Calc* calc) -> float
 		return 0.f;
 	}
 	auto& vh =
-	  SONGMAN->testChartList[ss].filemapping.at(ChartKey).version_history;
+	  SONGMAN::testChartList[ss].filemapping.at(ChartKey).version_history;
 
 	Decompress();
 	const auto& nerv = m_pNoteData->BuildAndGetNerv(GetTimingData());
@@ -564,7 +564,7 @@ Steps::GetCalcDebugOutput()
 					0.93f,
 					calcdebugoutput,
 					debugstrings,
-					*SONGMAN->calc.get());
+					*SONGMAN::calc.get());
 
 	m_pNoteData->UnsetNerv();
 	m_pNoteData->UnsetSerializedNoteData();
@@ -983,7 +983,7 @@ class LunaSteps : public Luna<Steps>
 		if (p->m_StepsType == StepsType_dance_solo) {
 			d = SoloCalc(ni, rate, goal);
 		} else {
-			d = MinaSDCalc(ni, rate, goal, SONGMAN->calc.get());
+			d = MinaSDCalc(ni, rate, goal, SONGMAN::calc.get());
 		}
 
 		auto ssrs = d;
@@ -1105,9 +1105,9 @@ class LunaSteps : public Luna<Steps>
 		}
 		for (auto hand = 0; hand < 2; hand++) {
 			lua_pushstring(L, hand ? "Right" : "Left");
-			lua_createtable(L, 0, SONGMAN->calc->jack_diff.at(hand).size());
-			auto vals = SONGMAN->calc->jack_diff.at(hand);
-			auto stam_vals = SONGMAN->calc->jack_stam_stuff.at(hand);
+			lua_createtable(L, 0, SONGMAN::calc->jack_diff.at(hand).size());
+			auto vals = SONGMAN::calc->jack_diff.at(hand);
+			auto stam_vals = SONGMAN::calc->jack_stam_stuff.at(hand);
 			for (auto i = 0; i < vals.size(); i++) {
 				auto p = vals[i];
 				vector<float> stuff{ p.first, p.second, stam_vals[i] };

--- a/src/Etterna/Models/StepsAndStyles/Steps.cpp
+++ b/src/Etterna/Models/StepsAndStyles/Steps.cpp
@@ -483,7 +483,7 @@ Steps::CalcEtternaMetadata(Calc* calc)
 	} else if (m_StepsType == StepsType_dance_single) {
 		if (calc == nullptr) {
 			// reloading at music select
-			diffByRate = MinaSDCalc(cereal, SONGMAN::calc.get());
+			diffByRate = MinaSDCalc(cereal, SongManager::calc.get());
 		} else {
 			diffByRate = MinaSDCalc(cereal, calc);
 		}
@@ -511,7 +511,7 @@ Steps::DoATestThing(float ev, Skillset ss, float rate, Calc* calc) -> float
 		return 0.f;
 	}
 	auto& vh =
-	  SONGMAN::testChartList[ss].filemapping.at(ChartKey).version_history;
+	  SongManager::testChartList[ss].filemapping.at(ChartKey).version_history;
 
 	Decompress();
 	const auto& nerv = m_pNoteData->BuildAndGetNerv(GetTimingData());
@@ -564,7 +564,7 @@ Steps::GetCalcDebugOutput()
 					0.93f,
 					calcdebugoutput,
 					debugstrings,
-					*SONGMAN::calc.get());
+					*SongManager::calc.get());
 
 	m_pNoteData->UnsetNerv();
 	m_pNoteData->UnsetSerializedNoteData();
@@ -983,7 +983,7 @@ class LunaSteps : public Luna<Steps>
 		if (p->m_StepsType == StepsType_dance_solo) {
 			d = SoloCalc(ni, rate, goal);
 		} else {
-			d = MinaSDCalc(ni, rate, goal, SONGMAN::calc.get());
+			d = MinaSDCalc(ni, rate, goal, SongManager::calc.get());
 		}
 
 		auto ssrs = d;
@@ -1105,9 +1105,9 @@ class LunaSteps : public Luna<Steps>
 		}
 		for (auto hand = 0; hand < 2; hand++) {
 			lua_pushstring(L, hand ? "Right" : "Left");
-			lua_createtable(L, 0, SONGMAN::calc->jack_diff.at(hand).size());
-			auto vals = SONGMAN::calc->jack_diff.at(hand);
-			auto stam_vals = SONGMAN::calc->jack_stam_stuff.at(hand);
+			lua_createtable(L, 0, SongManager::calc->jack_diff.at(hand).size());
+			auto vals = SongManager::calc->jack_diff.at(hand);
+			auto stam_vals = SongManager::calc->jack_stam_stuff.at(hand);
 			for (auto i = 0; i < vals.size(); i++) {
 				auto p = vals[i];
 				vector<float> stuff{ p.first, p.second, stam_vals[i] };

--- a/src/Etterna/Models/StepsAndStyles/StepsUtil.cpp
+++ b/src/Etterna/Models/StepsAndStyles/StepsUtil.cpp
@@ -43,7 +43,7 @@ StepsUtil::SortStepsPointerArrayByNumPlays(vector<Steps*>& vStepsPointers,
 										   bool bDecending)
 {
 	// ugly...
-	auto vpSongs = SONGMAN->GetAllSongs();
+	auto vpSongs = SONGMAN::GetAllSongs();
 	vector<Steps*> vpAllSteps;
 	std::map<Steps*, Song*> mapStepsToSong;
 	{

--- a/src/Etterna/Models/StepsAndStyles/StepsUtil.cpp
+++ b/src/Etterna/Models/StepsAndStyles/StepsUtil.cpp
@@ -43,7 +43,7 @@ StepsUtil::SortStepsPointerArrayByNumPlays(vector<Steps*>& vStepsPointers,
 										   bool bDecending)
 {
 	// ugly...
-	auto vpSongs = SONGMAN::GetAllSongs();
+	auto vpSongs = SongManager::GetAllSongs();
 	vector<Steps*> vpAllSteps;
 	std::map<Steps*, Song*> mapStepsToSong;
 	{

--- a/src/Etterna/Screen/Gameplay/ScreenGameplay.cpp
+++ b/src/Etterna/Screen/Gameplay/ScreenGameplay.cpp
@@ -358,7 +358,7 @@ ScreenGameplay::InitSongQueues()
 		m_apSongsQueue.clear();
 		m_vPlayerInfo.m_vpStepsQueue.clear();
 
-		Playlist& pl = SONGMAN->GetPlaylists()[SONGMAN->playlistcourse];
+		Playlist& pl = SONGMAN::GetPlaylists()[SONGMAN::playlistcourse];
 		FOREACH(Chart, pl.chartlist, ch)
 		{
 			m_apSongsQueue.emplace_back(ch->songptr);
@@ -1617,7 +1617,7 @@ ScreenGameplay::HandleScreenMessage(const ScreenMessage& SM)
 		MESSAGEMAN->Broadcast(msg);
 
 		if (GAMESTATE->IsPlaylistCourse()) {
-			SONGMAN->GetPlaylists()[SONGMAN->playlistcourse]
+			SONGMAN::GetPlaylists()[SONGMAN::playlistcourse]
 			  .courseruns.emplace_back(playlistscorekeys);
 		}
 
@@ -1698,7 +1698,7 @@ ScreenGameplay::HandleScreenMessage(const ScreenMessage& SM)
 
 		if (GAMESTATE->IsPlaylistCourse()) {
 			GAMESTATE->isplaylistcourse = false;
-			SONGMAN->playlistcourse = "";
+			SONGMAN::playlistcourse = "";
 		}
 	} else if (SM == SM_GainFocus) {
 		// We do this ourself.

--- a/src/Etterna/Screen/Gameplay/ScreenGameplay.cpp
+++ b/src/Etterna/Screen/Gameplay/ScreenGameplay.cpp
@@ -358,7 +358,7 @@ ScreenGameplay::InitSongQueues()
 		m_apSongsQueue.clear();
 		m_vPlayerInfo.m_vpStepsQueue.clear();
 
-		Playlist& pl = SONGMAN::GetPlaylists()[SONGMAN::playlistcourse];
+		Playlist& pl = SongManager::GetPlaylists()[SongManager::playlistcourse];
 		FOREACH(Chart, pl.chartlist, ch)
 		{
 			m_apSongsQueue.emplace_back(ch->songptr);
@@ -1617,7 +1617,7 @@ ScreenGameplay::HandleScreenMessage(const ScreenMessage& SM)
 		MESSAGEMAN->Broadcast(msg);
 
 		if (GAMESTATE->IsPlaylistCourse()) {
-			SONGMAN::GetPlaylists()[SONGMAN::playlistcourse]
+			SongManager::GetPlaylists()[SongManager::playlistcourse]
 			  .courseruns.emplace_back(playlistscorekeys);
 		}
 
@@ -1698,7 +1698,7 @@ ScreenGameplay::HandleScreenMessage(const ScreenMessage& SM)
 
 		if (GAMESTATE->IsPlaylistCourse()) {
 			GAMESTATE->isplaylistcourse = false;
-			SONGMAN::playlistcourse = "";
+			SongManager::playlistcourse = "";
 		}
 	} else if (SM == SM_GainFocus) {
 		// We do this ourself.

--- a/src/Etterna/Screen/Gameplay/ScreenGameplayPractice.cpp
+++ b/src/Etterna/Screen/Gameplay/ScreenGameplayPractice.cpp
@@ -91,7 +91,7 @@ ScreenGameplayPractice::Input(const InputEventPlus& input) -> bool
 			}
 
 			auto success = cursong->ReloadFromSongDir();
-			SONGMAN::ReconcileChartKeysForReloadedSong(cursong, oldKeys);
+			SongManager::ReconcileChartKeysForReloadedSong(cursong, oldKeys);
 
 			if (!success || GAMESTATE->m_pCurSteps->GetNoteData().IsEmpty()) {
 				LOG->Trace("The Player attempted something resulting in an "

--- a/src/Etterna/Screen/Gameplay/ScreenGameplayPractice.cpp
+++ b/src/Etterna/Screen/Gameplay/ScreenGameplayPractice.cpp
@@ -91,7 +91,7 @@ ScreenGameplayPractice::Input(const InputEventPlus& input) -> bool
 			}
 
 			auto success = cursong->ReloadFromSongDir();
-			SongManager::ReconcileChartKeysForReloadedSong(cursong, oldKeys);
+			SONGMAN::ReconcileChartKeysForReloadedSong(cursong, oldKeys);
 
 			if (!success || GAMESTATE->m_pCurSteps->GetNoteData().IsEmpty()) {
 				LOG->Trace("The Player attempted something resulting in an "

--- a/src/Etterna/Screen/Network/ScreenNetSelectMusic.cpp
+++ b/src/Etterna/Screen/Network/ScreenNetSelectMusic.cpp
@@ -301,9 +301,9 @@ void
 ScreenNetSelectMusic::BeginScreen()
 {
 	Profile* prof = PROFILEMAN->GetProfile(PLAYER_1);
-	SONGMAN->MakeSongGroupsFromPlaylists();
-	SONGMAN->SetFavoritedStatus(prof->FavoritedCharts);
-	SONGMAN->SetHasGoal(prof->goalmap);
+	SONGMAN::MakeSongGroupsFromPlaylists();
+	SONGMAN::SetFavoritedStatus(prof->FavoritedCharts);
+	SONGMAN::SetHasGoal(prof->goalmap);
 	ScreenSelectMusic::BeginScreen();
 }
 

--- a/src/Etterna/Screen/Network/ScreenNetSelectMusic.cpp
+++ b/src/Etterna/Screen/Network/ScreenNetSelectMusic.cpp
@@ -301,9 +301,9 @@ void
 ScreenNetSelectMusic::BeginScreen()
 {
 	Profile* prof = PROFILEMAN->GetProfile(PLAYER_1);
-	SONGMAN::MakeSongGroupsFromPlaylists();
-	SONGMAN::SetFavoritedStatus(prof->FavoritedCharts);
-	SONGMAN::SetHasGoal(prof->goalmap);
+	SongManager::MakeSongGroupsFromPlaylists();
+	SongManager::SetFavoritedStatus(prof->FavoritedCharts);
+	SongManager::SetHasGoal(prof->goalmap);
 	ScreenSelectMusic::BeginScreen();
 }
 

--- a/src/Etterna/Screen/Others/ScreenInstallOverlay.cpp
+++ b/src/Etterna/Screen/Others/ScreenInstallOverlay.cpp
@@ -92,9 +92,9 @@ DoInstalls(CommandLineActions::CommandLineArgs args)
 			EnsureSlashEnding(imgsOutputPath);
 
 			// Save pack banners
-			auto packs = SONGMAN->GetSongGroupNames();
+			auto packs = SONGMAN::GetSongGroupNames();
 			for (auto& pack : packs) {
-				auto path = SONGMAN->GetSongGroupBannerPath(pack);
+				auto path = SONGMAN::GetSongGroupBannerPath(pack);
 				if (path == "" || !FILEMAN->IsAFile(path))
 					continue;
 				RageFile f;
@@ -113,7 +113,7 @@ DoInstalls(CommandLineActions::CommandLineArgs args)
 				dst << src.rdbuf();
 				dst.close();
 			}
-			for (auto& pSong : SONGMAN->GetAllSongs()) {
+			for (auto& pSong : SONGMAN::GetAllSongs()) {
 				// Fill steps to save
 				vector<Steps*> vpStepsToSave;
 				for (auto& pSteps : pSong->m_vpSteps) {

--- a/src/Etterna/Screen/Others/ScreenInstallOverlay.cpp
+++ b/src/Etterna/Screen/Others/ScreenInstallOverlay.cpp
@@ -92,9 +92,9 @@ DoInstalls(CommandLineActions::CommandLineArgs args)
 			EnsureSlashEnding(imgsOutputPath);
 
 			// Save pack banners
-			auto packs = SONGMAN::GetSongGroupNames();
+			auto packs = SongManager::GetSongGroupNames();
 			for (auto& pack : packs) {
-				auto path = SONGMAN::GetSongGroupBannerPath(pack);
+				auto path = SongManager::GetSongGroupBannerPath(pack);
 				if (path == "" || !FILEMAN->IsAFile(path))
 					continue;
 				RageFile f;
@@ -113,7 +113,7 @@ DoInstalls(CommandLineActions::CommandLineArgs args)
 				dst << src.rdbuf();
 				dst.close();
 			}
-			for (auto& pSong : SONGMAN::GetAllSongs()) {
+			for (auto& pSong : SongManager::GetAllSongs()) {
 				// Fill steps to save
 				vector<Steps*> vpStepsToSave;
 				for (auto& pSteps : pSong->m_vpSteps) {

--- a/src/Etterna/Screen/Others/ScreenSelectMusic.cpp
+++ b/src/Etterna/Screen/Others/ScreenSelectMusic.cpp
@@ -162,7 +162,7 @@ ScreenSelectMusic::Init()
 
 	// build the playlist groups here, songmanager's init from disk can't
 	// because profiles aren't loaded until after that's done -mina
-	SONGMAN->MakeSongGroupsFromPlaylists();
+	SONGMAN::MakeSongGroupsFromPlaylists();
 
 	m_MusicWheel.SetName("MusicWheel");
 	m_MusicWheel.Load(MUSIC_WHEEL_TYPE);
@@ -202,10 +202,10 @@ ScreenSelectMusic::BeginScreen()
 	g_ScreenStartedLoadingAt.Touch();
 	m_timerIdleComment.GetDeltaTime();
 
-	SONGMAN->MakeSongGroupsFromPlaylists();
-	SONGMAN->SetFavoritedStatus(
+	SONGMAN::MakeSongGroupsFromPlaylists();
+	SONGMAN::SetFavoritedStatus(
 	  PROFILEMAN->GetProfile(PLAYER_1)->FavoritedCharts);
-	SONGMAN->SetHasGoal(PROFILEMAN->GetProfile(PLAYER_1)->goalmap);
+	SONGMAN::SetHasGoal(PROFILEMAN->GetProfile(PLAYER_1)->goalmap);
 	if (CommonMetrics::AUTO_SET_STYLE) {
 		GAMESTATE->SetCompatibleStylesForPlayers();
 	}
@@ -248,7 +248,7 @@ ScreenSelectMusic::BeginScreen()
 
 	if (GAMESTATE->IsPlaylistCourse()) {
 		GAMESTATE->isplaylistcourse = false;
-		SONGMAN->playlistcourse = "";
+		SONGMAN::playlistcourse = "";
 	}
 
 	// Update the leaderboard for the file we may have just left
@@ -367,7 +367,7 @@ void
 ScreenSelectMusic::DifferentialReload()
 {
 	// reload songs
-	SONGMAN->DifferentialReload();
+	SONGMAN::DifferentialReload();
 
 	const auto selSong = GAMESTATE->m_pCurSong;
 	const auto currentHoveredGroup = m_MusicWheel.GetCurrentGroup();
@@ -448,7 +448,7 @@ ScreenSelectMusic::Input(const InputEventPlus& input)
 					oldChartkeys.emplace_back(steps->GetChartKey());
 
 				to_reload->ReloadFromSongDir();
-				SONGMAN->ReconcileChartKeysForReloadedSong(to_reload,
+				SONGMAN::ReconcileChartKeysForReloadedSong(to_reload,
 														   oldChartkeys);
 
 				AfterMusicChange();
@@ -456,7 +456,7 @@ ScreenSelectMusic::Input(const InputEventPlus& input)
 			}
 		} else if (holding_shift && bHoldingCtrl && c == 'P' &&
 				   m_MusicWheel.IsSettled() && input.type == IET_FIRST_PRESS) {
-			SONGMAN->ForceReloadSongGroup(
+			SONGMAN::ForceReloadSongGroup(
 			  GetMusicWheel()->GetSelectedSection());
 			AfterMusicChange();
 			SCREENMAN->SystemMessage("Current pack reloaded");
@@ -477,7 +477,7 @@ ScreenSelectMusic::Input(const InputEventPlus& input)
 					// now update favorites playlist
 					// we have to do this here or it won't work for ??? reasons
 					pProfile->allplaylists.erase("Favorites");
-					SONGMAN->MakePlaylistFromFavorites(
+					SONGMAN::MakePlaylistFromFavorites(
 					  pProfile->FavoritedCharts, pProfile->allplaylists);
 				} else {
 					fav_me_biatch->SetFavorited(false);
@@ -488,7 +488,7 @@ ScreenSelectMusic::Input(const InputEventPlus& input)
 
 					// we have to do this here or it won't work for ??? reasons
 					pProfile->allplaylists.erase("Favorites");
-					SONGMAN->MakePlaylistFromFavorites(
+					SONGMAN::MakePlaylistFromFavorites(
 					  pProfile->FavoritedCharts, pProfile->allplaylists);
 				}
 				DLMAN->RefreshFavourites();
@@ -565,16 +565,16 @@ ScreenSelectMusic::Input(const InputEventPlus& input)
 		} else if (bHoldingCtrl && c == 'A' && m_MusicWheel.IsSettled() &&
 				   input.type == IET_FIRST_PRESS &&
 				   GAMESTATE->m_pCurSteps != nullptr) {
-			if (SONGMAN->GetPlaylists().empty())
+			if (SONGMAN::GetPlaylists().empty())
 				return true;
 
-			SONGMAN->GetPlaylists()[SONGMAN->activeplaylist].AddChart(
+			SONGMAN::GetPlaylists()[SONGMAN::activeplaylist].AddChart(
 			  GAMESTATE->m_pCurSteps->GetChartKey());
 			MESSAGEMAN->Broadcast("DisplaySinglePlaylist");
 			SCREENMAN->SystemMessage(
 			  ssprintf(ADDED_TO_PLAYLIST.GetValue(),
 					   GAMESTATE->m_pCurSong->GetDisplayMainTitle().c_str(),
-					   SONGMAN->activeplaylist.c_str()));
+					   SONGMAN::activeplaylist.c_str()));
 			return true;
 		} else if (bHoldingCtrl && c == 'T' && m_MusicWheel.IsSettled() &&
 				   input.type == IET_FIRST_PRESS &&
@@ -582,7 +582,7 @@ ScreenSelectMusic::Input(const InputEventPlus& input)
 
 			auto ck = GAMESTATE->m_pCurSteps->GetChartKey();
 			Skillset foundSS = Skillset_Invalid;
-			for (const auto& ss : SONGMAN->testChartList) {
+			for (const auto& ss : SONGMAN::testChartList) {
 				if (ss.second.filemapping.count(ck)) {
 					foundSS = ss.first;
 					break;
@@ -596,7 +596,7 @@ ScreenSelectMusic::Input(const InputEventPlus& input)
 				  "",
 				  128);
 			else {
-				// SONGMAN->testChartList[foundSS].filemapping.erase(ck);
+				// SONGMAN::testChartList[foundSS].filemapping.erase(ck);
 				SCREENMAN->SystemMessage(ssprintf(
 				  "Removed this chart from the test list (skillset %d)",
 				  foundSS));
@@ -1079,11 +1079,11 @@ ScreenSelectMusic::HandleScreenMessage(const ScreenMessage& SM)
 				else if (GAMESTATE->m_pCurSteps != nullptr) {
 					CalcTest thetest;
 					auto ck = GAMESTATE->m_pCurSteps->GetChartKey();
-					if (SONGMAN->testChartList.count(ss)) {
+					if (SONGMAN::testChartList.count(ss)) {
 						thetest.ck = ck;
 						thetest.ev = target;
 						thetest.rate = 1.f;
-						SONGMAN->testChartList[ss].filemapping[ck] = thetest;
+						SONGMAN::testChartList[ss].filemapping[ck] = thetest;
 					} else {
 						CalcTestList tl;
 						tl.skillset = ss;
@@ -1091,15 +1091,15 @@ ScreenSelectMusic::HandleScreenMessage(const ScreenMessage& SM)
 						thetest.ev = target;
 						thetest.rate = 1.f;
 						tl.filemapping[ck] = thetest;
-						SONGMAN->testChartList[ss] = tl;
+						SONGMAN::testChartList[ss] = tl;
 					}
 					SCREENMAN->SystemMessage(
 					  ssprintf("added %s to %s at rate 1.0",
 							   ck.c_str(),
 							   SkillsetToString(ss).c_str()));
-					SONGMAN->SaveCalcTestXmlToDir();
+					SONGMAN::SaveCalcTestXmlToDir();
 					float woo = GAMESTATE->m_pCurSteps->DoATestThing(
-					  target, ss, 1.f, SONGMAN->calc.get());
+					  target, ss, 1.f, SONGMAN::calc.get());
 				}
 			} catch (...) {
 				SCREENMAN->SystemMessage("you messed up (input exception)");
@@ -1114,11 +1114,11 @@ ScreenSelectMusic::HandleScreenMessage(const ScreenMessage& SM)
 				else if (GAMESTATE->m_pCurSteps != nullptr) {
 					CalcTest thetest;
 					auto ck = GAMESTATE->m_pCurSteps->GetChartKey();
-					if (SONGMAN->testChartList.count(ss)) {
+					if (SONGMAN::testChartList.count(ss)) {
 						thetest.ck = ck;
 						thetest.ev = target;
 						thetest.rate = rate;
-						SONGMAN->testChartList[ss].filemapping[ck] = thetest;
+						SONGMAN::testChartList[ss].filemapping[ck] = thetest;
 					} else {
 						CalcTestList tl;
 						tl.skillset = ss;
@@ -1126,16 +1126,16 @@ ScreenSelectMusic::HandleScreenMessage(const ScreenMessage& SM)
 						thetest.ev = target;
 						thetest.rate = rate;
 						tl.filemapping[ck] = thetest;
-						SONGMAN->testChartList[ss] = tl;
+						SONGMAN::testChartList[ss] = tl;
 					}
 					SCREENMAN->SystemMessage(
 					  ssprintf("added %s to %s at rate %f",
 							   ck.c_str(),
 							   SkillsetToString(ss).c_str(),
 							   rate));
-					SONGMAN->SaveCalcTestXmlToDir();
+					SONGMAN::SaveCalcTestXmlToDir();
 					float woo = GAMESTATE->m_pCurSteps->DoATestThing(
-					  target, ss, rate, SONGMAN->calc.get());
+					  target, ss, rate, SONGMAN::calc.get());
 				}
 			} catch (...) {
 				SCREENMAN->SystemMessage("you messed up (input exception)");
@@ -1149,8 +1149,8 @@ ScreenSelectMusic::HandleScreenMessage(const ScreenMessage& SM)
 		Playlist pl;
 		pl.name = ScreenTextEntry::s_sLastAnswer;
 		if (pl.name != "") {
-			SONGMAN->GetPlaylists().emplace(pl.name, pl);
-			SONGMAN->activeplaylist = pl.name;
+			SONGMAN::GetPlaylists().emplace(pl.name, pl);
+			SONGMAN::activeplaylist = pl.name;
 			MESSAGEMAN->Broadcast("DisplayAll");
 		}
 
@@ -1393,7 +1393,7 @@ ScreenSelectMusic::AfterMusicChange()
 			// handling) manually call songmans cleanup function (compresses all
 			// steps); we could optimize by only compressing the pack but this
 			// is pretty fast anyway -mina
-			SONGMAN->Cleanup();
+			SONGMAN::Cleanup();
 		}
 	} else {
 		GAMESTATE->m_pPreferredSong = pSong;
@@ -1701,7 +1701,7 @@ class LunaScreenSelectMusic : public Luna<ScreenSelectMusic>
 	static int StartPlaylistAsCourse(T* p, lua_State* L)
 	{
 		const string name = SArg(1);
-		Playlist& pl = SONGMAN->GetPlaylists()[name];
+		Playlist& pl = SONGMAN::GetPlaylists()[name];
 
 		// don't allow empty playlists to be started as a course
 		if (pl.chartlist.empty()) {
@@ -1723,7 +1723,7 @@ class LunaScreenSelectMusic : public Luna<ScreenSelectMusic>
 			return 1;
 		}
 
-		SONGMAN->playlistcourse = name;
+		SONGMAN::playlistcourse = name;
 		GAMESTATE->isplaylistcourse = true;
 		p->GetMusicWheel()->SelectSong(pl.chartlist[0].songptr);
 		GAMESTATE->m_SongOptions.GetPreferred().m_fMusicRate =

--- a/src/Etterna/Screen/Others/ScreenSelectMusic.cpp
+++ b/src/Etterna/Screen/Others/ScreenSelectMusic.cpp
@@ -162,7 +162,7 @@ ScreenSelectMusic::Init()
 
 	// build the playlist groups here, songmanager's init from disk can't
 	// because profiles aren't loaded until after that's done -mina
-	SONGMAN::MakeSongGroupsFromPlaylists();
+	SongManager::MakeSongGroupsFromPlaylists();
 
 	m_MusicWheel.SetName("MusicWheel");
 	m_MusicWheel.Load(MUSIC_WHEEL_TYPE);
@@ -202,10 +202,10 @@ ScreenSelectMusic::BeginScreen()
 	g_ScreenStartedLoadingAt.Touch();
 	m_timerIdleComment.GetDeltaTime();
 
-	SONGMAN::MakeSongGroupsFromPlaylists();
-	SONGMAN::SetFavoritedStatus(
+	SongManager::MakeSongGroupsFromPlaylists();
+	SongManager::SetFavoritedStatus(
 	  PROFILEMAN->GetProfile(PLAYER_1)->FavoritedCharts);
-	SONGMAN::SetHasGoal(PROFILEMAN->GetProfile(PLAYER_1)->goalmap);
+	SongManager::SetHasGoal(PROFILEMAN->GetProfile(PLAYER_1)->goalmap);
 	if (CommonMetrics::AUTO_SET_STYLE) {
 		GAMESTATE->SetCompatibleStylesForPlayers();
 	}
@@ -248,7 +248,7 @@ ScreenSelectMusic::BeginScreen()
 
 	if (GAMESTATE->IsPlaylistCourse()) {
 		GAMESTATE->isplaylistcourse = false;
-		SONGMAN::playlistcourse = "";
+		SongManager::playlistcourse = "";
 	}
 
 	// Update the leaderboard for the file we may have just left
@@ -367,7 +367,7 @@ void
 ScreenSelectMusic::DifferentialReload()
 {
 	// reload songs
-	SONGMAN::DifferentialReload();
+	SongManager::DifferentialReload();
 
 	const auto selSong = GAMESTATE->m_pCurSong;
 	const auto currentHoveredGroup = m_MusicWheel.GetCurrentGroup();
@@ -448,7 +448,7 @@ ScreenSelectMusic::Input(const InputEventPlus& input)
 					oldChartkeys.emplace_back(steps->GetChartKey());
 
 				to_reload->ReloadFromSongDir();
-				SONGMAN::ReconcileChartKeysForReloadedSong(to_reload,
+				SongManager::ReconcileChartKeysForReloadedSong(to_reload,
 														   oldChartkeys);
 
 				AfterMusicChange();
@@ -456,7 +456,7 @@ ScreenSelectMusic::Input(const InputEventPlus& input)
 			}
 		} else if (holding_shift && bHoldingCtrl && c == 'P' &&
 				   m_MusicWheel.IsSettled() && input.type == IET_FIRST_PRESS) {
-			SONGMAN::ForceReloadSongGroup(
+			SongManager::ForceReloadSongGroup(
 			  GetMusicWheel()->GetSelectedSection());
 			AfterMusicChange();
 			SCREENMAN->SystemMessage("Current pack reloaded");
@@ -477,7 +477,7 @@ ScreenSelectMusic::Input(const InputEventPlus& input)
 					// now update favorites playlist
 					// we have to do this here or it won't work for ??? reasons
 					pProfile->allplaylists.erase("Favorites");
-					SONGMAN::MakePlaylistFromFavorites(
+					SongManager::MakePlaylistFromFavorites(
 					  pProfile->FavoritedCharts, pProfile->allplaylists);
 				} else {
 					fav_me_biatch->SetFavorited(false);
@@ -488,7 +488,7 @@ ScreenSelectMusic::Input(const InputEventPlus& input)
 
 					// we have to do this here or it won't work for ??? reasons
 					pProfile->allplaylists.erase("Favorites");
-					SONGMAN::MakePlaylistFromFavorites(
+					SongManager::MakePlaylistFromFavorites(
 					  pProfile->FavoritedCharts, pProfile->allplaylists);
 				}
 				DLMAN->RefreshFavourites();
@@ -565,16 +565,16 @@ ScreenSelectMusic::Input(const InputEventPlus& input)
 		} else if (bHoldingCtrl && c == 'A' && m_MusicWheel.IsSettled() &&
 				   input.type == IET_FIRST_PRESS &&
 				   GAMESTATE->m_pCurSteps != nullptr) {
-			if (SONGMAN::GetPlaylists().empty())
+			if (SongManager::GetPlaylists().empty())
 				return true;
 
-			SONGMAN::GetPlaylists()[SONGMAN::activeplaylist].AddChart(
+			SongManager::GetPlaylists()[SongManager::activeplaylist].AddChart(
 			  GAMESTATE->m_pCurSteps->GetChartKey());
 			MESSAGEMAN->Broadcast("DisplaySinglePlaylist");
 			SCREENMAN->SystemMessage(
 			  ssprintf(ADDED_TO_PLAYLIST.GetValue(),
 					   GAMESTATE->m_pCurSong->GetDisplayMainTitle().c_str(),
-					   SONGMAN::activeplaylist.c_str()));
+					   SongManager::activeplaylist.c_str()));
 			return true;
 		} else if (bHoldingCtrl && c == 'T' && m_MusicWheel.IsSettled() &&
 				   input.type == IET_FIRST_PRESS &&
@@ -582,7 +582,7 @@ ScreenSelectMusic::Input(const InputEventPlus& input)
 
 			auto ck = GAMESTATE->m_pCurSteps->GetChartKey();
 			Skillset foundSS = Skillset_Invalid;
-			for (const auto& ss : SONGMAN::testChartList) {
+			for (const auto& ss : SongManager::testChartList) {
 				if (ss.second.filemapping.count(ck)) {
 					foundSS = ss.first;
 					break;
@@ -1079,11 +1079,11 @@ ScreenSelectMusic::HandleScreenMessage(const ScreenMessage& SM)
 				else if (GAMESTATE->m_pCurSteps != nullptr) {
 					CalcTest thetest;
 					auto ck = GAMESTATE->m_pCurSteps->GetChartKey();
-					if (SONGMAN::testChartList.count(ss)) {
+					if (SongManager::testChartList.count(ss)) {
 						thetest.ck = ck;
 						thetest.ev = target;
 						thetest.rate = 1.f;
-						SONGMAN::testChartList[ss].filemapping[ck] = thetest;
+						SongManager::testChartList[ss].filemapping[ck] = thetest;
 					} else {
 						CalcTestList tl;
 						tl.skillset = ss;
@@ -1091,15 +1091,15 @@ ScreenSelectMusic::HandleScreenMessage(const ScreenMessage& SM)
 						thetest.ev = target;
 						thetest.rate = 1.f;
 						tl.filemapping[ck] = thetest;
-						SONGMAN::testChartList[ss] = tl;
+						SongManager::testChartList[ss] = tl;
 					}
 					SCREENMAN->SystemMessage(
 					  ssprintf("added %s to %s at rate 1.0",
 							   ck.c_str(),
 							   SkillsetToString(ss).c_str()));
-					SONGMAN::SaveCalcTestXmlToDir();
+					SongManager::SaveCalcTestXmlToDir();
 					float woo = GAMESTATE->m_pCurSteps->DoATestThing(
-					  target, ss, 1.f, SONGMAN::calc.get());
+					  target, ss, 1.f, SongManager::calc.get());
 				}
 			} catch (...) {
 				SCREENMAN->SystemMessage("you messed up (input exception)");
@@ -1114,11 +1114,11 @@ ScreenSelectMusic::HandleScreenMessage(const ScreenMessage& SM)
 				else if (GAMESTATE->m_pCurSteps != nullptr) {
 					CalcTest thetest;
 					auto ck = GAMESTATE->m_pCurSteps->GetChartKey();
-					if (SONGMAN::testChartList.count(ss)) {
+					if (SongManager::testChartList.count(ss)) {
 						thetest.ck = ck;
 						thetest.ev = target;
 						thetest.rate = rate;
-						SONGMAN::testChartList[ss].filemapping[ck] = thetest;
+						SongManager::testChartList[ss].filemapping[ck] = thetest;
 					} else {
 						CalcTestList tl;
 						tl.skillset = ss;
@@ -1126,16 +1126,16 @@ ScreenSelectMusic::HandleScreenMessage(const ScreenMessage& SM)
 						thetest.ev = target;
 						thetest.rate = rate;
 						tl.filemapping[ck] = thetest;
-						SONGMAN::testChartList[ss] = tl;
+						SongManager::testChartList[ss] = tl;
 					}
 					SCREENMAN->SystemMessage(
 					  ssprintf("added %s to %s at rate %f",
 							   ck.c_str(),
 							   SkillsetToString(ss).c_str(),
 							   rate));
-					SONGMAN::SaveCalcTestXmlToDir();
+					SongManager::SaveCalcTestXmlToDir();
 					float woo = GAMESTATE->m_pCurSteps->DoATestThing(
-					  target, ss, rate, SONGMAN::calc.get());
+					  target, ss, rate, SongManager::calc.get());
 				}
 			} catch (...) {
 				SCREENMAN->SystemMessage("you messed up (input exception)");
@@ -1149,8 +1149,8 @@ ScreenSelectMusic::HandleScreenMessage(const ScreenMessage& SM)
 		Playlist pl;
 		pl.name = ScreenTextEntry::s_sLastAnswer;
 		if (pl.name != "") {
-			SONGMAN::GetPlaylists().emplace(pl.name, pl);
-			SONGMAN::activeplaylist = pl.name;
+			SongManager::GetPlaylists().emplace(pl.name, pl);
+			SongManager::activeplaylist = pl.name;
 			MESSAGEMAN->Broadcast("DisplayAll");
 		}
 
@@ -1393,7 +1393,7 @@ ScreenSelectMusic::AfterMusicChange()
 			// handling) manually call songmans cleanup function (compresses all
 			// steps); we could optimize by only compressing the pack but this
 			// is pretty fast anyway -mina
-			SONGMAN::Cleanup();
+			SongManager::Cleanup();
 		}
 	} else {
 		GAMESTATE->m_pPreferredSong = pSong;
@@ -1701,7 +1701,7 @@ class LunaScreenSelectMusic : public Luna<ScreenSelectMusic>
 	static int StartPlaylistAsCourse(T* p, lua_State* L)
 	{
 		const string name = SArg(1);
-		Playlist& pl = SONGMAN::GetPlaylists()[name];
+		Playlist& pl = SongManager::GetPlaylists()[name];
 
 		// don't allow empty playlists to be started as a course
 		if (pl.chartlist.empty()) {
@@ -1723,7 +1723,7 @@ class LunaScreenSelectMusic : public Luna<ScreenSelectMusic>
 			return 1;
 		}
 
-		SONGMAN::playlistcourse = name;
+		SongManager::playlistcourse = name;
 		GAMESTATE->isplaylistcourse = true;
 		p->GetMusicWheel()->SelectSong(pl.chartlist[0].songptr);
 		GAMESTATE->m_SongOptions.GetPreferred().m_fMusicRate =

--- a/src/Etterna/Singletons/DownloadManager.cpp
+++ b/src/Etterna/Singletons/DownloadManager.cpp
@@ -468,7 +468,7 @@ Download*
 DownloadManager::DownloadAndInstallPack(DownloadablePack* pack, bool mirror)
 {
 	vector<std::string> packs;
-	SONGMAN->GetSongGroupNames(packs);
+	SONGMAN::GetSongGroupNames(packs);
 	for (auto packName : packs) {
 		if (packName == pack->name) {
 			SCREENMAN->SystemMessage("Already have pack " + packName +
@@ -592,7 +592,7 @@ DownloadManager::UpdatePacks(float fDeltaSeconds)
 		else if (screen && screen->GetName() == "ScreenNetSelectMusic")
 			static_cast<ScreenNetSelectMusic*>(screen)->DifferentialReload();
 		else
-			SONGMAN->DifferentialReload();
+			SONGMAN::DifferentialReload();
 	}
 	if (downloadingPacks < maxPacksToDownloadAtOnce && !DownloadQueue.empty() &&
 		timeSinceLastDownload > DownloadCooldownTime) {
@@ -700,7 +700,7 @@ DownloadManager::UpdatePacks(float fDeltaSeconds)
 		else if (screen && screen->GetName() == "ScreenNetSelectMusic")
 			static_cast<ScreenNetSelectMusic*>(screen)->DifferentialReload();
 		else
-			SONGMAN->DifferentialReload();
+			SONGMAN::DifferentialReload();
 	}
 }
 
@@ -875,7 +875,7 @@ SetCURLPOSTScore(CURL*& curlHandle,
 	SetCURLFormPostField(
 	  curlHandle, form, lastPtr, "chartkey", hs->GetChartKey());
 	SetCURLFormPostField(curlHandle, form, lastPtr, "rate", hs->musics);
-	auto chart = SONGMAN->GetStepsByChartkey(hs->GetChartKey());
+	auto chart = SONGMAN::GetStepsByChartkey(hs->GetChartKey());
 	if (chart == nullptr)
 		return;
 	SetCURLFormPostField(curlHandle,
@@ -943,7 +943,7 @@ DownloadManager::UploadScore(HighScore* hs,
 	const auto& rows = hs->GetNoteRowVector();
 	if (!offsets.empty()) {
 		replayString = "[";
-		auto steps = SONGMAN->GetStepsByChartkey(hs->GetChartKey());
+		auto steps = SONGMAN::GetStepsByChartkey(hs->GetChartKey());
 		if (steps == nullptr) {
 			LOG->Trace("Attempted to upload score with no loaded steps "
 					   "(scorekey: \"%s\" chartkey: \"%s\")",
@@ -1236,7 +1236,7 @@ DownloadManager::ForceUploadScoresForPack(const std::string& pack,
 										  bool startnow)
 {
 	startnow = startnow && this->ScoreUploadSequentialQueue.empty();
-	auto songs = SONGMAN->GetSongs(pack);
+	auto songs = SONGMAN::GetSongs(pack);
 	for (auto so : songs)
 		for (auto c : so->GetAllSteps())
 			ForceUploadScoresForChart(c->GetChartKey(), false);
@@ -1254,7 +1254,7 @@ DownloadManager::ForceUploadAllScores()
 {
 	bool not_already_uploading = this->ScoreUploadSequentialQueue.empty();
 
-	auto songs = SONGMAN->GetSongs(GROUP_ALL);
+	auto songs = SONGMAN::GetSongs(GROUP_ALL);
 	for (auto so : songs)
 		for (auto c : so->GetAllSteps())
 			ForceUploadScoresForChart(c->GetChartKey(), false);

--- a/src/Etterna/Singletons/DownloadManager.cpp
+++ b/src/Etterna/Singletons/DownloadManager.cpp
@@ -468,7 +468,7 @@ Download*
 DownloadManager::DownloadAndInstallPack(DownloadablePack* pack, bool mirror)
 {
 	vector<std::string> packs;
-	SONGMAN::GetSongGroupNames(packs);
+	SongManager::GetSongGroupNames(packs);
 	for (auto packName : packs) {
 		if (packName == pack->name) {
 			SCREENMAN->SystemMessage("Already have pack " + packName +
@@ -592,7 +592,7 @@ DownloadManager::UpdatePacks(float fDeltaSeconds)
 		else if (screen && screen->GetName() == "ScreenNetSelectMusic")
 			static_cast<ScreenNetSelectMusic*>(screen)->DifferentialReload();
 		else
-			SONGMAN::DifferentialReload();
+			SongManager::DifferentialReload();
 	}
 	if (downloadingPacks < maxPacksToDownloadAtOnce && !DownloadQueue.empty() &&
 		timeSinceLastDownload > DownloadCooldownTime) {
@@ -700,7 +700,7 @@ DownloadManager::UpdatePacks(float fDeltaSeconds)
 		else if (screen && screen->GetName() == "ScreenNetSelectMusic")
 			static_cast<ScreenNetSelectMusic*>(screen)->DifferentialReload();
 		else
-			SONGMAN::DifferentialReload();
+			SongManager::DifferentialReload();
 	}
 }
 
@@ -875,7 +875,7 @@ SetCURLPOSTScore(CURL*& curlHandle,
 	SetCURLFormPostField(
 	  curlHandle, form, lastPtr, "chartkey", hs->GetChartKey());
 	SetCURLFormPostField(curlHandle, form, lastPtr, "rate", hs->musics);
-	auto chart = SONGMAN::GetStepsByChartkey(hs->GetChartKey());
+	auto chart = SongManager::GetStepsByChartkey(hs->GetChartKey());
 	if (chart == nullptr)
 		return;
 	SetCURLFormPostField(curlHandle,
@@ -943,7 +943,7 @@ DownloadManager::UploadScore(HighScore* hs,
 	const auto& rows = hs->GetNoteRowVector();
 	if (!offsets.empty()) {
 		replayString = "[";
-		auto steps = SONGMAN::GetStepsByChartkey(hs->GetChartKey());
+		auto steps = SongManager::GetStepsByChartkey(hs->GetChartKey());
 		if (steps == nullptr) {
 			LOG->Trace("Attempted to upload score with no loaded steps "
 					   "(scorekey: \"%s\" chartkey: \"%s\")",
@@ -1236,7 +1236,7 @@ DownloadManager::ForceUploadScoresForPack(const std::string& pack,
 										  bool startnow)
 {
 	startnow = startnow && this->ScoreUploadSequentialQueue.empty();
-	auto songs = SONGMAN::GetSongs(pack);
+	auto songs = SongManager::GetSongs(pack);
 	for (auto so : songs)
 		for (auto c : so->GetAllSteps())
 			ForceUploadScoresForChart(c->GetChartKey(), false);
@@ -1254,7 +1254,7 @@ DownloadManager::ForceUploadAllScores()
 {
 	bool not_already_uploading = this->ScoreUploadSequentialQueue.empty();
 
-	auto songs = SONGMAN::GetSongs(GROUP_ALL);
+	auto songs = SongManager::GetSongs(GROUP_ALL);
 	for (auto so : songs)
 		for (auto c : so->GetAllSteps())
 			ForceUploadScoresForChart(c->GetChartKey(), false);

--- a/src/Etterna/Singletons/NetworkSyncManager.cpp
+++ b/src/Etterna/Singletons/NetworkSyncManager.cpp
@@ -672,7 +672,7 @@ ETTProtocol::FindJsonChart(NetworkSyncManager* n, Value& ch)
 	  ch.HasMember("meter") && ch["meter"].IsInt() ? ch["meter"].GetInt() : -1;
 
 	if (!n->chartkey.empty()) {
-		auto song = SONGMAN->GetSongByChartkey(n->chartkey);
+		auto song = SONGMAN::GetSongByChartkey(n->chartkey);
 		if (song == nullptr)
 			return;
 		if ((n->m_sArtist.empty() ||
@@ -694,7 +694,7 @@ ETTProtocol::FindJsonChart(NetworkSyncManager* n, Value& ch)
 			}
 		}
 	} else {
-		vector<Song*> AllSongs = SONGMAN->GetAllSongs();
+		vector<Song*> AllSongs = SONGMAN::GetAllSongs();
 		for (size_t i = 0; i < AllSongs.size(); i++) {
 			auto& m_cSong = AllSongs[i];
 			if ((n->m_sArtist.empty() ||
@@ -823,7 +823,7 @@ ETTProtocol::Update(NetworkSyncManager* n, float fDeltaTime)
 						writer.String(GAMESTATE->GetEtternaVersion().c_str());
 						writer.Key("packs");
 						writer.StartArray();
-						auto& packs = SONGMAN->GetSongGroupNames();
+						auto& packs = SONGMAN::GetSongGroupNames();
 						for (auto& pack : packs) {
 							writer.String(correct_non_utf_8(pack).c_str());
 						}
@@ -1612,7 +1612,7 @@ ETTProtocol::ReportHighScore(HighScore* hs, PlayerStageStats& pss)
 						.GetString()
 						.c_str());
 	}
-	auto chart = SONGMAN->GetStepsByChartkey(hs->GetChartKey());
+	auto chart = SONGMAN::GetStepsByChartkey(hs->GetChartKey());
 	writer.Key("negsolo");
 	writer.Int(chart->GetTimingData()->HasWarps() ||
 			   chart->m_StepsType != StepsType_dance_single);

--- a/src/Etterna/Singletons/NetworkSyncManager.cpp
+++ b/src/Etterna/Singletons/NetworkSyncManager.cpp
@@ -672,7 +672,7 @@ ETTProtocol::FindJsonChart(NetworkSyncManager* n, Value& ch)
 	  ch.HasMember("meter") && ch["meter"].IsInt() ? ch["meter"].GetInt() : -1;
 
 	if (!n->chartkey.empty()) {
-		auto song = SONGMAN::GetSongByChartkey(n->chartkey);
+		auto song = SongManager::GetSongByChartkey(n->chartkey);
 		if (song == nullptr)
 			return;
 		if ((n->m_sArtist.empty() ||
@@ -694,7 +694,7 @@ ETTProtocol::FindJsonChart(NetworkSyncManager* n, Value& ch)
 			}
 		}
 	} else {
-		vector<Song*> AllSongs = SONGMAN::GetAllSongs();
+		vector<Song*> AllSongs = SongManager::GetAllSongs();
 		for (size_t i = 0; i < AllSongs.size(); i++) {
 			auto& m_cSong = AllSongs[i];
 			if ((n->m_sArtist.empty() ||
@@ -823,7 +823,7 @@ ETTProtocol::Update(NetworkSyncManager* n, float fDeltaTime)
 						writer.String(GAMESTATE->GetEtternaVersion().c_str());
 						writer.Key("packs");
 						writer.StartArray();
-						auto& packs = SONGMAN::GetSongGroupNames();
+						auto& packs = SongManager::GetSongGroupNames();
 						for (auto& pack : packs) {
 							writer.String(correct_non_utf_8(pack).c_str());
 						}
@@ -1612,7 +1612,7 @@ ETTProtocol::ReportHighScore(HighScore* hs, PlayerStageStats& pss)
 						.GetString()
 						.c_str());
 	}
-	auto chart = SONGMAN::GetStepsByChartkey(hs->GetChartKey());
+	auto chart = SongManager::GetStepsByChartkey(hs->GetChartKey());
 	writer.Key("negsolo");
 	writer.Int(chart->GetTimingData()->HasWarps() ||
 			   chart->m_StepsType != StepsType_dance_single);

--- a/src/Etterna/Singletons/ScoreManager.cpp
+++ b/src/Etterna/Singletons/ScoreManager.cpp
@@ -345,7 +345,7 @@ ScoreManager::GetAllPBPtrs(const string& profileID)
 {
 	vector<vector<HighScore*>> vec;
 	for (auto& i : pscores.at(profileID)) {
-		if (!SONGMAN->IsChartLoaded(i.first)) {
+		if (!SONGMAN::IsChartLoaded(i.first)) {
 			continue;
 		}
 		vec.emplace_back(i.second.GetAllPBPtrs());
@@ -382,7 +382,7 @@ void
 ScoreManager::SetAllTopScores(const string& profileID)
 {
 	for (auto& i : pscores[profileID]) {
-		if (!SONGMAN->IsChartLoaded(i.first)) {
+		if (!SONGMAN::IsChartLoaded(i.first)) {
 			continue;
 		}
 		i.second.SetTopScores();
@@ -499,7 +499,7 @@ ScoreManager::RecalculateSSRs(LoadingWindow* ld)
 				++scoreIndex;
 
 				auto ck = hs->GetChartKey();
-				auto* steps = SONGMAN->GetStepsByChartkey(ck);
+				auto* steps = SONGMAN::GetStepsByChartkey(ck);
 
 				// this _should_ be impossible since ischartloaded() checks
 				// are required on all charts before getting here but just
@@ -698,7 +698,7 @@ ScoreManager::RecalculateSSRs(const string& profileID)
 				++scoreIndex;
 
 				auto ck = hs->GetChartKey();
-				auto* steps = SONGMAN->GetStepsByChartkey(ck);
+				auto* steps = SONGMAN::GetStepsByChartkey(ck);
 
 				// check for unloaded steps, only allow 4k
 				if (steps == nullptr ||
@@ -822,7 +822,7 @@ ScoreManager::AggregateSSRs(Skillset ss,
 				ts->GetEtternaValid() &&
 				static_cast<int>(ts->GetChordCohesion()) == 0 &&
 				ts->GetTopScore() != 0 &&
-				SONGMAN->GetStepsByChartkey(ts->GetChartKey())->m_StepsType ==
+				SONGMAN::GetStepsByChartkey(ts->GetChartKey())->m_StepsType ==
 				  StepsType_dance_single) {
 				sum += std::max(
 				  0.0, 2.F / erfc(0.1 * (ts->GetSkillsetSSR(ss) - rating)) - 2);
@@ -841,7 +841,7 @@ ScoreManager::SortTopSSRPtrs(Skillset ss, const string& profileID)
 {
 	TopSSRs.clear();
 	for (auto& i : pscores[profileID]) {
-		if (!SONGMAN->IsChartLoaded(i.first)) {
+		if (!SONGMAN::IsChartLoaded(i.first)) {
 			continue;
 		}
 		for (const auto& hs : i.second.GetAllPBPtrs()) {
@@ -861,8 +861,8 @@ ScoreManager::SortTopSSRPtrsForGame(Skillset ss, const string& profileID)
 {
 	TopSSRsForGame.clear();
 	for (auto& i : pscores[profileID]) {
-		if (!SONGMAN->IsChartLoaded(i.first) ||
-			!SONGMAN->GetStepsByChartkey(i.first)->IsPlayableForCurrentGame()) {
+		if (!SONGMAN::IsChartLoaded(i.first) ||
+			!SONGMAN::GetStepsByChartkey(i.first)->IsPlayableForCurrentGame()) {
 			continue;
 		}
 		for (const auto& hs : i.second.GetAllPBPtrs()) {
@@ -902,7 +902,7 @@ ScoreManager::SortRecentScores(const string& profileID)
 {
 	TopSSRs.clear();
 	for (auto& i : pscores[profileID]) {
-		if (!SONGMAN->IsChartLoaded(i.first)) {
+		if (!SONGMAN::IsChartLoaded(i.first)) {
 			continue;
 		}
 		for (const auto& hs : i.second.GetAllScores()) {
@@ -922,8 +922,8 @@ ScoreManager::SortRecentScoresForGame(const string& profileID)
 {
 	TopSSRsForGame.clear();
 	for (auto& i : pscores[profileID]) {
-		if (!SONGMAN->IsChartLoaded(i.first) ||
-			!SONGMAN->GetStepsByChartkey(i.first)->IsPlayableForCurrentGame()) {
+		if (!SONGMAN::IsChartLoaded(i.first) ||
+			!SONGMAN::GetStepsByChartkey(i.first)->IsPlayableForCurrentGame()) {
 			continue;
 		}
 		for (const auto& hs : i.second.GetAllScores()) {
@@ -1108,7 +1108,7 @@ ScoresAtRate::LoadFromNode(const XNode* node,
 		 * and while it sort of makes sense from a user convenience aspect
 		 * to allow this, it definitely does not make sense from a clarity
 		 * or consistency perspective */
-		if ((oldcalc || getremarried) && SONGMAN->IsChartLoaded(ck)) {
+		if ((oldcalc || getremarried) && SONGMAN::IsChartLoaded(ck)) {
 			SCOREMAN->scorestorecalc.emplace_back(&scores[sk]);
 		}
 	}

--- a/src/Etterna/Singletons/ScoreManager.cpp
+++ b/src/Etterna/Singletons/ScoreManager.cpp
@@ -345,7 +345,7 @@ ScoreManager::GetAllPBPtrs(const string& profileID)
 {
 	vector<vector<HighScore*>> vec;
 	for (auto& i : pscores.at(profileID)) {
-		if (!SONGMAN::IsChartLoaded(i.first)) {
+		if (!SongManager::IsChartLoaded(i.first)) {
 			continue;
 		}
 		vec.emplace_back(i.second.GetAllPBPtrs());
@@ -382,7 +382,7 @@ void
 ScoreManager::SetAllTopScores(const string& profileID)
 {
 	for (auto& i : pscores[profileID]) {
-		if (!SONGMAN::IsChartLoaded(i.first)) {
+		if (!SongManager::IsChartLoaded(i.first)) {
 			continue;
 		}
 		i.second.SetTopScores();
@@ -499,7 +499,7 @@ ScoreManager::RecalculateSSRs(LoadingWindow* ld)
 				++scoreIndex;
 
 				auto ck = hs->GetChartKey();
-				auto* steps = SONGMAN::GetStepsByChartkey(ck);
+				auto* steps = SongManager::GetStepsByChartkey(ck);
 
 				// this _should_ be impossible since ischartloaded() checks
 				// are required on all charts before getting here but just
@@ -698,7 +698,7 @@ ScoreManager::RecalculateSSRs(const string& profileID)
 				++scoreIndex;
 
 				auto ck = hs->GetChartKey();
-				auto* steps = SONGMAN::GetStepsByChartkey(ck);
+				auto* steps = SongManager::GetStepsByChartkey(ck);
 
 				// check for unloaded steps, only allow 4k
 				if (steps == nullptr ||
@@ -822,7 +822,7 @@ ScoreManager::AggregateSSRs(Skillset ss,
 				ts->GetEtternaValid() &&
 				static_cast<int>(ts->GetChordCohesion()) == 0 &&
 				ts->GetTopScore() != 0 &&
-				SONGMAN::GetStepsByChartkey(ts->GetChartKey())->m_StepsType ==
+				SongManager::GetStepsByChartkey(ts->GetChartKey())->m_StepsType ==
 				  StepsType_dance_single) {
 				sum += std::max(
 				  0.0, 2.F / erfc(0.1 * (ts->GetSkillsetSSR(ss) - rating)) - 2);
@@ -841,7 +841,7 @@ ScoreManager::SortTopSSRPtrs(Skillset ss, const string& profileID)
 {
 	TopSSRs.clear();
 	for (auto& i : pscores[profileID]) {
-		if (!SONGMAN::IsChartLoaded(i.first)) {
+		if (!SongManager::IsChartLoaded(i.first)) {
 			continue;
 		}
 		for (const auto& hs : i.second.GetAllPBPtrs()) {
@@ -861,8 +861,8 @@ ScoreManager::SortTopSSRPtrsForGame(Skillset ss, const string& profileID)
 {
 	TopSSRsForGame.clear();
 	for (auto& i : pscores[profileID]) {
-		if (!SONGMAN::IsChartLoaded(i.first) ||
-			!SONGMAN::GetStepsByChartkey(i.first)->IsPlayableForCurrentGame()) {
+		if (!SongManager::IsChartLoaded(i.first) ||
+			!SongManager::GetStepsByChartkey(i.first)->IsPlayableForCurrentGame()) {
 			continue;
 		}
 		for (const auto& hs : i.second.GetAllPBPtrs()) {
@@ -902,7 +902,7 @@ ScoreManager::SortRecentScores(const string& profileID)
 {
 	TopSSRs.clear();
 	for (auto& i : pscores[profileID]) {
-		if (!SONGMAN::IsChartLoaded(i.first)) {
+		if (!SongManager::IsChartLoaded(i.first)) {
 			continue;
 		}
 		for (const auto& hs : i.second.GetAllScores()) {
@@ -922,8 +922,8 @@ ScoreManager::SortRecentScoresForGame(const string& profileID)
 {
 	TopSSRsForGame.clear();
 	for (auto& i : pscores[profileID]) {
-		if (!SONGMAN::IsChartLoaded(i.first) ||
-			!SONGMAN::GetStepsByChartkey(i.first)->IsPlayableForCurrentGame()) {
+		if (!SongManager::IsChartLoaded(i.first) ||
+			!SongManager::GetStepsByChartkey(i.first)->IsPlayableForCurrentGame()) {
 			continue;
 		}
 		for (const auto& hs : i.second.GetAllScores()) {
@@ -1108,7 +1108,7 @@ ScoresAtRate::LoadFromNode(const XNode* node,
 		 * and while it sort of makes sense from a user convenience aspect
 		 * to allow this, it definitely does not make sense from a clarity
 		 * or consistency perspective */
-		if ((oldcalc || getremarried) && SONGMAN::IsChartLoaded(ck)) {
+		if ((oldcalc || getremarried) && SongManager::IsChartLoaded(ck)) {
 			SCOREMAN->scorestorecalc.emplace_back(&scores[sk]);
 		}
 	}

--- a/src/Etterna/Singletons/ScreenManager.cpp
+++ b/src/Etterna/Singletons/ScreenManager.cpp
@@ -194,7 +194,7 @@ AfterDeleteScreen()
 
 	/* Cleanup song data. This can free up a fair bit of memory, so do it
 	 * after deleting screens. */
-	SONGMAN->Cleanup();
+	SONGMAN::Cleanup();
 }
 
 /* Take ownership of all screens and backgrounds that are owned by
@@ -302,7 +302,7 @@ ScreenManager::ThemeChanged()
 	m_soundScreenshot.Load(THEME->GetPathS("Common", "screenshot"));
 
 	// reload song manager colors (to avoid crashes) -aj
-	SONGMAN->ResetGroupColors();
+	SONGMAN::ResetGroupColors();
 
 	ReloadOverlayScreens();
 

--- a/src/Etterna/Singletons/ScreenManager.cpp
+++ b/src/Etterna/Singletons/ScreenManager.cpp
@@ -194,7 +194,7 @@ AfterDeleteScreen()
 
 	/* Cleanup song data. This can free up a fair bit of memory, so do it
 	 * after deleting screens. */
-	SONGMAN::Cleanup();
+	SongManager::Cleanup();
 }
 
 /* Take ownership of all screens and backgrounds that are owned by
@@ -302,7 +302,7 @@ ScreenManager::ThemeChanged()
 	m_soundScreenshot.Load(THEME->GetPathS("Common", "screenshot"));
 
 	// reload song manager colors (to avoid crashes) -aj
-	SONGMAN::ResetGroupColors();
+	SongManager::ResetGroupColors();
 
 	ReloadOverlayScreens();
 

--- a/src/Etterna/Singletons/SongManager.cpp
+++ b/src/Etterna/Singletons/SongManager.cpp
@@ -74,25 +74,18 @@ AutoScreenMessage(SM_BackFromNamePlaylist);
 
 namespace SONGMAN {
 namespace { // Anonymous namespace (For internally-used functions and variables)
-// Foward Function Declarations:
-void
-LoadEnabledSongsFromPref();
-void
-LoadStepManiaSongDir(std::string sDir, LoadingWindow* ld);
-auto
-IsSongDir(const std::string& sDir) -> bool;
-auto
-AddGroup(const std::string& sDir, const std::string& sGroupDirName) -> bool;
-void
-AddSongToList(Song* new_song);
+//------------- Foward Function Declarations -------------
+void LoadEnabledSongsFromPref();
+void LoadStepManiaSongDir(std::string sDir, LoadingWindow* ld);
+auto IsSongDir(const std::string& sDir) -> bool;
+auto AddGroup(const std::string& sDir, const std::string& sGroupDirName) -> bool;
+void AddSongToList(Song* new_song);
 // Indexed by chartkeys
-void
-AddKeyedPointers(Song* new_song);
-void
-InitSongsFromDisk(LoadingWindow* ld);
-void
-FreeSongs();
+void AddKeyedPointers(Song* new_song);
+void InitSongsFromDisk(LoadingWindow* ld);
+void FreeSongs();
 
+//------------- Internal Variables and Structs -------------
 /** @brief All of the songs that can be played. */
 std::vector<Song*> m_pSongs;
 std::map<std::string, Song*> m_SongsByDir;
@@ -110,13 +103,13 @@ using SongPointerVector = std::vector<Song*>;
 std::map<std::string, SongPointerVector, Comp> m_mapSongGroupIndex;
 ThemeMetric<int> NUM_SONG_GROUP_COLORS;
 ThemeMetric1D<RageColor> SONG_GROUP_COLOR;
+std::set<std::string> m_GroupsToNeverCache;
 } // End anonymous namespace
 
 // Extern Variables:
 std::unordered_map<std::string, Song*> SongsByKey;
 std::unordered_map<std::string, Steps*> StepsByKey;
 
-std::set<std::string> m_GroupsToNeverCache;
 /** @brief The most popular songs ranked by number of plays. */
 std::vector<Song*> m_pPopularSongs;
 
@@ -135,8 +128,7 @@ std::vector<std::string> playlistGroups; // To delete from groupderps when
 std::map<Skillset, CalcTestList> testChartList;
 std::unique_ptr<Calc> calc;
 
-void
-Init()
+void Init()
 {
 	NUM_SONG_GROUP_COLORS.Load("SongManager", "NumSongGroupColors");
 	SONG_GROUP_COLOR.Load(
@@ -146,14 +138,12 @@ Init()
 	calc = std::make_unique<Calc>();
 }
 
-void
-End()
+void End()
 {
 	FreeSongs();
 }
 
-void
-InitAll(LoadingWindow* ld)
+void InitAll(LoadingWindow* ld)
 {
 	vector<std::string> never_cache;
 	split(PREFSMAN->m_NeverCacheList, ",", never_cache);
@@ -170,8 +160,7 @@ static LocalizedString SANITY_CHECKING_GROUPS("SongManager",
 											  "Sanity checking groups...");
 
 // See InitSongsFromDisk for any comment clarification -mina
-auto
-DifferentialReload() -> int
+auto DifferentialReload() -> int
 {
 	MESSAGEMAN->Broadcast("DFRStarted");
 	FILEMAN->FlushDirCache(SpecialFiles::SONGS_DIR);
@@ -189,8 +178,7 @@ DifferentialReload() -> int
 }
 
 // See LoadStepManiaSongDir for any comment clarification -mina
-auto
-DifferentialReloadDir(string dir) -> int
+auto DifferentialReloadDir(string dir) -> int
 {
 	if (dir.back() != '/') {
 		dir += "/";
@@ -324,8 +312,7 @@ split(vector<T>& v, size_t elementsPerThread) -> std::vector<p<T>>
 	return ranges;
 }
 
-void
-FinalizeSong(Song* pNewSong, const std::string& dir)
+void FinalizeSong(Song* pNewSong, const std::string& dir)
 {
 	// never load stray songs from the cache -mina
 	if (pNewSong->m_sGroupName == "Songs" ||

--- a/src/Etterna/Singletons/SongManager.cpp
+++ b/src/Etterna/Singletons/SongManager.cpp
@@ -72,7 +72,7 @@ SONG_GROUP_COLOR_NAME(size_t i) -> std::string
 
 AutoScreenMessage(SM_BackFromNamePlaylist);
 
-namespace SONGMAN {
+namespace SongManager {
 namespace { // Anonymous namespace (For internally-used functions and variables)
 //------------- Foward Function Declarations -------------
 void LoadEnabledSongsFromPref();
@@ -765,8 +765,8 @@ makePlaylist(const std::string& answer)
 	Playlist pl;
 	pl.name = answer;
 	if (!pl.name.empty()) {
-		SONGMAN::GetPlaylists().emplace(pl.name, pl);
-		SONGMAN::activeplaylist = pl.name;
+		SongManager::GetPlaylists().emplace(pl.name, pl);
+		SongManager::activeplaylist = pl.name;
 		MESSAGEMAN->Broadcast("DisplayAll");
 		PROFILEMAN->SaveProfile(PLAYER_1);
 	}
@@ -832,7 +832,7 @@ LoadCalcTestNode()
 				tl.filemapping[key] = ct;
 			}
 		}
-		SONGMAN::testChartList[ss] = tl;
+		SongManager::testChartList[ss] = tl;
 	}
 }
 
@@ -1028,7 +1028,7 @@ LoadStepManiaSongDir(std::string sDir, LoadingWindow* ld)
 	auto onePercent = std::max(static_cast<int>(songFolders.size() / 100), 1);
 	for (const auto& folder : songFolders) {
 		auto burp = sDir + folder;
-		if (SONGMAN::IsSongDir(burp)) {
+		if (SongManager::IsSongDir(burp)) {
 			unknownGroup.songs.emplace_back(burp);
 		} else {
 			auto group = Group(folder);
@@ -1090,7 +1090,7 @@ LoadStepManiaSongDir(std::string sDir, LoadingWindow* ld)
 				  {
 					  std::lock_guard<std::mutex> lk(diskLoadSongMutex);
 					  AddSongToList(pNewSong);
-					  SONGMAN::AddKeyedPointers(pNewSong);
+					  SongManager::AddKeyedPointers(pNewSong);
 				  }
 				  index_entry.emplace_back(pNewSong);
 				  loaded++;
@@ -1103,7 +1103,7 @@ LoadStepManiaSongDir(std::string sDir, LoadingWindow* ld)
 						 (sDir + sGroupName).c_str());
 			  {
 				  std::lock_guard<std::mutex> lk(diskLoadGroupMutex);
-				  SONGMAN::AddGroup(sDir, sGroupName);
+				  SongManager::AddGroup(sDir, sGroupName);
 				  IMAGECACHE->CacheImage(
 					"Banner", GetSongGroupBannerPath(sDir + sGroupName));
 			  }
@@ -1211,7 +1211,7 @@ namespace {
 static auto
 GetAllSongs(lua_State* L) -> int
 {
-	const auto& v = SONGMAN::GetAllSongs();
+	const auto& v = SongManager::GetAllSongs();
 	LuaHelpers::CreateTableFromArray<Song*>(v, L);
 	return 1;
 }
@@ -1219,28 +1219,28 @@ GetAllSongs(lua_State* L) -> int
 static auto
 DifferentialReload(lua_State* L) -> int
 {
-	lua_pushnumber(L, SONGMAN::DifferentialReload());
+	lua_pushnumber(L, SongManager::DifferentialReload());
 	return 1;
 }
 
 static auto
 GetNumSongs(lua_State* L) -> int
 {
-	lua_pushnumber(L, SONGMAN::GetNumSongs());
+	lua_pushnumber(L, SongManager::GetNumSongs());
 	return 1;
 }
 
 static auto
 GetNumAdditionalSongs(lua_State* L) -> int
 {
-	lua_pushnumber(L, SONGMAN::GetNumAdditionalSongs());
+	lua_pushnumber(L, SongManager::GetNumAdditionalSongs());
 	return 1;
 }
 
 static auto
 GetNumSongGroups(lua_State* L) -> int
 {
-	lua_pushnumber(L, SONGMAN::GetNumSongGroups());
+	lua_pushnumber(L, SongManager::GetNumSongGroups());
 	return 1;
 }
 
@@ -1266,14 +1266,14 @@ GetSongFromSteps(lua_State* L) -> int
 static auto
 GetSongColor(lua_State* L) -> int
 {
-	LuaHelpers::Push(L, SONGMAN::GetSongColor(Luna<Song>::check(L, 1)));
+	LuaHelpers::Push(L, SongManager::GetSongColor(Luna<Song>::check(L, 1)));
 	return 1;
 }
 
 static auto
 GetSongGroupColor(lua_State* L) -> int
 {
-	LuaHelpers::Push(L, SONGMAN::GetSongGroupColor(SArg(1)));
+	LuaHelpers::Push(L, SongManager::GetSongGroupColor(SArg(1)));
 	return 1;
 }
 
@@ -1281,7 +1281,7 @@ static auto
 GetSongGroupNames(lua_State* L) -> int
 {
 	vector<std::string> v;
-	SONGMAN::GetSongGroupNames(v);
+	SongManager::GetSongGroupNames(v);
 	LuaHelpers::CreateTableFromArray<std::string>(v, L);
 	return 1;
 }
@@ -1289,7 +1289,7 @@ GetSongGroupNames(lua_State* L) -> int
 static auto
 GetSongsInGroup(lua_State* L) -> int
 {
-	vector<Song*> v = SONGMAN::GetSongs(SArg(1));
+	vector<Song*> v = SongManager::GetSongs(SArg(1));
 	LuaHelpers::CreateTableFromArray<Song*>(v, L);
 	return 1;
 }
@@ -1297,35 +1297,35 @@ GetSongsInGroup(lua_State* L) -> int
 static auto
 ShortenGroupName(lua_State* L) -> int
 {
-	LuaHelpers::Push(L, SONGMAN::ShortenGroupName(SArg(1)));
+	LuaHelpers::Push(L, SongManager::ShortenGroupName(SArg(1)));
 	return 1;
 }
 
 static auto
 GetSongGroupBannerPath(lua_State* L) -> int
 {
-	LuaHelpers::Push(L, SONGMAN::GetSongGroupBannerPath(SArg(1)));
+	LuaHelpers::Push(L, SongManager::GetSongGroupBannerPath(SArg(1)));
 	return 1;
 }
 
 static auto
 DoesSongGroupExist(lua_State* L) -> int
 {
-	LuaHelpers::Push(L, SONGMAN::DoesSongGroupExist(SArg(1)));
+	LuaHelpers::Push(L, SongManager::DoesSongGroupExist(SArg(1)));
 	return 1;
 }
 
 static auto
 IsChartLoaded(lua_State* L) -> int
 {
-	LuaHelpers::Push(L, SONGMAN::IsChartLoaded(SArg(1)));
+	LuaHelpers::Push(L, SongManager::IsChartLoaded(SArg(1)));
 	return 1;
 }
 
 static auto
 GetPopularSongs(lua_State* L) -> int
 {
-	const auto& v = SONGMAN::GetPopularSongs();
+	const auto& v = SongManager::GetPopularSongs();
 	LuaHelpers::CreateTableFromArray<Song*>(v, L);
 	return 1;
 }
@@ -1335,7 +1335,7 @@ WasLoadedFromAdditionalSongs(lua_State* L) -> int
 {
 	const Song* pSong = Luna<Song>::check(L, 1);
 	lua_pushboolean(
-	  L, static_cast<int>(SONGMAN::WasLoadedFromAdditionalSongs(pSong)));
+	  L, static_cast<int>(SongManager::WasLoadedFromAdditionalSongs(pSong)));
 	return 1;
 }
 
@@ -1343,7 +1343,7 @@ static auto
 GetSongByChartKey(lua_State* L) -> int
 {
 	std::string ck = SArg(1);
-	Song* pSong = SONGMAN::GetSongByChartkey(ck);
+	Song* pSong = SongManager::GetSongByChartkey(ck);
 	if (pSong != nullptr) {
 		pSong->PushSelf(L);
 	} else {
@@ -1356,7 +1356,7 @@ static auto
 GetStepsByChartKey(lua_State* L) -> int
 {
 	std::string ck = SArg(1);
-	Steps* pSteps = SONGMAN::GetStepsByChartkey(ck);
+	Steps* pSteps = SongManager::GetStepsByChartkey(ck);
 	if (pSteps != nullptr) {
 		pSteps->PushSelf(L);
 	} else {
@@ -1368,21 +1368,21 @@ GetStepsByChartKey(lua_State* L) -> int
 static auto
 GetActivePlaylist(lua_State* L) -> int
 {
-	SONGMAN::GetPlaylists()[SONGMAN::activeplaylist].PushSelf(L);
+	SongManager::GetPlaylists()[SongManager::activeplaylist].PushSelf(L);
 	return 1;
 }
 
 static auto
 SetActivePlaylist(lua_State* L) -> int
 {
-	SONGMAN::activeplaylist = SArg(1);
+	SongManager::activeplaylist = SArg(1);
 	return 0;
 }
 
 static auto NewPlaylist(lua_State * /*L*/) -> int
 {
 	ScreenTextEntry::TextEntry(
-	  SM_None, "Name Playlist", "", 128, nullptr, SONGMAN::makePlaylist);
+	  SM_None, "Name Playlist", "", 128, nullptr, SongManager::makePlaylist);
 	return 0;
 }
 
@@ -1391,7 +1391,7 @@ GetPlaylists(lua_State* L) -> int
 {
 	auto idx = 1;
 	lua_newtable(L);
-	for (auto pl : SONGMAN::GetPlaylists()) {
+	for (auto pl : SongManager::GetPlaylists()) {
 		pl.second.PushSelf(L);
 		lua_rawseti(L, -2, idx);
 		++idx;
@@ -1403,12 +1403,12 @@ GetPlaylists(lua_State* L) -> int
 static auto
 DeletePlaylist(lua_State* L) -> int
 {
-	SONGMAN::DeletePlaylist(SArg(1));
+	SongManager::DeletePlaylist(SArg(1));
 	PROFILEMAN->SaveProfile(PLAYER_1);
 	return 0;
 }
 
-const luaL_Reg SONGMANTable[] = { LIST_METHOD(GetAllSongs),
+const luaL_Reg SongManagerTable[] = { LIST_METHOD(GetAllSongs),
 								  LIST_METHOD(DifferentialReload),
 								  LIST_METHOD(GetNumSongs),
 								  LIST_METHOD(GetNumAdditionalSongs),
@@ -1434,7 +1434,7 @@ const luaL_Reg SONGMANTable[] = { LIST_METHOD(GetAllSongs),
 
 }; // Anonymous namespace
 
-LUA_REGISTER_NAMESPACE(SONGMAN)
+LUA_REGISTER_NAMESPACE(SongManager)
 
 class LunaPlaylist : public Luna<Playlist>
 {
@@ -1549,11 +1549,11 @@ Chart::FromKey(const string& ck)
 {
 	// TODO: This function should really be defined in
 	// Etterna/Models/Misc/Difficulty.cpp
-	auto song = SONGMAN::GetSongByChartkey(ck);
+	auto song = SongManager::GetSongByChartkey(ck);
 	key = ck;
 
 	if (song != nullptr) {
-		auto steps = SONGMAN::GetStepsByChartkey(ck);
+		auto steps = SongManager::GetStepsByChartkey(ck);
 		if (steps !=
 			nullptr) { // happens when you edit a file for playtesting -mina
 			lastpack = song->m_sGroupName;

--- a/src/Etterna/Singletons/SongManager.cpp
+++ b/src/Etterna/Singletons/SongManager.cpp
@@ -149,11 +149,6 @@ Init()
 void
 End()
 {
-	// Unregister with Lua.
-	LUA->UnsetGlobal("SONGMAN");
-
-	// Courses depend on Songs and Songs don't depend on Courses.
-	// So, delete the Courses first.
 	FreeSongs();
 }
 

--- a/src/Etterna/Singletons/SongManager.cpp
+++ b/src/Etterna/Singletons/SongManager.cpp
@@ -745,30 +745,6 @@ GetPlaylists() -> map<string, Playlist>&
 	return PROFILEMAN->GetProfile(PLAYER_1)->allplaylists;
 }
 
-void
-SaveEnabledSongsToPref()
-{
-	vector<std::string> vsDisabledSongs;
-
-	// Intentionally drop disabled song entries for songs that aren't
-	// currently loaded.
-
-	for (auto& s : SONGMAN::GetAllSongs()) {
-		SongID sid;
-		sid.FromSong(s);
-		if (!s->GetEnabled()) {
-			vsDisabledSongs.emplace_back(sid.ToString());
-		}
-	}
-	g_sDisabledSongs.Set(join(";", vsDisabledSongs));
-}
-
-void
-DeleteSteps(Steps* pSteps)
-{
-	pSteps->m_pSong->DeleteSteps(pSteps);
-}
-
 auto
 WasLoadedFromAdditionalSongs(const Song* pSong) -> bool
 {

--- a/src/Etterna/Singletons/SongManager.cpp
+++ b/src/Etterna/Singletons/SongManager.cpp
@@ -123,6 +123,7 @@ std::vector<Song*> m_pPopularSongs;
 std::vector<std::string> m_sSongGroupNames;
 std::vector<std::string> m_sSongGroupBannerPaths; // each song group may have a
 												  // banner associated with it
+												  // TODO: INTERNAL
 std::string activeplaylist = "";
 std::string playlistcourse = "";
 
@@ -741,17 +742,6 @@ Cleanup()
 			}
 		}
 	}
-}
-
-/* Flush all Song*, Steps* and Course* caches. This is when a Song or
- * its Steps are removed or changed. This doesn't touch GAMESTATE and
- * StageStats pointers. Currently, the only time Steps are altered
- * independently of the Courses and Songs is in Edit Mode, which updates
- * the other pointers it needs.
- */
-void
-Invalidate(const Song* pStaleSong)
-{
 }
 
 auto

--- a/src/Etterna/Singletons/SongManager.cpp
+++ b/src/Etterna/Singletons/SongManager.cpp
@@ -75,15 +75,23 @@ AutoScreenMessage(SM_BackFromNamePlaylist);
 namespace SONGMAN {
 namespace { // Anonymous namespace (For internally-used functions and variables)
 // Foward Function Declarations:
-void LoadEnabledSongsFromPref();
-void LoadStepManiaSongDir(std::string sDir, LoadingWindow* ld);
-auto IsSongDir(const std::string& sDir) -> bool;
-auto AddGroup(const std::string& sDir, const std::string& sGroupDirName) -> bool;
-void AddSongToList(Song* new_song);
+void
+LoadEnabledSongsFromPref();
+void
+LoadStepManiaSongDir(std::string sDir, LoadingWindow* ld);
+auto
+IsSongDir(const std::string& sDir) -> bool;
+auto
+AddGroup(const std::string& sDir, const std::string& sGroupDirName) -> bool;
+void
+AddSongToList(Song* new_song);
 // Indexed by chartkeys
-void AddKeyedPointers(Song* new_song);
-void InitSongsFromDisk(LoadingWindow* ld);
-void FreeSongs();
+void
+AddKeyedPointers(Song* new_song);
+void
+InitSongsFromDisk(LoadingWindow* ld);
+void
+FreeSongs();
 
 /** @brief All of the songs that can be played. */
 std::vector<Song*> m_pSongs;
@@ -104,7 +112,7 @@ ThemeMetric<int> NUM_SONG_GROUP_COLORS;
 ThemeMetric1D<RageColor> SONG_GROUP_COLOR;
 } // End anonymous namespace
 
-//Extern Variables:
+// Extern Variables:
 std::unordered_map<std::string, Song*> SongsByKey;
 std::unordered_map<std::string, Steps*> StepsByKey;
 
@@ -123,36 +131,12 @@ std::vector<std::string> playlistGroups; // To delete from groupderps when
 										 // rebuilding
 										 // playlist groups
 
-
-
 std::map<Skillset, CalcTestList> testChartList;
 std::unique_ptr<Calc> calc;
-
-
-
-
-
-
-
-
 
 void
 Init()
 {
-	// Register with Lua.
-	{
-		//TODO: This Lua stuff is broken.
-		/*
-		auto L = LUA->Get();
-		lua_pushstring(L, "SONGMAN");
-		// PushSelf(L);
-		// TODO: Check how to fix this. This was used when SongManager was
-		// a class
-		lua_settable(L, LUA_GLOBALSINDEX);
-		LUA->Release(L);
-		 */
-	}
-
 	NUM_SONG_GROUP_COLORS.Load("SongManager", "NumSongGroupColors");
 	SONG_GROUP_COLOR.Load(
 	  "SongManager", SONG_GROUP_COLOR_NAME, NUM_SONG_GROUP_COLORS);
@@ -165,7 +149,7 @@ void
 End()
 {
 	// Unregister with Lua.
-	LUA->UnsetGlobal("SONGMAN"); //TODO: This will probably crash horribly since it's not set.
+	LUA->UnsetGlobal("SONGMAN");
 
 	// Courses depend on Songs and Songs don't depend on Courses.
 	// So, delete the Courses first.
@@ -1331,9 +1315,6 @@ GetSongFromSteps(lua_State* L) -> int
 	return 1;
 }
 
-// DEFINE_METHOD(GetSongColor, GetSongColor(Luna<Song>::check(L, 1)))
-// TODO: DELETE ABOVE COMMENT IF FUNCTION BELOW WORKS
-
 static auto
 GetSongColor(lua_State* L) -> int
 {
@@ -1479,33 +1460,33 @@ DeletePlaylist(lua_State* L) -> int
 	return 0;
 }
 
-const luaL_Reg SongManagerTable[] = { LIST_METHOD(GetAllSongs),
-									  LIST_METHOD(DifferentialReload),
-									  LIST_METHOD(GetNumSongs),
-									  LIST_METHOD(GetNumAdditionalSongs),
-									  LIST_METHOD(GetNumSongGroups),
-									  LIST_METHOD(GetSongFromSteps),
-									  LIST_METHOD(GetSongColor),
-									  LIST_METHOD(GetSongGroupColor),
-									  LIST_METHOD(GetSongGroupNames),
-									  LIST_METHOD(GetSongsInGroup),
-									  LIST_METHOD(ShortenGroupName),
-									  LIST_METHOD(GetSongGroupBannerPath),
-									  LIST_METHOD(DoesSongGroupExist),
-									  LIST_METHOD(GetPopularSongs),
-									  LIST_METHOD(WasLoadedFromAdditionalSongs),
-									  LIST_METHOD(GetSongByChartKey),
-									  LIST_METHOD(GetStepsByChartKey),
-									  LIST_METHOD(GetActivePlaylist),
-									  LIST_METHOD(SetActivePlaylist),
-									  LIST_METHOD(NewPlaylist),
-									  LIST_METHOD(GetPlaylists),
-									  LIST_METHOD(DeletePlaylist),
-									  { nullptr, nullptr } };
+const luaL_Reg SONGMANTable[] = { LIST_METHOD(GetAllSongs),
+								  LIST_METHOD(DifferentialReload),
+								  LIST_METHOD(GetNumSongs),
+								  LIST_METHOD(GetNumAdditionalSongs),
+								  LIST_METHOD(GetNumSongGroups),
+								  LIST_METHOD(GetSongFromSteps),
+								  LIST_METHOD(GetSongColor),
+								  LIST_METHOD(GetSongGroupColor),
+								  LIST_METHOD(GetSongGroupNames),
+								  LIST_METHOD(GetSongsInGroup),
+								  LIST_METHOD(ShortenGroupName),
+								  LIST_METHOD(GetSongGroupBannerPath),
+								  LIST_METHOD(DoesSongGroupExist),
+								  LIST_METHOD(GetPopularSongs),
+								  LIST_METHOD(WasLoadedFromAdditionalSongs),
+								  LIST_METHOD(GetSongByChartKey),
+								  LIST_METHOD(GetStepsByChartKey),
+								  LIST_METHOD(GetActivePlaylist),
+								  LIST_METHOD(SetActivePlaylist),
+								  LIST_METHOD(NewPlaylist),
+								  LIST_METHOD(GetPlaylists),
+								  LIST_METHOD(DeletePlaylist),
+								  { nullptr, nullptr } };
 
 }; // Anonymous namespace
 
-LUA_REGISTER_NAMESPACE(SongManager)
+LUA_REGISTER_NAMESPACE(SONGMAN)
 
 class LunaPlaylist : public Luna<Playlist>
 {

--- a/src/Etterna/Singletons/SongManager.cpp
+++ b/src/Etterna/Singletons/SongManager.cpp
@@ -1258,8 +1258,22 @@ GetSongFromSteps(lua_State* L) -> int
 	return 1;
 }
 
-DEFINE_METHOD(GetSongColor, GetSongColor(Luna<Song>::check(L, 1)))
-DEFINE_METHOD(GetSongGroupColor, GetSongGroupColor(SArg(1)))
+// DEFINE_METHOD(GetSongColor, GetSongColor(Luna<Song>::check(L, 1)))
+// TODO: DELETE ABOVE COMMENT IF FUNCTION BELOW WORKS
+
+static auto
+GetSongColor(lua_State* L) -> int
+{
+	LuaHelpers::Push(L, SONGMAN::GetSongColor(Luna<Song>::check(L, 1)));
+	return 1;
+}
+
+static auto
+GetSongGroupColor(lua_State* L) -> int
+{
+	LuaHelpers::Push(L, SONGMAN::GetSongGroupColor(SArg(1)));
+	return 1;
+}
 
 static auto
 GetSongGroupNames(lua_State* L) -> int
@@ -1278,10 +1292,33 @@ GetSongsInGroup(lua_State* L) -> int
 	return 1;
 }
 
-DEFINE_METHOD(ShortenGroupName, ShortenGroupName(SArg(1)))
-DEFINE_METHOD(GetSongGroupBannerPath, GetSongGroupBannerPath(SArg(1)));
-DEFINE_METHOD(DoesSongGroupExist, DoesSongGroupExist(SArg(1)));
-DEFINE_METHOD(IsChartLoaded, IsChartLoaded(SArg(1)));
+static auto
+ShortenGroupName(lua_State* L) -> int
+{
+	LuaHelpers::Push(L, SONGMAN::ShortenGroupName(SArg(1)));
+	return 1;
+}
+
+static auto
+GetSongGroupBannerPath(lua_State* L) -> int
+{
+	LuaHelpers::Push(L, SONGMAN::GetSongGroupBannerPath(SArg(1)));
+	return 1;
+}
+
+static auto
+DoesSongGroupExist(lua_State* L) -> int
+{
+	LuaHelpers::Push(L, SONGMAN::DoesSongGroupExist(SArg(1)));
+	return 1;
+}
+
+static auto
+IsChartLoaded(lua_State* L) -> int
+{
+	LuaHelpers::Push(L, SONGMAN::IsChartLoaded(SArg(1)));
+	return 1;
+}
 
 static auto
 GetPopularSongs(lua_State* L) -> int
@@ -1379,19 +1416,21 @@ const luaL_Reg SongManagerTable[] = { LIST_METHOD(GetAllSongs),
 									  LIST_METHOD(GetSongGroupColor),
 									  LIST_METHOD(GetSongGroupNames),
 									  LIST_METHOD(GetSongsInGroup),
-									  LIST_METHOD(ShortenGroupName);
-LIST_METHOD(GetSongGroupBannerPath), LIST_METHOD(DoesSongGroupExist),
-  LIST_METHOD(GetPopularSongs), LIST_METHOD(WasLoadedFromAdditionalSongs),
-  LIST_METHOD(GetSongByChartKey), LIST_METHOD(GetStepsByChartKey),
-  LIST_METHOD(GetActivePlaylist), LIST_METHOD(SetActivePlaylist),
-  LIST_METHOD(NewPlaylist), LIST_METHOD(GetPlaylists),
-  LIST_METHOD(DeletePlaylist),
-{
-	nullptr, nullptr
-}
-}
-}
-;
+									  LIST_METHOD(ShortenGroupName),
+									  LIST_METHOD(GetSongGroupBannerPath),
+									  LIST_METHOD(DoesSongGroupExist),
+									  LIST_METHOD(GetPopularSongs),
+									  LIST_METHOD(WasLoadedFromAdditionalSongs),
+									  LIST_METHOD(GetSongByChartKey),
+									  LIST_METHOD(GetStepsByChartKey),
+									  LIST_METHOD(GetActivePlaylist),
+									  LIST_METHOD(SetActivePlaylist),
+									  LIST_METHOD(NewPlaylist),
+									  LIST_METHOD(GetPlaylists),
+									  LIST_METHOD(DeletePlaylist),
+									  { nullptr, nullptr } };
+
+}; // Anonymous namespace
 
 LUA_REGISTER_NAMESPACE(SongManager)
 
@@ -1508,11 +1547,11 @@ Chart::FromKey(const string& ck)
 {
 	// TODO: This function should really be defined in
 	// Etterna/Models/Misc/Difficulty.cpp
-	auto song = GetSongByChartkey(ck);
+	auto song = SONGMAN::GetSongByChartkey(ck);
 	key = ck;
 
 	if (song != nullptr) {
-		auto steps = GetStepsByChartkey(ck);
+		auto steps = SONGMAN::GetStepsByChartkey(ck);
 		if (steps !=
 			nullptr) { // happens when you edit a file for playtesting -mina
 			lastpack = song->m_sGroupName;

--- a/src/Etterna/Singletons/SongManager.cpp
+++ b/src/Etterna/Singletons/SongManager.cpp
@@ -73,25 +73,17 @@ SONG_GROUP_COLOR_NAME(size_t i) -> std::string
 AutoScreenMessage(SM_BackFromNamePlaylist);
 
 namespace SONGMAN {
-namespace { // Anonymous namespace
+namespace { // Anonymous namespace (For internally-used functions and variables)
 // Foward Function Declarations:
-void
-LoadEnabledSongsFromPref();
-void
-LoadStepManiaSongDir(std::string sDir, LoadingWindow* ld);
-auto
-IsSongDir(const std::string& sDir) -> bool;
-auto
-AddGroup(const std::string& sDir, const std::string& sGroupDirName) -> bool;
-void
-AddSongToList(Song* new_song);
+void LoadEnabledSongsFromPref();
+void LoadStepManiaSongDir(std::string sDir, LoadingWindow* ld);
+auto IsSongDir(const std::string& sDir) -> bool;
+auto AddGroup(const std::string& sDir, const std::string& sGroupDirName) -> bool;
+void AddSongToList(Song* new_song);
 // Indexed by chartkeys
-void
-AddKeyedPointers(Song* new_song);
-void
-InitSongsFromDisk(LoadingWindow* ld);
-void
-FreeSongs();
+void AddKeyedPointers(Song* new_song);
+void InitSongsFromDisk(LoadingWindow* ld);
+void FreeSongs();
 
 /** @brief All of the songs that can be played. */
 std::vector<Song*> m_pSongs;
@@ -111,18 +103,54 @@ std::map<std::string, SongPointerVector, Comp> m_mapSongGroupIndex;
 ThemeMetric<int> NUM_SONG_GROUP_COLORS;
 ThemeMetric1D<RageColor> SONG_GROUP_COLOR;
 } // End anonymous namespace
+
+//Extern Variables:
+std::unordered_map<std::string, Song*> SongsByKey;
+std::unordered_map<std::string, Steps*> StepsByKey;
+
+std::set<std::string> m_GroupsToNeverCache;
+/** @brief The most popular songs ranked by number of plays. */
+std::vector<Song*> m_pPopularSongs;
+
+std::vector<std::string> m_sSongGroupNames;
+std::vector<std::string> m_sSongGroupBannerPaths; // each song group may have a
+												  // banner associated with it
+std::string activeplaylist = "";
+std::string playlistcourse = "";
+
+std::map<std::string, std::vector<Song*>> groupderps;
+std::vector<std::string> playlistGroups; // To delete from groupderps when
+										 // rebuilding
+										 // playlist groups
+
+
+
+std::map<Skillset, CalcTestList> testChartList;
+std::unique_ptr<Calc> calc;
+
+
+
+
+
+
+
+
+
 void
 Init()
 {
 	// Register with Lua.
 	{
+		//TODO: This Lua stuff is broken.
+		/*
 		auto L = LUA->Get();
 		lua_pushstring(L, "SONGMAN");
 		// PushSelf(L);
-		// TODO: Check if this is neccesary. This was used when SongManager was
+		// TODO: Check how to fix this. This was used when SongManager was
 		// a class
 		lua_settable(L, LUA_GLOBALSINDEX);
 		LUA->Release(L);
+		 */
 	}
 
 	NUM_SONG_GROUP_COLORS.Load("SongManager", "NumSongGroupColors");
@@ -137,7 +165,7 @@ void
 End()
 {
 	// Unregister with Lua.
-	LUA->UnsetGlobal("SONGMAN");
+	LUA->UnsetGlobal("SONGMAN"); //TODO: This will probably crash horribly since it's not set.
 
 	// Courses depend on Songs and Songs don't depend on Courses.
 	// So, delete the Courses first.

--- a/src/Etterna/Singletons/SongManager.h
+++ b/src/Etterna/Singletons/SongManager.h
@@ -44,11 +44,7 @@ void
 End();
 
 void
-InitSongsFromDisk(LoadingWindow* ld);
-void
 CalcTestStuff();
-void
-FreeSongs();
 void
 Cleanup();
 
@@ -58,8 +54,6 @@ auto
 GetPlaylists() -> std::map<std::string, Playlist>&;
 void
 SaveEnabledSongsToPref();
-void
-LoadEnabledSongsFromPref();
 
 void
 InitAll(LoadingWindow* ld); // songs, groups - everything.

--- a/src/Etterna/Singletons/SongManager.h
+++ b/src/Etterna/Singletons/SongManager.h
@@ -24,7 +24,7 @@ auto SONG_GROUP_COLOR_NAME(size_t i) -> std::string;
 auto CompareNotesPointersForExtra(const Steps* n1, const Steps* n2) -> bool;
 
 /** @brief The holder for the Songs and its Steps. */
-namespace SONGMAN {
+namespace SongManager {
 
 extern std::unordered_map<std::string, Song*> SongsByKey;
 extern std::unordered_map<std::string, Steps*> StepsByKey;

--- a/src/Etterna/Singletons/SongManager.h
+++ b/src/Etterna/Singletons/SongManager.h
@@ -59,8 +59,6 @@ Cleanup();
 
 extern auto
 GetPlaylists() -> std::map<std::string, Playlist>&;
-extern void
-SaveEnabledSongsToPref(); // TODO: DEAD CODE
 
 extern void
 InitAll(LoadingWindow* ld); // songs, groups - everything.
@@ -80,12 +78,7 @@ SetHasGoal(std::unordered_map<std::string, GoalsForChart>& goalmap);
 
 extern auto
 GetSongGroupBannerPath(const std::string& sSongGroup) -> std::string;
-inline auto
-GetSongGroupBannerPaths() -> std::vector<std::string>
-{
-	return m_sSongGroupBannerPaths;
-} // TODO: DEAD CODE
-// std::string GetSongGroupBackgroundPath( std::string sSongGroup ) const;
+
 extern void
 GetSongGroupNames(std::vector<std::string>& AddTo);
 extern auto
@@ -119,7 +112,8 @@ extern void
 ResetGroupColors();
 
 extern auto
-ShortenGroupName(const std::string& sLongGroupName) -> std::string;
+ShortenGroupName(const std::string& sLongGroupName)
+  -> std::string; // Lua binding only
 
 // Lookup
 /**
@@ -168,9 +162,6 @@ GetSongGroupByIndex(const unsigned index) -> std::string
 	return m_sSongGroupNames[index];
 }
 
-extern void
-DeleteSteps(Steps* pSteps); // transfers ownership of pSteps
-							// ^ TODO: DEAD CODE
 extern auto
 WasLoadedFromAdditionalSongs(const Song* pSong) -> bool;
 extern auto

--- a/src/Etterna/Singletons/SongManager.h
+++ b/src/Etterna/Singletons/SongManager.h
@@ -45,38 +45,37 @@ extern std::vector<std::string> playlistGroups;
 extern std::map<Skillset, CalcTestList> testChartList;
 extern std::unique_ptr<Calc> calc;
 
-extern void Init();
-extern void End();
-extern void CalcTestStuff();
-extern void Cleanup();
+void Init();
+void End();
+void CalcTestStuff();
+void Cleanup();
 
-extern auto
-GetPlaylists() -> std::map<std::string, Playlist>&;
+auto GetPlaylists() -> std::map<std::string, Playlist>&;
 
-extern void InitAll(LoadingWindow* ld); // songs, groups - everything.
-extern auto DifferentialReload() -> int;
-extern auto DifferentialReloadDir(std::string dir) -> int; // TODO: INTERNAL
+void InitAll(LoadingWindow* ld); // songs, groups - everything.
+auto DifferentialReload() -> int;
+auto DifferentialReloadDir(std::string dir) -> int; // TODO: INTERNAL
 
-extern auto IsGroupNeverCached(const std::string& group) -> bool;
-extern void SetFavoritedStatus(std::set<std::string>& favs);
-extern void SetPermaMirroredStatus(std::set<std::string>& pmir);
-extern void SetHasGoal(std::unordered_map<std::string, GoalsForChart>& goalmap);
+auto IsGroupNeverCached(const std::string& group) -> bool;
+void SetFavoritedStatus(std::set<std::string>& favs);
+void SetPermaMirroredStatus(std::set<std::string>& pmir);
+void SetHasGoal(std::unordered_map<std::string, GoalsForChart>& goalmap);
 
-extern auto GetSongGroupBannerPath(const std::string& sSongGroup) -> std::string;
+auto GetSongGroupBannerPath(const std::string& sSongGroup) -> std::string;
 
-extern void GetSongGroupNames(std::vector<std::string>& AddTo);
-extern auto GetSongGroupNames() -> const std::vector<std::string>&;
-extern auto DoesSongGroupExist(const std::string& sSongGroup) -> bool;
-extern auto GetSongGroupColor(const std::string& sSongGroupName,
+void GetSongGroupNames(std::vector<std::string>& AddTo);
+auto GetSongGroupNames() -> const std::vector<std::string>&;
+auto DoesSongGroupExist(const std::string& sSongGroup) -> bool;
+auto GetSongGroupColor(const std::string& sSongGroupName,
 				  std::map<std::string, Playlist>& playlists = GetPlaylists())
   -> RageColor;
-extern auto GetSongColor(const Song* pSong) -> RageColor;
+auto GetSongColor(const Song* pSong) -> RageColor;
 
 // temporary solution to reorganizing the entire songid/stepsid system -
 // mina
-extern auto GetStepsByChartkey(const std::string& ck) -> Steps*;
-extern auto GetSongByChartkey(const std::string& ck) -> Song*;
-extern void UnloadAllCalcDebugOutput(); // TODO: Should be used but isn't.
+auto GetStepsByChartkey(const std::string& ck) -> Steps*;
+auto GetSongByChartkey(const std::string& ck) -> Song*;
+void UnloadAllCalcDebugOutput(); // TODO: Should be used but isn't.
 inline auto IsChartLoaded(const std::string& ck) -> bool //Lua binding only
 {
 	return SongsByKey.count(ck) == 1 &&
@@ -84,11 +83,9 @@ inline auto IsChartLoaded(const std::string& ck) -> bool //Lua binding only
 			 1; // shouldn't be necessary but apparently it is -mina
 }
 
-extern void
-ResetGroupColors();
+void ResetGroupColors();
 
-extern auto
-ShortenGroupName(const std::string& sLongGroupName)
+auto ShortenGroupName(const std::string& sLongGroupName)
   -> std::string; // Lua binding only
 
 // Lookup
@@ -96,8 +93,8 @@ ShortenGroupName(const std::string& sLongGroupName)
  * @brief Retrieve all of the songs that belong to a particular group.
  * @param sGroupName the name of the group.
  * @return the songs that belong in the group. */
-extern auto GetSongs(const std::string& sGroupName) -> const std::vector<Song*>&;
-extern void ForceReloadSongGroup(const std::string& sGroupName);
+auto GetSongs(const std::string& sGroupName) -> const std::vector<Song*>&;
+void ForceReloadSongGroup(const std::string& sGroupName);
 /**
  * @brief Retrieve all of the songs in the game.
  * @return all of the songs. */
@@ -116,41 +113,41 @@ inline auto GetPopularSongs() -> const std::vector<Song*>& // Lua binding only
 	return m_pPopularSongs;
 }
 
-extern void GetFavoriteSongs(std::vector<Song*>& songs);
+void GetFavoriteSongs(std::vector<Song*>& songs);
 /**
  * @brief Retrieve the number of songs in the game.
  * @return the number of songs. */
-extern auto GetNumSongs() -> int;
-extern auto GetNumAdditionalSongs() -> int; // Lua binding only
-extern auto GetNumSongGroups() -> int;
+auto GetNumSongs() -> int;
+auto GetNumAdditionalSongs() -> int; // Lua binding only
+auto GetNumSongGroups() -> int;
 // sm-ssc addition:
 inline auto GetSongGroupByIndex(const unsigned index) -> std::string
 {
 	return m_sSongGroupNames[index];
 }
 
-extern auto WasLoadedFromAdditionalSongs(const Song* pSong) -> bool;
-extern auto GetSongFromDir(std::string sDir) -> Song*;
-extern void SortSongs(); // sort m_pSongs by CompareSongPointersByTitle
+auto WasLoadedFromAdditionalSongs(const Song* pSong) -> bool;
+auto GetSongFromDir(std::string sDir) -> Song*;
+void SortSongs(); // sort m_pSongs by CompareSongPointersByTitle
 
-extern void
+void
 ReconcileChartKeysForReloadedSong(const Song* reloadedSong,
 								  const std::vector<std::string>& oldChartkeys);
-// ^ TODO: INTERNAL
-extern void MakeSongGroupsFromPlaylists(
+// ^ TODO: INTERNAL?
+void MakeSongGroupsFromPlaylists(
   std::map<std::string, Playlist>& playlists = GetPlaylists());
-extern void DeletePlaylist(
+void DeletePlaylist(
   const std::string& pl,
   std::map<std::string, Playlist>& playlists = GetPlaylists()); // Lua only
-extern void MakePlaylistFromFavorites(
+void MakePlaylistFromFavorites(
   std::set<std::string>& favs,
   std::map<std::string, Playlist>& playlists = GetPlaylists());
 
-extern void FinalizeSong(Song* pNewSong, const std::string& dir); // TODO: INTERNAL
+void FinalizeSong(Song* pNewSong, const std::string& dir); // TODO: INTERNAL
 
 // calc test stuff
-extern auto SaveCalcTestCreateNode() -> XNode*; // TODO: INTERNAL
-extern void LoadCalcTestNode(); // TODO: INTERNAL
-extern void SaveCalcTestXmlToDir();
+auto SaveCalcTestCreateNode() -> XNode*; // TODO: INTERNAL
+void LoadCalcTestNode(); // TODO: INTERNAL
+void SaveCalcTestXmlToDir();
 };
 #endif

--- a/src/Etterna/Singletons/SongManager.h
+++ b/src/Etterna/Singletons/SongManager.h
@@ -27,106 +27,88 @@ CompareNotesPointersForExtra(const Steps* n1, const Steps* n2) -> bool;
 
 /** @brief The holder for the Songs and its Steps. */
 namespace SONGMAN {
-std::unordered_map<std::string, Song*> SongsByKey;
-std::unordered_map<std::string, Steps*> StepsByKey;
 
-std::set<std::string> m_GroupsToNeverCache;
+extern std::unordered_map<std::string, Song*> SongsByKey;
+extern std::unordered_map<std::string, Steps*> StepsByKey;
+extern std::set<std::string> m_GroupsToNeverCache;
 /** @brief The most popular songs ranked by number of plays. */
-std::vector<Song*> m_pPopularSongs;
+extern std::vector<Song*> m_pPopularSongs;
 
-std::vector<std::string> m_sSongGroupNames;
-std::vector<std::string> m_sSongGroupBannerPaths; // each song group may have a
+extern std::vector<std::string> m_sSongGroupNames;
+extern std::vector<std::string> m_sSongGroupBannerPaths; // each song group may have a
 												  // banner associated with it
+extern std::string activeplaylist;
+extern std::string playlistcourse;
 
-void
-Init();
-void
-End();
+extern std::map<std::string, std::vector<Song*>> groupderps;
+/**@brief To delete from groupderps when rebuilding playlist groups*/
+extern std::vector<std::string> playlistGroups;
 
-void
-CalcTestStuff();
-void
-Cleanup();
+extern std::map<Skillset, CalcTestList> testChartList;
+extern std::unique_ptr<Calc> calc;
 
-void
-Invalidate(const Song* pStaleSong);
-auto
-GetPlaylists() -> std::map<std::string, Playlist>&;
-void
-SaveEnabledSongsToPref();
 
-void
-InitAll(LoadingWindow* ld); // songs, groups - everything.
-auto
-DifferentialReload() -> int;
-auto
-DifferentialReloadDir(std::string dir) -> int;
 
-auto
-IsGroupNeverCached(const std::string& group) -> bool;
-void
-SetFavoritedStatus(std::set<std::string>& favs);
-void
-SetPermaMirroredStatus(std::set<std::string>& pmir);
-void
-SetHasGoal(std::unordered_map<std::string, GoalsForChart>& goalmap);
 
-auto
-GetSongGroupBannerPath(const std::string& sSongGroup) -> std::string;
-auto
-GetSongGroupBannerPaths() -> std::vector<std::string>
+extern void Init();
+extern void End();
+extern void CalcTestStuff();
+extern void Cleanup();
+
+extern void Invalidate(const Song* pStaleSong);
+extern auto GetPlaylists() -> std::map<std::string, Playlist>&;
+extern void SaveEnabledSongsToPref();
+
+extern void InitAll(LoadingWindow* ld); // songs, groups - everything.
+extern auto DifferentialReload() -> int;
+extern auto DifferentialReloadDir(std::string dir) -> int;
+
+extern auto IsGroupNeverCached(const std::string& group) -> bool;
+extern void SetFavoritedStatus(std::set<std::string>& favs);
+extern void SetPermaMirroredStatus(std::set<std::string>& pmir);
+extern void SetHasGoal(std::unordered_map<std::string, GoalsForChart>& goalmap);
+
+extern auto GetSongGroupBannerPath(const std::string& sSongGroup) -> std::string;
+inline auto GetSongGroupBannerPaths() -> std::vector<std::string>
 {
 	return m_sSongGroupBannerPaths;
 }
 // std::string GetSongGroupBackgroundPath( std::string sSongGroup ) const;
-void
-GetSongGroupNames(std::vector<std::string>& AddTo);
-auto
-GetSongGroupNames() -> const std::vector<std::string>&;
-auto
-DoesSongGroupExist(const std::string& sSongGroup) -> bool;
-auto
-GetSongGroupColor(const std::string& sSongGroupName,
+extern void GetSongGroupNames(std::vector<std::string>& AddTo);
+extern auto GetSongGroupNames() -> const std::vector<std::string>&;
+extern auto DoesSongGroupExist(const std::string& sSongGroup) -> bool;
+extern auto GetSongGroupColor(const std::string& sSongGroupName,
 				  std::map<std::string, Playlist>& playlists = GetPlaylists())
   -> RageColor;
-auto
-GetSongColor(const Song* pSong) -> RageColor;
+extern auto GetSongColor(const Song* pSong) -> RageColor;
 
 // temporary solution to reorganizing the entire songid/stepsid system -
 // mina
-auto
-GetStepsByChartkey(const std::string& ck) -> Steps*;
-auto
-GetSongByChartkey(const std::string& ck) -> Song*;
-void
-UnloadAllCalcDebugOutput();
-auto
-IsChartLoaded(const std::string& ck) -> bool
+extern auto GetStepsByChartkey(const std::string& ck) -> Steps*;
+extern auto GetSongByChartkey(const std::string& ck) -> Song*;
+extern void UnloadAllCalcDebugOutput();
+inline auto IsChartLoaded(const std::string& ck) -> bool
 {
 	return SongsByKey.count(ck) == 1 &&
 		   StepsByKey.count(ck) ==
 			 1; // shouldn't be necessary but apparently it is -mina
 }
 
-void
-ResetGroupColors();
+extern void ResetGroupColors();
 
-auto
-ShortenGroupName(const std::string& sLongGroupName) -> std::string;
+extern auto ShortenGroupName(const std::string& sLongGroupName) -> std::string;
 
 // Lookup
 /**
  * @brief Retrieve all of the songs that belong to a particular group.
  * @param sGroupName the name of the group.
  * @return the songs that belong in the group. */
-auto
-GetSongs(const std::string& sGroupName) -> const std::vector<Song*>&;
-void
-ForceReloadSongGroup(const std::string& sGroupName);
+extern auto GetSongs(const std::string& sGroupName) -> const std::vector<Song*>&;
+extern void ForceReloadSongGroup(const std::string& sGroupName);
 /**
  * @brief Retrieve all of the songs in the game.
  * @return all of the songs. */
-auto
+inline auto
 GetAllSongs() -> const std::vector<Song*>&
 {
 	return GetSongs(GROUP_ALL);
@@ -137,77 +119,53 @@ GetAllSongs() -> const std::vector<Song*>&
  * Popularity is determined specifically by the number of times
  * a song is chosen.
  * @return all of the popular songs. */
-auto
+inline auto
 GetPopularSongs() -> const std::vector<Song*>&
 {
 	return m_pPopularSongs;
 }
 
-void
-GetFavoriteSongs(std::vector<Song*>& songs);
+extern void GetFavoriteSongs(std::vector<Song*>& songs);
 /**
  * @brief Retrieve the number of songs in the game.
  * @return the number of songs. */
-auto
-GetNumSongs() -> int;
-auto
-GetNumAdditionalSongs() -> int;
-auto
-GetNumSongGroups() -> int;
+extern auto GetNumSongs() -> int;
+extern auto GetNumAdditionalSongs() -> int;
+extern auto GetNumSongGroups() -> int;
 // sm-ssc addition:
-auto
+inline auto
 GetSongGroupByIndex(const unsigned index) -> std::string
 {
 	return m_sSongGroupNames[index];
 }
 
-void
-DeleteSteps(Steps* pSteps); // transfers ownership of pSteps
-auto
-WasLoadedFromAdditionalSongs(const Song* pSong) -> bool;
+extern void DeleteSteps(Steps* pSteps); // transfers ownership of pSteps
+extern auto WasLoadedFromAdditionalSongs(const Song* pSong) -> bool;
+extern auto GetSongFromDir(std::string sDir) -> Song*;
+extern void SortSongs(); // sort m_pSongs by CompareSongPointersByTitle
 
-auto
-GetSongFromDir(std::string sDir) -> Song*;
+/* Possibly unneccesary since SONGMAN is no longer a class? //TODO: CHECK THIS
+	// Lua
+	void
+	PushSelf(lua_State* L);
+ **/
 
-void
-SortSongs(); // sort m_pSongs by CompareSongPointersByTitle
-
-// Lua
-void
-PushSelf(lua_State* L);
-
-std::string activeplaylist = "";
-std::string playlistcourse = "";
-void
-ReconcileChartKeysForReloadedSong(const Song* reloadedSong,
+extern void ReconcileChartKeysForReloadedSong(const Song* reloadedSong,
 								  const std::vector<std::string>& oldChartkeys);
-void
-MakeSongGroupsFromPlaylists(
+extern void MakeSongGroupsFromPlaylists(
   std::map<std::string, Playlist>& playlists = GetPlaylists());
-void
-DeletePlaylist(const std::string& pl,
+extern void DeletePlaylist(const std::string& pl,
 			   std::map<std::string, Playlist>& playlists = GetPlaylists());
-void
-MakePlaylistFromFavorites(
+extern void MakePlaylistFromFavorites(
   std::set<std::string>& favs,
   std::map<std::string, Playlist>& playlists = GetPlaylists());
 
-std::map<std::string, std::vector<Song*>> groupderps;
-std::vector<std::string> playlistGroups; // To delete from groupderps when
-										 // rebuilding
-										 // playlist groups
 
-void
-FinalizeSong(Song* pNewSong, const std::string& dir);
+extern void FinalizeSong(Song* pNewSong, const std::string& dir);
 
 // calc test stuff
-auto
-SaveCalcTestCreateNode() -> XNode*;
-void
-LoadCalcTestNode();
-void
-SaveCalcTestXmlToDir();
-std::map<Skillset, CalcTestList> testChartList;
-std::unique_ptr<Calc> calc;
+extern auto SaveCalcTestCreateNode() -> XNode*;
+extern void LoadCalcTestNode();
+extern void SaveCalcTestXmlToDir();
 };
 #endif

--- a/src/Etterna/Singletons/SongManager.h
+++ b/src/Etterna/Singletons/SongManager.h
@@ -35,8 +35,9 @@ extern std::set<std::string> m_GroupsToNeverCache;
 extern std::vector<Song*> m_pPopularSongs;
 
 extern std::vector<std::string> m_sSongGroupNames;
-extern std::vector<std::string> m_sSongGroupBannerPaths; // each song group may have a
-												  // banner associated with it
+extern std::vector<std::string>
+  m_sSongGroupBannerPaths; // each song group may have a
+						   // banner associated with it
 extern std::string activeplaylist;
 extern std::string playlistcourse;
 
@@ -47,64 +48,88 @@ extern std::vector<std::string> playlistGroups;
 extern std::map<Skillset, CalcTestList> testChartList;
 extern std::unique_ptr<Calc> calc;
 
+extern void
+Init();
+extern void
+End();
+extern void
+CalcTestStuff();
+extern void
+Cleanup();
 
+extern auto
+GetPlaylists() -> std::map<std::string, Playlist>&;
+extern void
+SaveEnabledSongsToPref(); // TODO: DEAD CODE
 
+extern void
+InitAll(LoadingWindow* ld); // songs, groups - everything.
+extern auto
+DifferentialReload() -> int;
+extern auto
+DifferentialReloadDir(std::string dir) -> int; // TODO: INTERNAL
 
-extern void Init();
-extern void End();
-extern void CalcTestStuff();
-extern void Cleanup();
+extern auto
+IsGroupNeverCached(const std::string& group) -> bool;
+extern void
+SetFavoritedStatus(std::set<std::string>& favs);
+extern void
+SetPermaMirroredStatus(std::set<std::string>& pmir);
+extern void
+SetHasGoal(std::unordered_map<std::string, GoalsForChart>& goalmap);
 
-extern void Invalidate(const Song* pStaleSong);
-extern auto GetPlaylists() -> std::map<std::string, Playlist>&;
-extern void SaveEnabledSongsToPref();
-
-extern void InitAll(LoadingWindow* ld); // songs, groups - everything.
-extern auto DifferentialReload() -> int;
-extern auto DifferentialReloadDir(std::string dir) -> int;
-
-extern auto IsGroupNeverCached(const std::string& group) -> bool;
-extern void SetFavoritedStatus(std::set<std::string>& favs);
-extern void SetPermaMirroredStatus(std::set<std::string>& pmir);
-extern void SetHasGoal(std::unordered_map<std::string, GoalsForChart>& goalmap);
-
-extern auto GetSongGroupBannerPath(const std::string& sSongGroup) -> std::string;
-inline auto GetSongGroupBannerPaths() -> std::vector<std::string>
+extern auto
+GetSongGroupBannerPath(const std::string& sSongGroup) -> std::string;
+inline auto
+GetSongGroupBannerPaths() -> std::vector<std::string>
 {
 	return m_sSongGroupBannerPaths;
-}
+} // TODO: DEAD CODE
 // std::string GetSongGroupBackgroundPath( std::string sSongGroup ) const;
-extern void GetSongGroupNames(std::vector<std::string>& AddTo);
-extern auto GetSongGroupNames() -> const std::vector<std::string>&;
-extern auto DoesSongGroupExist(const std::string& sSongGroup) -> bool;
-extern auto GetSongGroupColor(const std::string& sSongGroupName,
+extern void
+GetSongGroupNames(std::vector<std::string>& AddTo);
+extern auto
+GetSongGroupNames() -> const std::vector<std::string>&;
+extern auto
+DoesSongGroupExist(const std::string& sSongGroup) -> bool;
+extern auto
+GetSongGroupColor(const std::string& sSongGroupName,
 				  std::map<std::string, Playlist>& playlists = GetPlaylists())
   -> RageColor;
-extern auto GetSongColor(const Song* pSong) -> RageColor;
+extern auto
+GetSongColor(const Song* pSong) -> RageColor;
 
 // temporary solution to reorganizing the entire songid/stepsid system -
 // mina
-extern auto GetStepsByChartkey(const std::string& ck) -> Steps*;
-extern auto GetSongByChartkey(const std::string& ck) -> Song*;
-extern void UnloadAllCalcDebugOutput();
-inline auto IsChartLoaded(const std::string& ck) -> bool
+extern auto
+GetStepsByChartkey(const std::string& ck) -> Steps*;
+extern auto
+GetSongByChartkey(const std::string& ck) -> Song*;
+extern void
+UnloadAllCalcDebugOutput(); // TODO: Should be used but isn't.
+inline auto
+IsChartLoaded(const std::string& ck) -> bool // TODO: INTERNAL
 {
 	return SongsByKey.count(ck) == 1 &&
 		   StepsByKey.count(ck) ==
 			 1; // shouldn't be necessary but apparently it is -mina
 }
 
-extern void ResetGroupColors();
+extern void
+ResetGroupColors();
 
-extern auto ShortenGroupName(const std::string& sLongGroupName) -> std::string;
+extern auto
+ShortenGroupName(const std::string& sLongGroupName) -> std::string;
 
 // Lookup
 /**
  * @brief Retrieve all of the songs that belong to a particular group.
  * @param sGroupName the name of the group.
  * @return the songs that belong in the group. */
-extern auto GetSongs(const std::string& sGroupName) -> const std::vector<Song*>&;
-extern void ForceReloadSongGroup(const std::string& sGroupName);
+extern auto
+GetSongs(const std::string& sGroupName) -> const std::vector<Song*>&;
+extern void
+ForceReloadSongGroup(const std::string& sGroupName);
 /**
  * @brief Retrieve all of the songs in the game.
  * @return all of the songs. */
@@ -120,18 +145,22 @@ GetAllSongs() -> const std::vector<Song*>&
  * a song is chosen.
  * @return all of the popular songs. */
 inline auto
-GetPopularSongs() -> const std::vector<Song*>&
+GetPopularSongs() -> const std::vector<Song*>& // Lua binding only
 {
 	return m_pPopularSongs;
 }
 
-extern void GetFavoriteSongs(std::vector<Song*>& songs);
+extern void
+GetFavoriteSongs(std::vector<Song*>& songs);
 /**
  * @brief Retrieve the number of songs in the game.
  * @return the number of songs. */
-extern auto GetNumSongs() -> int;
-extern auto GetNumAdditionalSongs() -> int;
-extern auto GetNumSongGroups() -> int;
+extern auto
+GetNumSongs() -> int;
+extern auto
+GetNumAdditionalSongs() -> int; // Lua binding only
+extern auto
+GetNumSongGroups() -> int;
 // sm-ssc addition:
 inline auto
 GetSongGroupByIndex(const unsigned index) -> std::string
@@ -139,33 +168,41 @@ GetSongGroupByIndex(const unsigned index) -> std::string
 	return m_sSongGroupNames[index];
 }
 
-extern void DeleteSteps(Steps* pSteps); // transfers ownership of pSteps
-extern auto WasLoadedFromAdditionalSongs(const Song* pSong) -> bool;
-extern auto GetSongFromDir(std::string sDir) -> Song*;
-extern void SortSongs(); // sort m_pSongs by CompareSongPointersByTitle
+extern void
+DeleteSteps(Steps* pSteps); // transfers ownership of pSteps
+							// ^ TODO: DEAD CODE
+extern auto
+WasLoadedFromAdditionalSongs(const Song* pSong) -> bool;
+extern auto
+GetSongFromDir(std::string sDir) -> Song*;
+extern void
+SortSongs(); // sort m_pSongs by CompareSongPointersByTitle
 
-/* Possibly unneccesary since SONGMAN is no longer a class? //TODO: CHECK THIS
-	// Lua
-	void
-	PushSelf(lua_State* L);
- **/
-
-extern void ReconcileChartKeysForReloadedSong(const Song* reloadedSong,
+extern void
+ReconcileChartKeysForReloadedSong(const Song* reloadedSong,
 								  const std::vector<std::string>& oldChartkeys);
-extern void MakeSongGroupsFromPlaylists(
+// ^ TODO: INTERNAL
+extern void
+MakeSongGroupsFromPlaylists(
   std::map<std::string, Playlist>& playlists = GetPlaylists());
-extern void DeletePlaylist(const std::string& pl,
-			   std::map<std::string, Playlist>& playlists = GetPlaylists());
-extern void MakePlaylistFromFavorites(
+extern void
+DeletePlaylist(
+  const std::string& pl,
+  std::map<std::string, Playlist>& playlists = GetPlaylists()); // Lua only
+extern void
+MakePlaylistFromFavorites(
   std::set<std::string>& favs,
   std::map<std::string, Playlist>& playlists = GetPlaylists());
 
-
-extern void FinalizeSong(Song* pNewSong, const std::string& dir);
+extern void
+FinalizeSong(Song* pNewSong, const std::string& dir); // TODO: INTERNAL
 
 // calc test stuff
-extern auto SaveCalcTestCreateNode() -> XNode*;
-extern void LoadCalcTestNode();
-extern void SaveCalcTestXmlToDir();
+extern auto
+SaveCalcTestCreateNode() -> XNode*; // TODO: INTERNAL
+extern void
+LoadCalcTestNode(); // TODO: INTERNAL
+extern void
+SaveCalcTestXmlToDir();
 };
 #endif

--- a/src/Etterna/Singletons/SongManager.h
+++ b/src/Etterna/Singletons/SongManager.h
@@ -25,185 +25,229 @@ auto
 CompareNotesPointersForExtra(const Steps* n1, const Steps* n2) -> bool;
 
 /** @brief The holder for the Songs and its Steps. */
-class SongManager
+namespace SONGMAN {
+std::unordered_map<std::string, Song*> SongsByKey;
+std::unordered_map<std::string, Steps*> StepsByKey;
+
+std::set<std::string> m_GroupsToNeverCache;
+/** @brief The most popular songs ranked by number of plays. */
+std::vector<Song*> m_pPopularSongs;
+
+std::vector<std::string> m_sSongGroupNames;
+std::vector<std::string> m_sSongGroupBannerPaths; // each song group may have a
+												  // banner associated with it
+
+// SongManager(); //TODO: FIXME
+//~SongManager(); //TODO: FIXME
+
+void
+InitSongsFromDisk(LoadingWindow* ld);
+void
+CalcTestStuff();
+void
+FreeSongs();
+void
+Cleanup();
+
+void
+Invalidate(const Song* pStaleSong);
+auto
+GetPlaylists() -> std::map<std::string, Playlist>&;
+void
+SaveEnabledSongsToPref();
+void
+LoadEnabledSongsFromPref();
+
+void
+InitAll(LoadingWindow* ld); // songs, groups - everything.
+auto
+DifferentialReload() -> int;
+auto
+DifferentialReloadDir(std::string dir) -> int;
+
+auto
+IsGroupNeverCached(const std::string& group) -> bool;
+void
+SetFavoritedStatus(std::set<std::string>& favs);
+void
+SetPermaMirroredStatus(std::set<std::string>& pmir);
+void
+SetHasGoal(std::unordered_map<std::string, GoalsForChart>& goalmap);
+
+auto
+GetSongGroupBannerPath(const std::string& sSongGroup) -> std::string;
+auto
+GetSongGroupBannerPaths() -> std::vector<std::string>
 {
-  public:
-	SongManager();
-	~SongManager();
+	return m_sSongGroupBannerPaths;
+}
+// std::string GetSongGroupBackgroundPath( std::string sSongGroup ) const;
+void
+GetSongGroupNames(std::vector<std::string>& AddTo);
+auto
+GetSongGroupNames() -> const std::vector<std::string>&;
+auto
+DoesSongGroupExist(const std::string& sSongGroup) -> bool;
+auto
+GetSongGroupColor(const std::string& sSongGroupName,
+				  std::map<std::string, Playlist>& playlists = GetPlaylists())
+  -> RageColor;
+auto
+GetSongColor(const Song* pSong) -> RageColor;
 
-	void InitSongsFromDisk(LoadingWindow* ld);
-	void CalcTestStuff();
-	void FreeSongs();
-	void Cleanup();
+// temporary solution to reorganizing the entire songid/stepsid system -
+// mina
+auto
+GetStepsByChartkey(const std::string& ck) -> Steps*;
+auto
+GetSongByChartkey(const std::string& ck) -> Song*;
+void
+UnloadAllCalcDebugOutput();
+auto
+IsChartLoaded(const std::string& ck) -> bool
+{
+	return SongsByKey.count(ck) == 1 &&
+		   StepsByKey.count(ck) ==
+			 1; // shouldn't be necessary but apparently it is -mina
+}
 
-	void Invalidate(const Song* pStaleSong);
-	static auto GetPlaylists() -> std::map<std::string, Playlist>&;
-	static void SaveEnabledSongsToPref();
-	static void LoadEnabledSongsFromPref();
+void
+ResetGroupColors();
 
-	void InitAll(LoadingWindow* ld); // songs, groups - everything.
-	auto DifferentialReload() -> int;
-	auto DifferentialReloadDir(std::string dir) -> int;
+static auto
+ShortenGroupName(const std::string& sLongGroupName) -> std::string;
 
-	auto IsGroupNeverCached(const std::string& group) const -> bool;
-	void SetFavoritedStatus(std::set<std::string>& favs);
-	void SetPermaMirroredStatus(std::set<std::string>& pmir);
-	void SetHasGoal(std::unordered_map<std::string, GoalsForChart>& goalmap);
+// Lookup
+/**
+ * @brief Retrieve all of the songs that belong to a particular group.
+ * @param sGroupName the name of the group.
+ * @return the songs that belong in the group. */
+auto
+GetSongs(const std::string& sGroupName) -> const std::vector<Song*>&;
+void
+ForceReloadSongGroup(const std::string& sGroupName);
+/**
+ * @brief Retrieve all of the songs in the game.
+ * @return all of the songs. */
+auto
+GetAllSongs() -> const std::vector<Song*>&
+{
+	return GetSongs(GROUP_ALL);
+}
+/**
+ * @brief Retrieve all of the popular songs.
+ *
+ * Popularity is determined specifically by the number of times
+ * a song is chosen.
+ * @return all of the popular songs. */
+auto
+GetPopularSongs() -> const std::vector<Song*>&
+{
+	return m_pPopularSongs;
+}
 
-	auto GetSongGroupBannerPath(const std::string& sSongGroup) const
-	  -> std::string;
-	auto GetSongGroupBannerPaths() const -> std::vector<std::string>
+void
+GetFavoriteSongs(std::vector<Song*>& songs);
+/**
+ * @brief Retrieve the number of songs in the game.
+ * @return the number of songs. */
+auto
+GetNumSongs() -> int;
+auto
+GetNumAdditionalSongs() -> int;
+auto
+GetNumSongGroups() -> int;
+// sm-ssc addition:
+auto
+GetSongGroupByIndex(const unsigned index) -> std::string
+{
+	return m_sSongGroupNames[index];
+}
+
+static void
+DeleteSteps(Steps* pSteps); // transfers ownership of pSteps
+static auto
+WasLoadedFromAdditionalSongs(const Song* pSong) -> bool;
+
+auto
+GetSongFromDir(std::string sDir) -> Song*;
+
+void
+SortSongs(); // sort m_pSongs by CompareSongPointersByTitle
+
+// Lua
+void
+PushSelf(lua_State* L);
+
+std::string activeplaylist = "";
+std::string playlistcourse = "";
+static void
+ReconcileChartKeysForReloadedSong(const Song* reloadedSong,
+								  const std::vector<std::string>& oldChartkeys);
+void
+MakeSongGroupsFromPlaylists(
+  std::map<std::string, Playlist>& playlists = GetPlaylists());
+void
+DeletePlaylist(const std::string& pl,
+			   std::map<std::string, Playlist>& playlists = GetPlaylists());
+static void
+MakePlaylistFromFavorites(
+  std::set<std::string>& favs,
+  std::map<std::string, Playlist>& playlists = GetPlaylists());
+
+std::map<std::string, std::vector<Song*>> groupderps;
+std::vector<std::string> playlistGroups; // To delete from groupderps when
+										 // rebuilding
+										 // playlist groups
+
+static void
+FinalizeSong(Song* pNewSong, const std::string& dir);
+
+// calc test stuff
+auto
+SaveCalcTestCreateNode() -> XNode*;
+static void
+LoadCalcTestNode();
+void
+SaveCalcTestXmlToDir();
+std::map<Skillset, CalcTestList> testChartList;
+std::unique_ptr<Calc> calc;
+
+namespace { // Anonymous namespace -- functions equivalently to private for a
+			// class
+void
+LoadStepManiaSongDir(std::string sDir, LoadingWindow* ld);
+static auto
+IsSongDir(const std::string& sDir) -> bool;
+auto
+AddGroup(const std::string& sDir, const std::string& sGroupDirName) -> bool;
+
+void
+AddSongToList(Song* new_song);
+/** @brief All of the songs that can be played. */
+std::vector<Song*> m_pSongs;
+std::map<std::string, Song*> m_SongsByDir;
+
+std::vector<std::pair<std::pair<std::string, unsigned int>, Song*>*> cache;
+
+// Indexed by chartkeys
+void
+AddKeyedPointers(Song* new_song);
+// vector<std::string>		m_sSongGroupBackgroundPaths; // each song group
+// may have a background associated with it (very rarely)
+
+struct Comp
+{
+	auto operator()(const std::string& s, const std::string& t) const -> bool
 	{
-		return m_sSongGroupBannerPaths;
+		return CompareStringsAsc(s, t);
 	}
-	// std::string GetSongGroupBackgroundPath( std::string sSongGroup ) const;
-	void GetSongGroupNames(std::vector<std::string>& AddTo) const;
-	auto GetSongGroupNames() const -> const std::vector<std::string>&;
-	auto DoesSongGroupExist(const std::string& sSongGroup) const -> bool;
-	auto GetSongGroupColor(const std::string& sSongGroupName,
-						   std::map<std::string, Playlist>& playlists =
-							 GetPlaylists()) const -> RageColor;
-	auto GetSongColor(const Song* pSong) const -> RageColor;
-
-	// temporary solution to reorganizing the entire songid/stepsid system -
-	// mina
-	auto GetStepsByChartkey(const std::string& ck) -> Steps*;
-	auto GetSongByChartkey(const std::string& ck) -> Song*;
-	void UnloadAllCalcDebugOutput();
-	auto IsChartLoaded(const std::string& ck) const -> bool
-	{
-		return SongsByKey.count(ck) == 1 &&
-			   StepsByKey.count(ck) ==
-				 1; // shouldn't be necessary but apparently it is -mina
-	}
-
-	void ResetGroupColors();
-
-	static auto ShortenGroupName(const std::string& sLongGroupName)
-	  -> std::string;
-
-	// Lookup
-	/**
-	 * @brief Retrieve all of the songs that belong to a particular group.
-	 * @param sGroupName the name of the group.
-	 * @return the songs that belong in the group. */
-	auto GetSongs(const std::string& sGroupName) const
-	  -> const std::vector<Song*>&;
-	void ForceReloadSongGroup(const std::string& sGroupName) const;
-	/**
-	 * @brief Retrieve all of the songs in the game.
-	 * @return all of the songs. */
-	auto GetAllSongs() const -> const std::vector<Song*>&
-	{
-		return GetSongs(GROUP_ALL);
-	}
-	/**
-	 * @brief Retrieve all of the popular songs.
-	 *
-	 * Popularity is determined specifically by the number of times
-	 * a song is chosen.
-	 * @return all of the popular songs. */
-	auto GetPopularSongs() const -> const std::vector<Song*>&
-	{
-		return m_pPopularSongs;
-	}
-
-	void GetFavoriteSongs(std::vector<Song*>& songs) const;
-	/**
-	 * @brief Retrieve the number of songs in the game.
-	 * @return the number of songs. */
-	auto GetNumSongs() const -> int;
-	auto GetNumAdditionalSongs() const -> int;
-	auto GetNumSongGroups() const -> int;
-	// sm-ssc addition:
-	auto GetSongGroupByIndex(const unsigned index) -> std::string
-	{
-		return m_sSongGroupNames[index];
-	}
-
-	static void DeleteSteps(Steps* pSteps); // transfers ownership of pSteps
-	static auto WasLoadedFromAdditionalSongs(const Song* pSong) -> bool;
-
-	auto GetSongFromDir(std::string sDir) const -> Song*;
-
-	void SortSongs(); // sort m_pSongs by CompareSongPointersByTitle
-
-	// Lua
-	void PushSelf(lua_State* L);
-
-	std::string activeplaylist = "";
-	std::string playlistcourse = "";
-	static void ReconcileChartKeysForReloadedSong(
-	  const Song* reloadedSong,
-	  const std::vector<std::string>& oldChartkeys);
-	void MakeSongGroupsFromPlaylists(
-	  std::map<std::string, Playlist>& playlists = GetPlaylists());
-	void DeletePlaylist(
-	  const std::string& pl,
-	  std::map<std::string, Playlist>& playlists = GetPlaylists());
-	static void MakePlaylistFromFavorites(
-	  std::set<std::string>& favs,
-	  std::map<std::string, Playlist>& playlists = GetPlaylists());
-
-	std::map<std::string, std::vector<Song*>> groupderps;
-	std::vector<std::string> playlistGroups; // To delete from groupderps when
-											 // rebuilding
-											 // playlist groups
-
-	static void FinalizeSong(Song* pNewSong, const std::string& dir);
-
-	// calc test stuff
-	auto SaveCalcTestCreateNode() const -> XNode*;
-	static void LoadCalcTestNode();
-	void SaveCalcTestXmlToDir() const;
-	std::map<Skillset, CalcTestList> testChartList;
-	std::unique_ptr<Calc> calc;
-
-  protected:
-	void LoadStepManiaSongDir(std::string sDir, LoadingWindow* ld);
-	static auto IsSongDir(const std::string& sDir) -> bool;
-	auto AddGroup(const std::string& sDir, const std::string& sGroupDirName)
-	  -> bool;
-
-	void AddSongToList(Song* new_song);
-	/** @brief All of the songs that can be played. */
-	std::vector<Song*> m_pSongs;
-	std::map<std::string, Song*> m_SongsByDir;
-
-	std::vector<std::pair<std::pair<std::string, unsigned int>, Song*>*> cache;
-
-	// Indexed by chartkeys
-	void AddKeyedPointers(Song* new_song);
-	std::unordered_map<std::string, Song*> SongsByKey;
-	std::unordered_map<std::string, Steps*> StepsByKey;
-
-	std::set<std::string> m_GroupsToNeverCache;
-	/** @brief The most popular songs ranked by number of plays. */
-	std::vector<Song*> m_pPopularSongs;
-
-	std::vector<std::string> m_sSongGroupNames;
-	std::vector<std::string>
-	  m_sSongGroupBannerPaths; // each song group may have a
-							   // banner associated with it
-	// vector<std::string>		m_sSongGroupBackgroundPaths; // each song group
-	// may have a background associated with it (very rarely)
-
-	struct Comp
-	{
-		auto operator()(const std::string& s, const std::string& t) const
-		  -> bool
-		{
-			return CompareStringsAsc(s, t);
-		}
-	};
-	using SongPointerVector = std::vector<Song*>;
-	std::map<std::string, SongPointerVector, Comp> m_mapSongGroupIndex;
-
-	ThemeMetric<int> NUM_SONG_GROUP_COLORS;
-	ThemeMetric1D<RageColor> SONG_GROUP_COLOR;
 };
+using SongPointerVector = std::vector<Song*>;
+std::map<std::string, SongPointerVector, Comp> m_mapSongGroupIndex;
 
-extern SongManager*
-  SONGMAN; // global and accessible from anywhere in our program
-
+ThemeMetric<int> NUM_SONG_GROUP_COLORS;
+ThemeMetric1D<RageColor> SONG_GROUP_COLOR;
+}
+};
 #endif

--- a/src/Etterna/Singletons/SongManager.h
+++ b/src/Etterna/Singletons/SongManager.h
@@ -7,6 +7,7 @@
 #include "RageUtil/Misc/RageTypes.h"
 #include "RageUtil/Utils/RageUtil.h"
 #include "Etterna/Models/Misc/ThemeMetric.h"
+#include "Etterna/MinaCalc/MinaCalc.h"
 
 #include <unordered_map>
 
@@ -37,8 +38,10 @@ std::vector<std::string> m_sSongGroupNames;
 std::vector<std::string> m_sSongGroupBannerPaths; // each song group may have a
 												  // banner associated with it
 
-// SongManager(); //TODO: FIXME
-//~SongManager(); //TODO: FIXME
+void
+Init();
+void
+End();
 
 void
 InitSongsFromDisk(LoadingWindow* ld);
@@ -114,7 +117,7 @@ IsChartLoaded(const std::string& ck) -> bool
 void
 ResetGroupColors();
 
-static auto
+auto
 ShortenGroupName(const std::string& sLongGroupName) -> std::string;
 
 // Lookup
@@ -164,9 +167,9 @@ GetSongGroupByIndex(const unsigned index) -> std::string
 	return m_sSongGroupNames[index];
 }
 
-static void
+void
 DeleteSteps(Steps* pSteps); // transfers ownership of pSteps
-static auto
+auto
 WasLoadedFromAdditionalSongs(const Song* pSong) -> bool;
 
 auto
@@ -181,7 +184,7 @@ PushSelf(lua_State* L);
 
 std::string activeplaylist = "";
 std::string playlistcourse = "";
-static void
+void
 ReconcileChartKeysForReloadedSong(const Song* reloadedSong,
 								  const std::vector<std::string>& oldChartkeys);
 void
@@ -190,7 +193,7 @@ MakeSongGroupsFromPlaylists(
 void
 DeletePlaylist(const std::string& pl,
 			   std::map<std::string, Playlist>& playlists = GetPlaylists());
-static void
+void
 MakePlaylistFromFavorites(
   std::set<std::string>& favs,
   std::map<std::string, Playlist>& playlists = GetPlaylists());
@@ -200,54 +203,17 @@ std::vector<std::string> playlistGroups; // To delete from groupderps when
 										 // rebuilding
 										 // playlist groups
 
-static void
+void
 FinalizeSong(Song* pNewSong, const std::string& dir);
 
 // calc test stuff
 auto
 SaveCalcTestCreateNode() -> XNode*;
-static void
+void
 LoadCalcTestNode();
 void
 SaveCalcTestXmlToDir();
 std::map<Skillset, CalcTestList> testChartList;
 std::unique_ptr<Calc> calc;
-
-namespace { // Anonymous namespace -- functions equivalently to private for a
-			// class
-void
-LoadStepManiaSongDir(std::string sDir, LoadingWindow* ld);
-static auto
-IsSongDir(const std::string& sDir) -> bool;
-auto
-AddGroup(const std::string& sDir, const std::string& sGroupDirName) -> bool;
-
-void
-AddSongToList(Song* new_song);
-/** @brief All of the songs that can be played. */
-std::vector<Song*> m_pSongs;
-std::map<std::string, Song*> m_SongsByDir;
-
-std::vector<std::pair<std::pair<std::string, unsigned int>, Song*>*> cache;
-
-// Indexed by chartkeys
-void
-AddKeyedPointers(Song* new_song);
-// vector<std::string>		m_sSongGroupBackgroundPaths; // each song group
-// may have a background associated with it (very rarely)
-
-struct Comp
-{
-	auto operator()(const std::string& s, const std::string& t) const -> bool
-	{
-		return CompareStringsAsc(s, t);
-	}
-};
-using SongPointerVector = std::vector<Song*>;
-std::map<std::string, SongPointerVector, Comp> m_mapSongGroupIndex;
-
-ThemeMetric<int> NUM_SONG_GROUP_COLORS;
-ThemeMetric1D<RageColor> SONG_GROUP_COLOR;
-}
 };
 #endif

--- a/src/Etterna/Singletons/SongManager.h
+++ b/src/Etterna/Singletons/SongManager.h
@@ -20,17 +20,14 @@ class Calc;
 struct lua_State;
 struct GoalsForChart;
 
-auto
-SONG_GROUP_COLOR_NAME(size_t i) -> std::string;
-auto
-CompareNotesPointersForExtra(const Steps* n1, const Steps* n2) -> bool;
+auto SONG_GROUP_COLOR_NAME(size_t i) -> std::string;
+auto CompareNotesPointersForExtra(const Steps* n1, const Steps* n2) -> bool;
 
 /** @brief The holder for the Songs and its Steps. */
 namespace SONGMAN {
 
 extern std::unordered_map<std::string, Song*> SongsByKey;
 extern std::unordered_map<std::string, Steps*> StepsByKey;
-extern std::set<std::string> m_GroupsToNeverCache;
 /** @brief The most popular songs ranked by number of plays. */
 extern std::vector<Song*> m_pPopularSongs;
 
@@ -48,60 +45,39 @@ extern std::vector<std::string> playlistGroups;
 extern std::map<Skillset, CalcTestList> testChartList;
 extern std::unique_ptr<Calc> calc;
 
-extern void
-Init();
-extern void
-End();
-extern void
-CalcTestStuff();
-extern void
-Cleanup();
+extern void Init();
+extern void End();
+extern void CalcTestStuff();
+extern void Cleanup();
 
 extern auto
 GetPlaylists() -> std::map<std::string, Playlist>&;
 
-extern void
-InitAll(LoadingWindow* ld); // songs, groups - everything.
-extern auto
-DifferentialReload() -> int;
-extern auto
-DifferentialReloadDir(std::string dir) -> int; // TODO: INTERNAL
+extern void InitAll(LoadingWindow* ld); // songs, groups - everything.
+extern auto DifferentialReload() -> int;
+extern auto DifferentialReloadDir(std::string dir) -> int; // TODO: INTERNAL
 
-extern auto
-IsGroupNeverCached(const std::string& group) -> bool;
-extern void
-SetFavoritedStatus(std::set<std::string>& favs);
-extern void
-SetPermaMirroredStatus(std::set<std::string>& pmir);
-extern void
-SetHasGoal(std::unordered_map<std::string, GoalsForChart>& goalmap);
+extern auto IsGroupNeverCached(const std::string& group) -> bool;
+extern void SetFavoritedStatus(std::set<std::string>& favs);
+extern void SetPermaMirroredStatus(std::set<std::string>& pmir);
+extern void SetHasGoal(std::unordered_map<std::string, GoalsForChart>& goalmap);
 
-extern auto
-GetSongGroupBannerPath(const std::string& sSongGroup) -> std::string;
+extern auto GetSongGroupBannerPath(const std::string& sSongGroup) -> std::string;
 
-extern void
-GetSongGroupNames(std::vector<std::string>& AddTo);
-extern auto
-GetSongGroupNames() -> const std::vector<std::string>&;
-extern auto
-DoesSongGroupExist(const std::string& sSongGroup) -> bool;
-extern auto
-GetSongGroupColor(const std::string& sSongGroupName,
+extern void GetSongGroupNames(std::vector<std::string>& AddTo);
+extern auto GetSongGroupNames() -> const std::vector<std::string>&;
+extern auto DoesSongGroupExist(const std::string& sSongGroup) -> bool;
+extern auto GetSongGroupColor(const std::string& sSongGroupName,
 				  std::map<std::string, Playlist>& playlists = GetPlaylists())
   -> RageColor;
-extern auto
-GetSongColor(const Song* pSong) -> RageColor;
+extern auto GetSongColor(const Song* pSong) -> RageColor;
 
 // temporary solution to reorganizing the entire songid/stepsid system -
 // mina
-extern auto
-GetStepsByChartkey(const std::string& ck) -> Steps*;
-extern auto
-GetSongByChartkey(const std::string& ck) -> Song*;
-extern void
-UnloadAllCalcDebugOutput(); // TODO: Should be used but isn't.
-inline auto
-IsChartLoaded(const std::string& ck) -> bool // TODO: INTERNAL
+extern auto GetStepsByChartkey(const std::string& ck) -> Steps*;
+extern auto GetSongByChartkey(const std::string& ck) -> Song*;
+extern void UnloadAllCalcDebugOutput(); // TODO: Should be used but isn't.
+inline auto IsChartLoaded(const std::string& ck) -> bool //Lua binding only
 {
 	return SongsByKey.count(ck) == 1 &&
 		   StepsByKey.count(ck) ==
@@ -120,15 +96,12 @@ ShortenGroupName(const std::string& sLongGroupName)
  * @brief Retrieve all of the songs that belong to a particular group.
  * @param sGroupName the name of the group.
  * @return the songs that belong in the group. */
-extern auto
-GetSongs(const std::string& sGroupName) -> const std::vector<Song*>&;
-extern void
-ForceReloadSongGroup(const std::string& sGroupName);
+extern auto GetSongs(const std::string& sGroupName) -> const std::vector<Song*>&;
+extern void ForceReloadSongGroup(const std::string& sGroupName);
 /**
  * @brief Retrieve all of the songs in the game.
  * @return all of the songs. */
-inline auto
-GetAllSongs() -> const std::vector<Song*>&
+inline auto GetAllSongs() -> const std::vector<Song*>&
 {
 	return GetSongs(GROUP_ALL);
 }
@@ -138,62 +111,46 @@ GetAllSongs() -> const std::vector<Song*>&
  * Popularity is determined specifically by the number of times
  * a song is chosen.
  * @return all of the popular songs. */
-inline auto
-GetPopularSongs() -> const std::vector<Song*>& // Lua binding only
+inline auto GetPopularSongs() -> const std::vector<Song*>& // Lua binding only
 {
 	return m_pPopularSongs;
 }
 
-extern void
-GetFavoriteSongs(std::vector<Song*>& songs);
+extern void GetFavoriteSongs(std::vector<Song*>& songs);
 /**
  * @brief Retrieve the number of songs in the game.
  * @return the number of songs. */
-extern auto
-GetNumSongs() -> int;
-extern auto
-GetNumAdditionalSongs() -> int; // Lua binding only
-extern auto
-GetNumSongGroups() -> int;
+extern auto GetNumSongs() -> int;
+extern auto GetNumAdditionalSongs() -> int; // Lua binding only
+extern auto GetNumSongGroups() -> int;
 // sm-ssc addition:
-inline auto
-GetSongGroupByIndex(const unsigned index) -> std::string
+inline auto GetSongGroupByIndex(const unsigned index) -> std::string
 {
 	return m_sSongGroupNames[index];
 }
 
-extern auto
-WasLoadedFromAdditionalSongs(const Song* pSong) -> bool;
-extern auto
-GetSongFromDir(std::string sDir) -> Song*;
-extern void
-SortSongs(); // sort m_pSongs by CompareSongPointersByTitle
+extern auto WasLoadedFromAdditionalSongs(const Song* pSong) -> bool;
+extern auto GetSongFromDir(std::string sDir) -> Song*;
+extern void SortSongs(); // sort m_pSongs by CompareSongPointersByTitle
 
 extern void
 ReconcileChartKeysForReloadedSong(const Song* reloadedSong,
 								  const std::vector<std::string>& oldChartkeys);
 // ^ TODO: INTERNAL
-extern void
-MakeSongGroupsFromPlaylists(
+extern void MakeSongGroupsFromPlaylists(
   std::map<std::string, Playlist>& playlists = GetPlaylists());
-extern void
-DeletePlaylist(
+extern void DeletePlaylist(
   const std::string& pl,
   std::map<std::string, Playlist>& playlists = GetPlaylists()); // Lua only
-extern void
-MakePlaylistFromFavorites(
+extern void MakePlaylistFromFavorites(
   std::set<std::string>& favs,
   std::map<std::string, Playlist>& playlists = GetPlaylists());
 
-extern void
-FinalizeSong(Song* pNewSong, const std::string& dir); // TODO: INTERNAL
+extern void FinalizeSong(Song* pNewSong, const std::string& dir); // TODO: INTERNAL
 
 // calc test stuff
-extern auto
-SaveCalcTestCreateNode() -> XNode*; // TODO: INTERNAL
-extern void
-LoadCalcTestNode(); // TODO: INTERNAL
-extern void
-SaveCalcTestXmlToDir();
+extern auto SaveCalcTestCreateNode() -> XNode*; // TODO: INTERNAL
+extern void LoadCalcTestNode(); // TODO: INTERNAL
+extern void SaveCalcTestXmlToDir();
 };
 #endif


### PR DESCRIPTION
This should have minor compile-time improvements.
It should also make for clearer overall code.

Ideally, this should be the first of many such PRs to convert all of our singletons.

Note: Lua is currently broken because of this; Poco knows how to fix it.
Other Note: The physical location of code within the source file could be tidied a bit, additionally some functions are only used internally and should be moved inside of the anonymous namespace.