### PR TITLE
Unsolicited proof-of-concept machine learning jackspeed PR  

### DIFF
--- a/src/Etterna/MinaCalc/Dependent/HD_Sequencers/GenericSequencing.h
+++ b/src/Etterna/MinaCalc/Dependent/HD_Sequencers/GenericSequencing.h
@@ -144,9 +144,9 @@ struct Anchor_Sequencing
 			return _len_cap_ms;
 		}
 
-		static const auto avg_ms_mult = 1.075F;
-		static const auto anchor_time_buffer_ms = 25.F;
-		static const auto min_ms = 82.5F;
+		static const auto avg_ms_mult = 1.0363214F;
+		static const auto anchor_time_buffer_ms = 24.336933F;
+		static const auto min_ms = 79.538712F;
 
 		// get total ms
 		const auto total_ms = ms_from(_last, _start);
@@ -167,7 +167,7 @@ struct Anchor_Sequencing
 
 		// BAD TEMP HACK LUL
 		if (_len == 2) {
-			ms *= 1.1F;
+			ms *= 1.1018715F;
 			ms = ms < 155.F ? 155.F : ms;
 		}
 

--- a/src/Etterna/MinaCalc/MinaCalc.cpp
+++ b/src/Etterna/MinaCalc/MinaCalc.cpp
@@ -954,7 +954,7 @@ MinaSDCalcDebug(
 	}
 }
 
-int mina_calc_version = 441;
+int mina_calc_version = 442;
 auto
 GetCalcVersion() -> int
 {

--- a/src/Etterna/MinaCalc/MinaCalc.cpp
+++ b/src/Etterna/MinaCalc/MinaCalc.cpp
@@ -105,7 +105,7 @@ Calc::CalcMain(const std::vector<NoteInfo>& NoteInfo,
 		 * files */
 		for (auto i = 0; i < NUM_Skillset; ++i) {
 			if (mcbloop[i] > base * 0.9f) {
-				mcbloop[i] = Chisel(mcbloop[i] * 0.9F,
+				mcbloop[i] = Chisel(mcbloop[i] * 0.82792711F,
 									0.32F,
 									score_goal,
 									static_cast<Skillset>(i),
@@ -298,11 +298,11 @@ JackStamAdjust(const float x, Calc& calc, const int hi)
   -> std::vector<std::pair<float, float>>
 {
 	// Jack stamina Model params (see above)
-	static const auto stam_ceil = 1.05234F;
-	static const auto stam_mag = 23.F;
-	static const auto stam_fscale = 2150.F;
-	static const auto stam_prop = 0.49424F;
-	auto stam_floor = 0.95F;
+	static const auto stam_ceil = 1.0087639F;
+	static const auto stam_mag = 22.086582F;
+	static const auto stam_fscale = 2060.1338F;
+	static const auto stam_prop = 0.48069301F;
+	auto stam_floor = 0.90450478F;
 	auto mod = 0.95F;
 
 	auto avs2 = 0.F;
@@ -316,7 +316,7 @@ JackStamAdjust(const float x, Calc& calc, const int hi)
 	for (size_t i = 0; i < diff.size(); i++) {
 		const auto avs1 = avs2;
 		avs2 = diff.at(i).second;
-		mod += ((((avs1 + avs2) / 2.F) / (stam_prop * x)) - 1.F) / stam_mag;
+		mod += ((((avs1 + avs2) / 2.F) / (stam_prop * x)) - 1.0156831F) / stam_mag;
 		if (mod > 0.95F) {
 			stam_floor += (mod - 0.95F) / stam_fscale;
 		}
@@ -333,12 +333,12 @@ JackStamAdjust(const float x, Calc& calc, const int hi)
 	return doot;
 }
 
-constexpr float magic_num = 16.F;
+constexpr float magic_num = 16.077566F;
 
 [[nodiscard]] inline auto
 hit_the_road(const float& x, const float& y) -> float
 {
-	return std::max(static_cast<float>(magic_num * erf(0.04F * (y - x))), 0.F);
+	return std::max(static_cast<float>(magic_num * erf(0.096623257F * (y - x))), 0.040538613F);
 }
 
 /* ok this is a little jank, we are calculating jack loss looping over the
@@ -516,7 +516,7 @@ Calc::InitializeHands(const std::vector<NoteInfo>& NoteInfo,
  * degree above the actual max points as a cheap hack to water down some of the
  * absurd scaling hs/js/cj had. Note: do not set these values below 1 */
 constexpr float tech_pbm = 1.F;
-constexpr float jack_pbm = 1.0175F;
+constexpr float jack_pbm = 1.0013144F;
 constexpr float stream_pbm = 1.01F;
 constexpr float bad_newbie_skillsets_pbm = 1.05F;
 
@@ -829,6 +829,16 @@ Calc::InitAdjDiff(Calc& calc, const int& hi)
 					auto b = calc.soap.at(hi).at(NPSBase).at(i) *
 							 tp_mods[Skill_Jumpstream];
 					*stam_base = max<float>(a, b);
+				} break;
+				case Skill_JackSpeed: {
+					if (i < calc.jack_diff.at(hi).size()) {
+						auto* jack_diff = &calc.jack_diff.at(hi).at(i).second;
+						if (*jack_diff > 0) {
+							auto tech_funk_at_jacks = calc.soap.at(hi).at(TechBase).at(i) * tp_mods.at(ss) * basescalers.at(ss);
+							tech_funk_at_jacks /= max<float>(calc.doot.at(hi).at(CJ).at(i) * calc.doot.at(hi).at(CJ).at(i), 1.0F);
+							*jack_diff = lerp(0.3179549F, *jack_diff, tech_funk_at_jacks / fastsqrt(*jack_diff));
+						}
+					}
 				} break;
 				case Skill_Chordjack:
 					*adj_diff *= fastsqrt(calc.doot.at(hi).at(CJOHJump).at(i));

--- a/src/Etterna/MinaCalc/PatternModHelpers.h
+++ b/src/Etterna/MinaCalc/PatternModHelpers.h
@@ -95,3 +95,9 @@ weighted_average(const float& a, const float& b, const float& x, const float& y)
 {
 	return (x * a + ((y - x) * b)) / y;
 }
+
+inline auto
+lerp(float t, float a, float b) -> float
+{
+	return (1.F - t)*a + t*b;
+}

--- a/src/Etterna/MinaCalc/UlbuAcolytes.h
+++ b/src/Etterna/MinaCalc/UlbuAcolytes.h
@@ -10,7 +10,7 @@
  * patterns have lower enps than streams, streams default to 1 and chordstreams
  * start lower, stam is a special case and may use normalizers again */
 static const std::array<float, NUM_Skillset> basescalers = {
-	0.F, 0.93F, 0.885F, 0.84F, 0.925F, 0.91F, 0.8F, 0.83F
+	0.F, 0.93F, 0.885F, 0.84F, 0.925F, 0.8833277F, 0.8F, 0.83F
 };
 
 static const std::string calc_params_xml = "Save/calc params.xml";


### PR DESCRIPTION
a

There is a lot to say about this PR but mostly you should just pull it and have a look. This substantially reduces overrated jackspeed outliers but is still pretty accurate on actual for real definitely-jackspeed files, at least going by mina's CalcTestList.xml and from what I can tell from my own profile. Non-jackspeed files are not changed. I think this change is pretty good, but I'm pretty ignorant about high level difficulty, and it might be that you don't want to use it and instead use my tooling to find a better set of changes.

I do make a change to how the jack_diff array is computed, this was necessary to preserve proper scaling with rates in certain situations. This is basically an inelegant hack to cover for the fact there are no jackspeed pattern mods.

Now, the good stuff: I really have no idea what any of the changed parameters do or mean. I don't even really know what the code I added does (although the `lerp` is just a weighted average between the old behaviour and the new behaviour). The reason I can do this at all is because a few months ago I made [seeminacalc](https://seeminacalc.glitch.me/) which turns out to be like, 85% of what you need to build an interactive calc-parameter optimizer. And it needs to be interactive cause the calc is not a well-behaved function at all. [The source for all this is here](https://github.com/graemephi/seeminacalc/tree/opt), but if you want to really use it properly you might have to talk to me first (getting new files into it will be pretty inscrutable for most people). I'm pretty much done thinking about this, but if there's interest, I can make it more user-friendly.

As far as I can tell, the way this parameterisation works is by making use of the change in 441. Basically, every file that gets the jackspeed chisel run on it gets its rating boosted significantly. But it is super sceptical about what files are jackspeed. This means you still have massively underrated files that are right on the border, but I think there might actually be fewer underrated files than before--you'll have to have someone who actually has any understanding of jackspeed difficulty to have a look.

The parameters that have been optimized over are just those that can actually change the rating of Busy? Or Dizzy? without changing every other files rating. Yes, they live in weird places in the code, and no, I don't use the XML stuff. Using every tuneable floating point literal in the calc is possible but treating the calc this way is prone to overfitting in surprising ways. For example, since jackspeed rating falls off as rate increases and the files enter garbage territory, the easiest way to fit a 32MSD file is to say, okay, that 32MSD file is actually a garbage file, and at 4 rates below, it's 36MSD. If you are just looking at the AA rating at a single rate for each file this is very hard to spot. Since running into this I've added regularisation to the optimizer so maybe this is not so bad now, but it's bad. An other example: if the optimizer isn't looking at the overall MSD, it will feel free to make every file a stamina file. The process just works better if you try to make focused changes rather than big sweeping ones. 