### PR TITLE
Replace stof with stod (truncating result to float) to prevent low-value crash

### DIFF
--- a/src/Etterna/Models/NoteLoaders/NotesLoaderOSU.cpp
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderOSU.cpp
@@ -149,7 +149,7 @@ OsuLoader::SetTimingData(map<string, map<string, string>> parsedData, Song& out)
 		auto values = split(line, ",");
 
 		tp.emplace_back(
-		  std::pair<int, float>(stoi(values[0]), stof(values[1])));
+		  std::pair<int, float>(stoi(values[0]), stod(values[1])));
 	}
 	sort(tp.begin(),
 		 tp.end(),
@@ -353,8 +353,9 @@ OsuLoader::LoadNoteDataFromSimfile(const std::string& path, Steps& out)
 {
 	RageFile f;
 	if (!f.Open(path)) {
-//		LOG->UserLog(
-//		  "Song file", path, "couldn't be opened: %s", f.GetError().c_str());
+		//		LOG->UserLog(
+		//		  "Song file", path, "couldn't be opened: %s",
+		// f.GetError().c_str());
 		return false;
 	}
 


### PR DESCRIPTION


Extremely small BPM values being passed into the OSU loader could cause
 Etterna to crash by making stof go out of range by passing a value in too
 small to be representable by a float.

This change sidesteps this issue by instead using stod, and allowing the
 result to be truncated to a float (truncating unrepresantable values to 0).

This can still technically crash, but you'd need to pass in even more
 ludicrously small values to do so.
In the future, it might make sense to wrap this in a try-catch block and
 catch the std::out-of-range exception to continue cleanly.

Note: I'm leaving this draft for now to let someone more knowledgeable than me make sure it's ok.
Notably, the second value can be exactly 0; I don't know if that's potentially harmful. 
I tried playing a file that previously crashed for the above reason, and it seemed to play correctly.