### PR TITLE
Exclude tags fixes

### DIFF
--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/tags.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/tags.lua
@@ -243,7 +243,9 @@ local r =
 					end
 				end
 			end
+			local ssong = GAMESTATE:GetCurrentSong()
 			whee:FilterByAndAgainstStepKeys(charts, oCharts)
+			whee:SelectSong(ssong)
 			filterChanged = false
 		end
 		

--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/tags.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/tags.lua
@@ -504,7 +504,7 @@ r[#r + 1] =
 				self:zoom(fontScale):halign(0)
 			end,
 			BORPBORPNORFNORFcCommand = function(self)
-				self:settextf("%s: %s", translated_info["Mode"], (filterMode and translated_info["AND"] or translated_info["OR"]))
+				self:settextf("%s: %s", translated_info["Mode"], (filterMode and translated_info["AND"] or translated_info["OR"])):maxwidth(((frameWidth - 40) / 2) / fontScale)
 			end,
 			UpdateTagsMessageCommand = function(self)
 				self:queuecommand("BORPBORPNORFNORFc")
@@ -512,7 +512,7 @@ r[#r + 1] =
 		},
 	Def.Quad {
 		InitCommand = function(self)
-			self:zoomto(120, 18):halign(0):diffusealpha(0)
+			self:zoomto((frameWidth - 40) / 2, 18):halign(0):diffusealpha(0)
 		end,
 		MouseLeftClickMessageCommand = function(self)
 			if isOver(self) and onTab then
@@ -528,7 +528,8 @@ r[#r + 1] =
 r[#r + 1] =
 	Def.ActorFrame {
 	InitCommand = function(self)
-		self:xy(frameX + 200, frameY + capWideScale(80, 80) + 225)
+		-- Is inverse of frameX + 10, makes it start at exactly half way + 10px each side padding
+		self:xy(frameX + ((frameWidth - 40) / 2) + 30, frameY + capWideScale(80, 80) + 225)
 	end,
 	BORPBORPNORFNORFcCommand = function(self)
 		self:visible(tagFunction == 2)
@@ -542,7 +543,7 @@ r[#r + 1] =
 				self:zoom(fontScale):halign(0)
 			end,
 			BORPBORPNORFNORFcCommand = function(self)
-				self:settextf("%s: %s", translated_info["ExcludeMode"], (filterAgainstMode and translated_info["AND"] or translated_info["OR"]))
+				self:settextf("%s: %s", translated_info["ExcludeMode"], (filterAgainstMode and translated_info["AND"] or translated_info["OR"])):maxwidth(((frameWidth - 40) / 2) / fontScale)
 			end,
 			UpdateTagsMessageCommand = function(self)
 				self:queuecommand("BORPBORPNORFNORFc")
@@ -550,7 +551,7 @@ r[#r + 1] =
 		},
 	Def.Quad {
 		InitCommand = function(self)
-			self:zoomto(120, 18):halign(0):diffusealpha(0)
+			self:zoomto(((frameWidth - 40) / 2), 18):halign(0):diffusealpha(0)
 		end,
 		MouseLeftClickMessageCommand = function(self)
 			if isOver(self) and onTab then

--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/tags.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/tags.lua
@@ -178,12 +178,12 @@ local r =
 			if next(filterTags) then
 				-- MODE == AND in menu, requires all tags to be active
 				if filterMode then
-					toFilterTags = {}
+					local toFilterTags = {}
 					for tag, v in pairs(filterTags) do
 						toFilterTags[#toFilterTags + 1] = tag
 					end
 
-					inCharts = {}
+					local inCharts = {}
 					-- Gather initial first tags chart keys
 					for chartKey, v in pairs(ptags[toFilterTags[1]]) do
 						inCharts[#inCharts + 1] = chartKey
@@ -212,12 +212,12 @@ local r =
 			if next(filterAgainstTags) then
 				-- MODE == AND in menu, requires all tags to be active
 				if filterAgainstMode then
-					toFilterAgainstTags = {}
+					local toFilterAgainstTags = {}
 					for tag, v in pairs(filterAgainstTags) do
 						toFilterAgainstTags[#toFilterAgainstTags + 1] = tag
 					end
 
-					outCharts = {}
+					local outCharts = {}
 					-- Gather initial first tags chart keys
 					for chartKey, v in pairs(ptags[toFilterAgainstTags[1]]) do
 						outCharts[#outCharts + 1] = chartKey


### PR DESCRIPTION
I found a couple of bugs/inconveniences/bad code that cropped up with my exclude tags features.

*Makes songs reselect on tag change
*Makes local variables be local in RefreshTagsMessageCommand
*Makes the previous GUI associated that didn't work with 4:3 resolution now work with 16:9 and 4:3 resolution (and theoretically any resolution that ends up supported because it's based on frameWidth now)