### PR TITLE
Switch static array to vector for interval based MinaCalc containers

### DIFF
--- a/src/Etterna/MinaCalc/MinaCalc.cpp
+++ b/src/Etterna/MinaCalc/MinaCalc.cpp
@@ -252,11 +252,11 @@ StamAdjust(const float x,
 	const auto super_stam_ceil = 1.11F;
 
 	// use this to calculate the mod growth
-	const std::array<float, max_intervals>* base_diff =
+	const std::vector<float>* base_diff =
 	  &(calc.base_diff_for_stam_mod.at(hi).at(ss));
 	// but apply the mod growth to these values
 	// they might be the same, or not
-	const std::array<float, max_intervals>* diff =
+	const std::vector<float>* diff =
 	  &(calc.base_adj_diff.at(hi).at(ss));
 
 	// i don't like the copypasta either but the boolchecks where
@@ -407,7 +407,7 @@ CalcInternal(float& gotpoints,
 	}
 
 	// final difficulty values to use
-	const std::array<float, max_intervals>* v =
+	const std::vector<float>* v =
 	  &(stam ? calc.stam_adj_diff : calc.base_adj_diff.at(hi).at(ss));
 	auto powindromemordniwop = 1.7F;
 	if (ss == Skill_Chordjack) {
@@ -916,7 +916,7 @@ MinaSDCalcDebug(
 	}
 }
 
-int mina_calc_version = 438;
+int mina_calc_version = 440;
 auto
 GetCalcVersion() -> int
 {

--- a/src/Etterna/MinaCalc/UlbuAcolytes.h
+++ b/src/Etterna/MinaCalc/UlbuAcolytes.h
@@ -18,7 +18,7 @@ static const std::array<unsigned, num_hands> hand_col_ids = { 3, 12 };
 constexpr float interval_span = 0.5F;
 
 inline void
-Smooth(std::array<float, max_intervals>& input,
+Smooth(std::vector<float>& input,
 	   const float neutral,
 	   const int end_interval)
 {
@@ -34,7 +34,7 @@ Smooth(std::array<float, max_intervals>& input,
 }
 
 inline void
-MSSmooth(std::array<float, max_intervals>& input,
+MSSmooth(std::vector<float>& input,
 		 const float neutral,
 		 const int end_interval)
 {
@@ -125,9 +125,13 @@ fast_walk_and_check_for_skip(const std::vector<NoteInfo>& ni,
 	 * the end */
 	calc.numitv = time_to_itv_idx(ni.back().rowTime / rate) + 1;
 
-	// are there more intervals than our alloted max
-	if (calc.numitv >= max_intervals) {
-		return true;
+	// are there more intervals than our emplaced max
+	if (calc.numitv >= calc.itv_size.size()) {
+		// hard cap for memory considerations
+		if (calc.numitv >= max_intervals)
+			return true;
+		// accesses can happen way at the end so give it some breathing room
+		calc.resize_interval_dependent_vectors(calc.numitv + 2);
 	}
 
 	// for various reasons we actually have to do this, scan the file and make

--- a/src/Etterna/Singletons/LuaManager.cpp
+++ b/src/Etterna/Singletons/LuaManager.cpp
@@ -12,6 +12,7 @@
 #include "arch/Dialog/Dialog.h"
 #include "ver.h"
 
+#include <algorithm>
 #include <array>
 #include <cassert>
 #include <csetjmp>


### PR DESCRIPTION
Due to a change in MSVC 16.7 it appears that static arrays of a large size take a simply unacceptable amount of RAM/heap to compile. This kills GHA as well as almost our local machines. This is a change that "fixes" the issue by removing the very large static arrays.

Although this behavior may be due to a real MSVC bug, this change is useful on its own to allow a somewhat greater range of files. But still, the difference between 40k intervals and 100k intervals for a max size is basically nothing in the grand scheme of files available. Most files fall within 500-1000 intervals (4-8 minutes).

Merge AFTER #883 