### PR TITLE
MinaCalc Profilemancy

### DIFF
--- a/src/Etterna/MinaCalc/MinaCalc.cpp
+++ b/src/Etterna/MinaCalc/MinaCalc.cpp
@@ -97,19 +97,20 @@ Calc::CalcMain(const std::vector<NoteInfo>& NoteInfo,
 		const auto base = mcbloop[highest_base_skillset];
 
 		/* rerun all with stam on, optimize by starting at the non-stam adjusted
-		 * base value for each skillset we can actually set the stam floor to <
-		 * 1 to shift the curve a bit do we actually need to rerun _all_ with
-		 * stam on? we gain significant speed from not doing so, however the
-		 * tradeoff is files that are close in 2/3 skillsets will have the stam
-		 * bonus stripped from the second and third components, devaluing the
-		 * file as a whole, we could run it for the 2nd/3rd highest skillsets
-		 * but i'm too lazy to implement that right now */
+		 * base value for each skillset. we can actually set the stam floor to <
+		 * 1 to shift the curve a bit. chisels are expensive, so we only want
+		 * to refine the values for the most important skillsets. (base * 0.9)
+		 * is not a principled choice, but it makes the calc faster than v263 on
+		 * average and results in exactly the same value for overall for ~99% of
+		 * files */
 		for (auto i = 0; i < NUM_Skillset; ++i) {
-			mcbloop[i] = Chisel(mcbloop[i] * 0.9F,
-								0.32F,
-								score_goal,
-								static_cast<Skillset>(i),
-								true);
+			if (mcbloop[i] > base * 0.9f) {
+				mcbloop[i] = Chisel(mcbloop[i] * 0.9F,
+									0.32F,
+									score_goal,
+									static_cast<Skillset>(i),
+									true);
+			}
 		}
 
 		const auto highest_stam_adjusted_skillset =

--- a/src/Etterna/MinaCalc/MinaCalc.cpp
+++ b/src/Etterna/MinaCalc/MinaCalc.cpp
@@ -944,7 +944,7 @@ MinaSDCalcDebug(
 	}
 }
 
-int mina_calc_version = 440;
+int mina_calc_version = 441;
 auto
 GetCalcVersion() -> int
 {

--- a/src/Etterna/MinaCalc/UlbuAcolytes.h
+++ b/src/Etterna/MinaCalc/UlbuAcolytes.h
@@ -208,6 +208,11 @@ fast_walk_and_check_for_skip(const std::vector<NoteInfo>& ni,
 			++right;
 		}
 
+		if (nri.row_count < 0 || nri.row_count > 0b1111) {
+			// not a 4k file
+			return true;
+		}
+
 		assert(left + right == nri.row_count);
 
 		nri.hand_counts[left_hand] = left;

--- a/src/Etterna/MinaCalc/UlbuAcolytes.h
+++ b/src/Etterna/MinaCalc/UlbuAcolytes.h
@@ -158,6 +158,11 @@ fast_walk_and_check_for_skip(const std::vector<NoteInfo>& ni,
 
 		const auto& ri = i;
 
+		// either not a 4k file or malformed
+		if (ri.notes < 0 || ri.notes > 0b1111) {
+			return true;
+		}
+
 		// 90000 bpm flams may produce 0s due to float precision, we can ignore
 		// this for now, there should be no /0 errors due to it
 		/*if (i > 0) {
@@ -206,11 +211,6 @@ fast_walk_and_check_for_skip(const std::vector<NoteInfo>& ni,
 		}
 		if ((ri.notes & 8U) != 0U) {
 			++right;
-		}
-
-		if (nri.row_count < 0 || nri.row_count > 0b1111) {
-			// not a 4k file
-			return true;
 		}
 
 		assert(left + right == nri.row_count);


### PR DESCRIPTION

This PR does small two things:

1) Implement a suggestion from one of mina's comments in the calc. This makes the calc slightly faster than v263 was on average. 

   Basically, it's possible to avoid a lot of work by only chiseling on skillsets that actually effect the result of the final `AggregateRatings`. 
   
   This _does_ change the output slightly, but 98.7% of the charts on my machine (~20k) produce the exact same overall value (bit-exact). Only 20 files increased in rating, the rest went lower. Here's the 20 largest changes:
   
   ```
    # Difference File                                           Chartkey
   01 -0.48      Road of Death (Edit)                           X8a1a1fc7a55986e2397791da4936097283cefc55
   02 -0.36      Pandemonic Hyperblast (Challenge)              X28bdf6d15e3ad299ba97847625b1de9d517f45e3
   03 -0.20      Nightmare (Challenge)                          X98c537575dd902878b1b7e5d478881b44d2f77fe
   04 -0.18      Push it to the Limit (Beginner)                X5bb38a1d6ae610a095f6746eb2a38ea22bf5657e
   05 -0.14      Last Battle-T260G- (Easy)                      X192fc03a8b4d70ad0a9ee22f94c83fb1900feedc
   06  0.13      Bergentrückung (sophie, Beginner)              Xe9ce892b1a0808119fa39fd1a4979214a774eba4
   07  0.13      дцп (poco0317, Hard)                           Xcff9deab501bd456867a741cb3e5f9385ddcbd86
   08  0.12      は！か！た！の！しお！ (Easy)                    X7d95eb42939e042c81fecc039ff22d1f1b93a817
   09 -0.12      Tax Evasion (Challenge)                        Xdb7853c12963decbe68f8833eff5ad371dec964c
   10 -0.12      =TEH FINAL BOSS SONG= (Challenge)              X6fd07b385b9f506316bea65c12e685c32f7c3bfe
   11 -0.12      Honor Thy Father (Challenge)                   X8b13f756a26523c8806bed8f1c4fa6cce458fcba
   12 -0.10      HELL SCAPER FOR NIMA (Challenge)               X03226df5e39812b7378e48f43e938fef702c52b5
   13 -0.10      RAP Itachi (sophie, Easy)                      X074d3080f8ffcd64401f3c8954f1e749dafdf522
   14 -0.09      Starlight In Ebony (HandsomeEinar, Challenge)  X82ee7e7814b45ef793e15f3fa5abf085c4aa5f3e
   15 -0.09      Chik Habit (John Bernhard, Beginner)           X481fc1abae34d3535c807d834f0dd76c8c39d630
   16 -0.09      Chik Habit (John Bernhard, Beginner)           X481fc1abae34d3535c807d834f0dd76c8c39d630
   17 -0.08      Alice (Beginner)                               X22b39818a6de7d0de6e9e0cd752538f28dedcb31
   18 -0.08      Vertex BETA (Dark Bahamut, Hard)               X600b4448a8e15fe384cf2e9c5a3e14a6b1d40d62
   19 -0.08      Crack In The Hourglass (Challenge)             Xaf766ae3042b68ff4880bd7487d830a039bd43a4
   20 -0.08      ATEKS TRIALOGUE (LeiN-, Challenge)             Xaf9126b915a381ca6943b1b3830d47334754a10a
   
      -0.00      Average
   ```
    (Don't ask me why Chik Habit is in there twice, I just iterated over the steps table in cache.db)

   Individual skillset ratings drop around 0.2 lower on average, but that's because stamina was diffusing rating over every skillset. The actual top skillsets and overall rating don't change. 

2) Detect and discard 6k input. This was probably what was causing that assert to be hit. That can't happen anymore; I left it in because it stills checks against any changes to the nearby code in the future.  