### PR TITLE
Add virtual default destructor to Core::ILogger so child destructors …

### DIFF
--- a/src/Core/Services/ILogger.hpp
+++ b/src/Core/Services/ILogger.hpp
@@ -18,6 +18,9 @@ namespace Core {
 class ILogger {
 
 public:
+    /** Virtual destructor to ensure derived objects are guaranteed to have destructor */
+    virtual ~ILogger() = default;
+
     /**
      * Severity Enum - Middle man between each logging backed
      * and their own severity terminology.
@@ -47,7 +50,7 @@ public:
     /** @brief Enabled or disable a stdout prompt on Windows */
     bool setConsoleEnabled(bool enable);
     virtual void setLogLevel(ILogger::Severity logLevel) = 0;
-	virtual ~ILogger() = default; 
+
 protected:
     /**
      * Implementations only need to implement this log function to send logs

--- a/src/Core/Services/ILogger.hpp
+++ b/src/Core/Services/ILogger.hpp
@@ -47,7 +47,7 @@ public:
     /** @brief Enabled or disable a stdout prompt on Windows */
     bool setConsoleEnabled(bool enable);
     virtual void setLogLevel(ILogger::Severity logLevel) = 0;
-
+	virtual ~ILogger() = default; 
 protected:
     /**
      * Implementations only need to implement this log function to send logs


### PR DESCRIPTION
A virtual destructor was added, as when a base class does not have a virtual destructor, calling a derived destructor in the form of...
```
Base *base = new Derived();
delete base;
``` 
... will cause undefined behavior. This PR will guarantee default destruction.