### PR TITLE
Refactor variable name and location for minimum filter rate

### DIFF
--- a/src/Etterna/Actor/Menus/MusicWheel.cpp
+++ b/src/Etterna/Actor/Menus/MusicWheel.cpp
@@ -736,7 +736,7 @@ MusicWheel::FilterBySkillsets(vector<Song*>& inv)
 	for (auto* song : inv) {
 		auto addsong = false;
 		for (auto currate = FILTERMAN->MaxFilterRate;
-			 currate > FILTERMAN->m_pPlayerState->wtFFF - .01F;
+			 currate > FILTERMAN->MinFilterRate - .01F;
 			 currate -= 0.1F) { /* Iterate over all possible rates.
 								 * The .01f delta is because floating points
 								 * don't like exact equivalency*/

--- a/src/Etterna/Models/Misc/PlayerState.h
+++ b/src/Etterna/Models/Misc/PlayerState.h
@@ -108,7 +108,6 @@ class PlayerState
 	auto GetNumCols() -> int { return m_NumCols; };
 
 	float playertargetgoal = 0.93F;
-	float wtFFF = 1.F; // lol dont ask - mina
 
 	// Lua
 	void PushSelf(lua_State* L);

--- a/src/Etterna/Models/Songs/SongUtil.cpp
+++ b/src/Etterna/Models/Songs/SongUtil.cpp
@@ -69,7 +69,7 @@ SongUtil::GetSteps(const Song* pSong,
 			// explanation in MusicWheel::FilterBySkillsets
 			auto success = false;
 			for (auto currate = FILTERMAN->MaxFilterRate;
-				 currate > FILTERMAN->m_pPlayerState->wtFFF - .01f;
+				 currate > FILTERMAN->MinFilterRate - .01f;
 				 currate -= 0.1f) {
 				if (pSteps->MatchesFilter(currate + 0.001f)) {
 					success = true;
@@ -1040,7 +1040,9 @@ SongUtil::GetPlayableStepsTypes(const Song* pSong, set<StepsType>& vOut)
 }
 
 void
-SongUtil::GetPlayableSteps(const Song* pSong, vector<Steps*>& vOut, bool filteringSteps)
+SongUtil::GetPlayableSteps(const Song* pSong,
+						   vector<Steps*>& vOut,
+						   bool filteringSteps)
 {
 	set<StepsType> vStepsType;
 	GetPlayableStepsTypes(pSong, vStepsType);

--- a/src/Etterna/Singletons/FilterManager.cpp
+++ b/src/Etterna/Singletons/FilterManager.cpp
@@ -65,10 +65,8 @@ FilterManager::ResetAllFilters()
 	ExclusiveFilter = false;
 	HighestSkillsetsOnly = false;
 
-	if (m_pPlayerState != nullptr)
-		m_pPlayerState->wtFFF = 1.F;
+	MinFilterRate = 1.F;
 	MaxFilterRate = 1.F;
-	
 }
 
 // tmp filter stuff - mina
@@ -131,8 +129,7 @@ class LunaFilterManager : public Luna<FilterManager>
 	static int SetMaxFilterRate(T* p, lua_State* L)
 	{
 		float mfr = FArg(1);
-		auto loot = p->m_pPlayerState;
-		CLAMP(mfr, loot->wtFFF, 3.f);
+		CLAMP(mfr, p->MinFilterRate, 3.f);
 		p->MaxFilterRate = mfr;
 		return 0;
 	}
@@ -145,14 +142,13 @@ class LunaFilterManager : public Luna<FilterManager>
 	{
 		float mfr = FArg(1);
 		CLAMP(mfr, 0.7f, p->MaxFilterRate);
-		auto loot = p->m_pPlayerState;
-		loot->wtFFF = mfr;
+		p->MinFilterRate = mfr;
 		return 0;
 	}
 	static int GetMinFilterRate(T* p, lua_State* L)
 	{
 		auto loot = p->m_pPlayerState;
-		lua_pushnumber(L, loot->wtFFF);
+		lua_pushnumber(L, p->MinFilterRate);
 		return 1;
 	}
 	static int ToggleFilterMode(T* p, lua_State* L)

--- a/src/Etterna/Singletons/FilterManager.h
+++ b/src/Etterna/Singletons/FilterManager.h
@@ -16,6 +16,7 @@ class FilterManager
 	float SSFilterLowerBounds[NUM_Skillset + 1];
 	float SSFilterUpperBounds[NUM_Skillset + 1];
 	float MaxFilterRate = 1.F;
+	float MinFilterRate = 1.F;
 	bool ExclusiveFilter = false; // if true the filter system will only match
 								  // songs that meet all criteria rather than
 								  // all that meet any - mina


### PR DESCRIPTION
`FILTERMAN->m_pPlayerState->wtFFF` was changed into `FILTERMAN->MinFilterRate`
There was no reason for the minimum filter rate to be within m_pPlayerState instead of FILTERMAN directly. 
MinFilterRate has been changed to function exactly the same as MaxFilterRate currently does.