### PR TITLE
Fix RageTexture-related heap corruption crash

### DIFF
--- a/src/Etterna/Actor/Base/Sprite.cpp
+++ b/src/Etterna/Actor/Base/Sprite.cpp
@@ -1366,19 +1366,22 @@ class LunaSprite : public Luna<Sprite>
 	}
 	static int SetTexture(T* p, lua_State* L)
 	{
-		auto pTexture = Luna<RageTexture>::check(L, 1);
-		std::shared_ptr<RageTexture> rt(pTexture);
-		rt = TEXTUREMAN->CopyTexture(rt);
-		p->SetTexture(rt);
+		RTPtrContainer* pTexture = Luna<RTPtrContainer>::check(L, 1);
+		if (pTexture->handle != nullptr)
+			pTexture->handle->m_iRefCount++;
+		p->SetTexture(pTexture->handle);
 		COMMON_RETURN_SELF;
 	}
 	static int GetTexture(T* p, lua_State* L)
 	{
-		auto pTexture = p->GetTexture();
-		if (pTexture != nullptr)
+		RTPtrContainer* pTexture = new RTPtrContainer;
+		pTexture->handle = p->GetTexture();
+		if (pTexture->handle != nullptr)
 			pTexture->PushSelf(L);
-		else
+		else {
+			delete pTexture;
 			lua_pushnil(L);
+		}
 		return 1;
 	}
 	static int SetEffectMode(T* p, lua_State* L)

--- a/src/RageUtil/Graphics/RageTexture.cpp
+++ b/src/RageUtil/Graphics/RageTexture.cpp
@@ -165,3 +165,148 @@ class LunaRageTexture : public Luna<RageTexture>
 
 LUA_REGISTER_CLASS(RageTexture)
 // lua end
+
+class LunaRTPtrContainer : public Luna<RTPtrContainer>
+{
+public:
+
+	static int position(T* p, lua_State* L)
+	{
+		if (p->handle == nullptr) {
+			lua_pushnil(L);
+			return 1;
+		}
+		p->handle->SetPosition(FArg(1));
+		COMMON_RETURN_SELF;
+	}
+	static int loop(T* p, lua_State* L)
+	{
+		if (p->handle == nullptr) {
+			lua_pushnil(L);
+			return 1;
+		}
+		p->handle->SetLooping(BIArg(1));
+		COMMON_RETURN_SELF;
+	}
+	static int rate(T* p, lua_State* L)
+	{
+		if (p->handle == nullptr) {
+			lua_pushnil(L);
+			return 1;
+		}
+		p->handle->SetPlaybackRate(FArg(1));
+		COMMON_RETURN_SELF;
+	}
+	static int GetTextureCoordRect(T* p, lua_State* L)
+	{
+		if (p->handle == nullptr) {
+			lua_pushnil(L);
+			return 1;
+		}
+		const auto pRect = p->handle->GetTextureCoordRect(IArg(1));
+		lua_pushnumber(L, pRect->left);
+		lua_pushnumber(L, pRect->top);
+		lua_pushnumber(L, pRect->right);
+		lua_pushnumber(L, pRect->bottom);
+		return 4;
+	}
+	static int GetNumFrames(T* p, lua_State* L)
+	{
+		if (p->handle == nullptr) {
+			lua_pushnil(L);
+			return 1;
+		}
+		lua_pushnumber(L, p->handle->GetNumFrames());
+		return 1;
+	}
+	static int Reload(T* p, lua_State* L)
+	{
+		if (p->handle == nullptr) {
+			lua_pushnil(L);
+			return 1;
+		}
+		p->handle->Reload();
+		COMMON_RETURN_SELF;
+	}
+	static int GetSourceWidth(T* p, lua_State* L)
+	{
+		if (p->handle == nullptr) {
+			lua_pushnil(L);
+			return 1;
+		}
+		lua_pushnumber(L, p->handle->GetSourceWidth());
+		return 1;
+	}
+	static int GetSourceHeight(T* p, lua_State* L)
+	{
+		if (p->handle == nullptr) {
+			lua_pushnil(L);
+			return 1;
+		}
+		lua_pushnumber(L, p->handle->GetSourceHeight());
+		return 1;
+	}
+	static int GetTextureWidth(T* p, lua_State* L)
+	{
+		if (p->handle == nullptr) {
+			lua_pushnil(L);
+			return 1;
+		}
+		lua_pushnumber(L, p->handle->GetTextureWidth());
+		return 1;
+	}
+	static int GetTextureHeight(T* p, lua_State* L)
+	{
+		if (p->handle == nullptr) {
+			lua_pushnil(L);
+			return 1;
+		}
+		lua_pushnumber(L, p->handle->GetTextureHeight());
+		return 1;
+	}
+	static int GetImageWidth(T* p, lua_State* L)
+	{
+		if (p->handle == nullptr) {
+			lua_pushnil(L);
+			return 1;
+		}
+		lua_pushnumber(L, p->handle->GetImageWidth());
+		return 1;
+	}
+	static int GetImageHeight(T* p, lua_State* L)
+	{
+		if (p->handle == nullptr) {
+			lua_pushnil(L);
+			return 1;
+		}
+		lua_pushnumber(L, p->handle->GetImageHeight());
+		return 1;
+	}
+	static int GetPath(T* p, lua_State* L)
+	{
+		if (p->handle == nullptr) {
+			lua_pushnil(L);
+			return 1;
+		}
+		lua_pushstring(L, p->handle->GetID().filename.c_str());
+		return 1;
+	}
+	
+	LunaRTPtrContainer()
+	{
+		ADD_METHOD(position);
+		ADD_METHOD(loop);
+		ADD_METHOD(rate);
+		ADD_METHOD(GetTextureCoordRect);
+		ADD_METHOD(GetNumFrames);
+		ADD_METHOD(Reload);
+		ADD_METHOD(GetSourceWidth);
+		ADD_METHOD(GetSourceHeight);
+		ADD_METHOD(GetTextureWidth);
+		ADD_METHOD(GetTextureHeight);
+		ADD_METHOD(GetImageWidth);
+		ADD_METHOD(GetImageHeight);
+		ADD_METHOD(GetPath);
+	}
+};
+LUA_REGISTER_CLASS(RTPtrContainer)

--- a/src/RageUtil/Graphics/RageTexture.h
+++ b/src/RageUtil/Graphics/RageTexture.h
@@ -144,4 +144,12 @@ class RageTexture
 	virtual void CreateFrameRects();
 };
 
+class RTPtrContainer
+{
+  public:
+	std::shared_ptr<RageTexture> handle;
+
+	void PushSelf(lua_State* L);
+};
+
 #endif


### PR DESCRIPTION
So because we handle all RageTextures behind `std::shared_ptr` there remained one last place where we still give the raw pointers out. It's against all the rules in the world to give away the raw pointer from a shared pointer like that and then take it back in and create a new shared pointer on a pointer which potentially already has one. This causes a range of undefined behavior when destructing either/both shared pointers.

The change here basically makes a container for the shared pointer to be handed through lua... I really really don't like this solution.