### PR TITLE
Make new Lua binding Song:GetChartsMatchingFilter() that returns charts in current game mode matching filter

### DIFF
--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/stepsdisplay.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/stepsdisplay.lua
@@ -40,7 +40,7 @@ local sd =
 	CurrentSongChangedMessageCommand = function(self, song)
 		local song = song.ptr
 		if song then 
-			thesteps = song:GetChartsOfCurrentGameMode()
+			thesteps = song:GetChartsMatchingFilter()
 			self:playcommand("UpdateStepsRows")
 		else 
 			self:playcommand("Off")

--- a/src/Etterna/Actor/Menus/MusicWheel.cpp
+++ b/src/Etterna/Actor/Menus/MusicWheel.cpp
@@ -736,7 +736,7 @@ MusicWheel::FilterBySkillsets(vector<Song*>& inv)
 	for (auto* song : inv) {
 		auto addsong = false;
 		for (auto currate = FILTERMAN->MaxFilterRate;
-			 currate > FILTERMAN->m_pPlayerState->wtFFF - .01F;
+			 currate > FILTERMAN->MinFilterRate - .01F;
 			 currate -= 0.1F) { /* Iterate over all possible rates.
 								 * The .01f delta is because floating points
 								 * don't like exact equivalency*/

--- a/src/Etterna/Models/Misc/PlayerState.h
+++ b/src/Etterna/Models/Misc/PlayerState.h
@@ -108,7 +108,6 @@ class PlayerState
 	auto GetNumCols() -> int { return m_NumCols; };
 
 	float playertargetgoal = 0.93F;
-	float wtFFF = 1.F; // lol dont ask - mina
 
 	// Lua
 	void PushSelf(lua_State* L);

--- a/src/Etterna/Models/Songs/Song.cpp
+++ b/src/Etterna/Models/Songs/Song.cpp
@@ -1638,6 +1638,24 @@ Song::GetChartsOfCurrentGameMode() const
 	return steps;
 }
 
+std::vector<Steps*>
+Song::GetChartsMatchingFilter() const
+{
+	std::vector<Steps*> charts = GetChartsOfCurrentGameMode();
+	std::vector<Steps*> matches;
+	for (auto& i : charts) {
+		for (auto currate = FILTERMAN->MaxFilterRate;
+			 currate > FILTERMAN->MinFilterRate - .01F;
+			 currate -= 0.1F) { /* Iterate over all possible rates.
+								 * The .01f delta is because floating points
+								 * don't like exact equivalency*/
+			if (i->MatchesFilter(currate))
+				matches.push_back(i);
+		}
+	}
+	return matches;
+}
+
 float
 Song::HighestMSDOfSkillset(Skillset skill, float rate) const
 {
@@ -2305,6 +2323,11 @@ class LunaSong : public Luna<Song>
 		LuaHelpers::CreateTableFromArray(p->GetChartsOfCurrentGameMode(), L);
 		return 1;
 	}
+	static int GetChartsMatchingFilter(T* p, lua_State* L)
+	{
+		LuaHelpers::CreateTableFromArray(p->GetChartsMatchingFilter(), L);
+		return 1;
+	}
 	LunaSong()
 	{
 		ADD_METHOD(GetDisplayFullTitle);
@@ -2371,6 +2394,7 @@ class LunaSong : public Luna<Song>
 		ADD_METHOD(ReloadFromSongDir);
 		ADD_METHOD(PlaySampleMusicExtended);
 		ADD_METHOD(GetChartsOfCurrentGameMode);
+		ADD_METHOD(GetChartsMatchingFilter);
 	}
 };
 

--- a/src/Etterna/Models/Songs/Song.cpp
+++ b/src/Etterna/Models/Songs/Song.cpp
@@ -1642,6 +1642,8 @@ std::vector<Steps*>
 Song::GetChartsMatchingFilter() const
 {
 	std::vector<Steps*> charts = GetChartsOfCurrentGameMode();
+	if (!FILTERMAN->AnyActiveFilter())
+		return charts;
 	std::vector<Steps*> matches;
 	for (auto& i : charts) {
 		for (auto currate = FILTERMAN->MaxFilterRate;

--- a/src/Etterna/Models/Songs/Song.h
+++ b/src/Etterna/Models/Songs/Song.h
@@ -474,6 +474,7 @@ class Song
 	/** @brief Get the steps of all types within the current game mode */
 	[[nodiscard]] auto GetChartsOfCurrentGameMode() const
 	  -> std::vector<Steps*>;
+	[[nodiscard]] auto GetChartsMatchingFilter() const -> std::vector<Steps*>;
 	[[nodiscard]] auto HasEdits(StepsType st) const -> bool;
 
 	auto IsFavorited() const -> bool { return isfavorited; }

--- a/src/Etterna/Models/Songs/SongUtil.cpp
+++ b/src/Etterna/Models/Songs/SongUtil.cpp
@@ -69,7 +69,7 @@ SongUtil::GetSteps(const Song* pSong,
 			// explanation in MusicWheel::FilterBySkillsets
 			auto success = false;
 			for (auto currate = FILTERMAN->MaxFilterRate;
-				 currate > FILTERMAN->m_pPlayerState->wtFFF - .01f;
+				 currate > FILTERMAN->MinFilterRate - .01f;
 				 currate -= 0.1f) {
 				if (pSteps->MatchesFilter(currate + 0.001f)) {
 					success = true;
@@ -1040,7 +1040,9 @@ SongUtil::GetPlayableStepsTypes(const Song* pSong, set<StepsType>& vOut)
 }
 
 void
-SongUtil::GetPlayableSteps(const Song* pSong, vector<Steps*>& vOut, bool filteringSteps)
+SongUtil::GetPlayableSteps(const Song* pSong,
+						   vector<Steps*>& vOut,
+						   bool filteringSteps)
 {
 	set<StepsType> vStepsType;
 	GetPlayableStepsTypes(pSong, vStepsType);

--- a/src/Etterna/Singletons/FilterManager.cpp
+++ b/src/Etterna/Singletons/FilterManager.cpp
@@ -65,10 +65,8 @@ FilterManager::ResetAllFilters()
 	ExclusiveFilter = false;
 	HighestSkillsetsOnly = false;
 
-	if (m_pPlayerState != nullptr)
-		m_pPlayerState->wtFFF = 1.F;
+	MinFilterRate = 1.F;
 	MaxFilterRate = 1.F;
-	
 }
 
 // tmp filter stuff - mina
@@ -131,8 +129,7 @@ class LunaFilterManager : public Luna<FilterManager>
 	static int SetMaxFilterRate(T* p, lua_State* L)
 	{
 		float mfr = FArg(1);
-		auto loot = p->m_pPlayerState;
-		CLAMP(mfr, loot->wtFFF, 3.f);
+		CLAMP(mfr, p->MinFilterRate, 3.f);
 		p->MaxFilterRate = mfr;
 		return 0;
 	}
@@ -145,14 +142,13 @@ class LunaFilterManager : public Luna<FilterManager>
 	{
 		float mfr = FArg(1);
 		CLAMP(mfr, 0.7f, p->MaxFilterRate);
-		auto loot = p->m_pPlayerState;
-		loot->wtFFF = mfr;
+		p->MinFilterRate = mfr;
 		return 0;
 	}
 	static int GetMinFilterRate(T* p, lua_State* L)
 	{
 		auto loot = p->m_pPlayerState;
-		lua_pushnumber(L, loot->wtFFF);
+		lua_pushnumber(L, p->MinFilterRate);
 		return 1;
 	}
 	static int ToggleFilterMode(T* p, lua_State* L)

--- a/src/Etterna/Singletons/FilterManager.h
+++ b/src/Etterna/Singletons/FilterManager.h
@@ -16,6 +16,7 @@ class FilterManager
 	float SSFilterLowerBounds[NUM_Skillset + 1];
 	float SSFilterUpperBounds[NUM_Skillset + 1];
 	float MaxFilterRate = 1.F;
+	float MinFilterRate = 1.F;
 	bool ExclusiveFilter = false; // if true the filter system will only match
 								  // songs that meet all criteria rather than
 								  // all that meet any - mina


### PR DESCRIPTION
Earlier, Song:GetChartsOfCurrentGameMode() was used instead, which had two effects
1) Charts were not hidden when a filter was set
2) Bad glitchy things happened because it was referencing charts that were hidden on the C++ side.

This PR changes the Lua behavior to be as intended.

Note: The PR is based upon #864. 