### PR TITLE
Fix several compile-time warning messages to make build output more useful

### DIFF
--- a/src/Etterna/Models/Misc/GameCommand.cpp
+++ b/src/Etterna/Models/Misc/GameCommand.cpp
@@ -431,8 +431,8 @@ GameCommand::ApplySelf(const vector<PlayerNumber>& vpns) const
 			case StyleType_OnePlayerTwoSides:
 				break;
 			default:
-				LuaHelpers::ReportScriptError("Invalid StyleType: " +
-											  m_pStyle->m_StyleType);
+				LuaHelpers::ReportScriptError(ssprintf(
+				  "%s%d", "Invalid StyleType: ", m_pStyle->m_StyleType));
 		}
 	}
 	if (m_dc != Difficulty_Invalid)

--- a/src/Etterna/Models/Misc/Profile.cpp
+++ b/src/Etterna/Models/Misc/Profile.cpp
@@ -562,7 +562,9 @@ ScoreGoal::LoadFromNode(const XNode* pNode)
 		pNode->GetChildValue("TimeAchieved", s);
 		timeachieved.FromString(s);
 		pNode->GetChildValue("ScoreKey", s);
-		scorekey;
+		// scorekey;
+		// TODO: This was likely meant to be part of something...
+		//      It was uncommented out earlier.
 	}
 
 	pNode->GetChildValue("Comment", comment);

--- a/src/Etterna/Models/NoteData/NoteDataWithScoring.cpp
+++ b/src/Etterna/Models/NoteData/NoteDataWithScoring.cpp
@@ -38,7 +38,7 @@ LastTapNoteScoreTrack(const NoteData& in, const unsigned& row)
 		const auto tns = tn.result.tns;
 
 		if (tns == TNS_Miss ||
-			!GAMESTATE->CountNotesSeparately() && tns == TNS_None) {
+			(!GAMESTATE->CountNotesSeparately() && tns == TNS_None)) {
 			return t;
 		}
 		if (tns == TNS_None)

--- a/src/Etterna/Singletons/DownloadManager.cpp
+++ b/src/Etterna/Singletons/DownloadManager.cpp
@@ -1262,7 +1262,7 @@ DownloadManager::ForceUploadAllScores()
 	if (not_already_uploading) {
 		this->sequentialScoreUploadTotalWorkload =
 		  this->ScoreUploadSequentialQueue.size();
-		LOG->Trace("Starting sequential upload of %d scores",
+		LOG->Trace("Starting sequential upload of %lu scores",
 				   this->ScoreUploadSequentialQueue.size());
 		uploadSequentially();
 	}

--- a/src/Etterna/Singletons/GameManager.cpp
+++ b/src/Etterna/Singletons/GameManager.cpp
@@ -1480,8 +1480,6 @@ GameManager::GameManager()
 	m_bResetModifiers = false;
 	m_bResetTurns = false;
 	m_fPreviousRate = 1.f;
-	m_sModsToReset;
-	m_vTurnsToReset;
 	// Register with Lua.
 	{
 		Lua* L = LUA->Get();

--- a/src/RageUtil/Utils/RageUtil.cpp
+++ b/src/RageUtil/Utils/RageUtil.cpp
@@ -1633,7 +1633,7 @@ utf8_to_wchar_ec(const std::string& s, unsigned& start, wchar_t& ch)
 			start += i;
 			return false;
 		}
-		ch = ch << 6 | byte & 0x3F;
+		ch = ch << 6 | (byte & 0x3F);
 	}
 
 	auto bValid = true;
@@ -1677,26 +1677,26 @@ utf8_to_wchar(const char* s, size_t iLength, unsigned& start, wchar_t& ch)
 			ch = s[start + 0] & 0x7F;
 			break;
 		case 2:
-			ch = (s[start + 0] & 0x1F) << 6 | s[start + 1] & 0x3F;
+			ch = (s[start + 0] & 0x1F) << 6 | (s[start + 1] & 0x3F);
 			break;
 		case 3:
 			ch = (s[start + 0] & 0x0F) << 12 | (s[start + 1] & 0x3F) << 6 |
-				 s[start + 2] & 0x3F;
+				 (s[start + 2] & 0x3F);
 			break;
 		case 4:
 			ch = (s[start + 0] & 0x07) << 18 | (s[start + 1] & 0x3F) << 12 |
-				 (s[start + 2] & 0x3F) << 6 | s[start + 3] & 0x3F;
+				 (s[start + 2] & 0x3F) << 6 | (s[start + 3] & 0x3F);
 			break;
 		case 5:
 			ch = (s[start + 0] & 0x03) << 24 | (s[start + 1] & 0x3F) << 18 |
 				 (s[start + 2] & 0x3F) << 12 | (s[start + 3] & 0x3F) << 6 |
-				 s[start + 4] & 0x3F;
+				 (s[start + 4] & 0x3F);
 			break;
 
 		case 6:
 			ch = (s[start + 0] & 0x01) << 30 | (s[start + 1] & 0x3F) << 24 |
 				 (s[start + 2] & 0x3F) << 18 | (s[start + 3] & 0x3F) << 12 |
-				 (s[start + 4] & 0x3F) << 6 | s[start + 5] & 0x3F;
+				 (s[start + 4] & 0x3F) << 6 | (s[start + 5] & 0x3F);
 			break;
 	}
 
@@ -1733,7 +1733,7 @@ wchar_to_utf8(wchar_t ch, std::string& out)
 
 	for (auto i = 0; i < cbytes; ++i) {
 		const auto shift = (cbytes - i - 1) * 6;
-		out.append(1, static_cast<char>(0x80 | ch >> shift & 0x3F));
+		out.append(1, static_cast<char>(0x80 | (ch >> shift & 0x3F)));
 	}
 }
 
@@ -2220,7 +2220,7 @@ CollapsePath(std::string& sPath, bool bRemoveLeadingDot)
 			sPath[iPos + 2] == '/') {
 			/* If this is the first path element (nothing to delete),
 			 * or all we have is a slash, leave it. */
-			if (sOut.empty() || sOut.size() == 1 && sOut[0] == '/') {
+			if (sOut.empty() || (sOut.size() == 1 && sOut[0] == '/')) {
 				sOut.append(sPath, iPos, iNext - iPos);
 				continue;
 			}

--- a/src/RageUtil/Utils/RageUtil.h
+++ b/src/RageUtil/Utils/RageUtil.h
@@ -543,6 +543,11 @@ FormatNumberAndSuffix(int i) -> std::string;
 auto
 GetLocalTime() -> struct tm;
 
+// Supress warnings about format strings not being string literals
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-security"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
 template<typename... Args>
 auto
 ssprintf(const char* format, Args... args) -> std::string
@@ -551,10 +556,11 @@ ssprintf(const char* format, Args... args) -> std::string
 	size_t size = snprintf(nullptr, 0, format, args...) + 1;
 	std::unique_ptr<char[]> buf(new char[size]);
 	snprintf(buf.get(), size, format, args...);
-
 	// Don't want the '\0' inside
 	return std::string(buf.get(), buf.get() + size - 1);
 }
+#pragma clang pop
+#pragma GCC pop
 
 template<typename... Args>
 auto

--- a/src/RageUtil/Utils/RageUtil.h
+++ b/src/RageUtil/Utils/RageUtil.h
@@ -544,10 +544,15 @@ auto
 GetLocalTime() -> struct tm;
 
 // Supress warnings about format strings not being string literals
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wformat-security"
+#elif defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-security"
+#elif defined(_MSC_VER)
+// TODO: Suppress warnings for Windows
+#endif
 template<typename... Args>
 auto
 ssprintf(const char* format, Args... args) -> std::string
@@ -559,8 +564,13 @@ ssprintf(const char* format, Args... args) -> std::string
 	// Don't want the '\0' inside
 	return std::string(buf.get(), buf.get() + size - 1);
 }
+#if defined(__clang__)
 #pragma clang pop
+#elif defined(__GNUC__)
 #pragma GCC pop
+#elif defined(_MSC_VER)
+// TODO: Suppress warnings for Windows
+#endif
 
 template<typename... Args>
 auto

--- a/src/arch/Sound/RageSoundDriver_AU.cpp
+++ b/src/arch/Sound/RageSoundDriver_AU.cpp
@@ -18,7 +18,7 @@ static const UInt32 kFormatFlags =
   kAudioFormatFlagsNativeEndian | kAudioFormatFlagIsFloat;
 
 #define WERROR(str, num, extra...)                                             \
-	str ": '%s' (%lu).", ##extra, FourCCToString(num).c_str(), (num)
+	str ": '%s' (%d).", ##extra, FourCCToString(num).c_str(), (num)
 #define ERROR(str, num, extra...) (ssprintf(WERROR(str, (num), ##extra)))
 
 static inline std::string


### PR DESCRIPTION
The following changes were made:
Parenthesis were placed around some logical operators to remove warnings about implicit ordering.
Pragmas were placed to explicitly suppress warnings about non-literal format strings within `ssprintf`.
An incorrect format specifier was fixed within the `WERROR` macro.
An enum value that had been "added" to a string was changed to actually be appended.

This drastically reduces the number of warnings on my machine (100+ into ~15), and should generally make building information significantly more useful, as well as allowing important warnings to be seen.