### PR TITLE
Make profile goals go from 99->AAA->4A->5A

### DIFF
--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/wifeTwirl.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/wifeTwirl.lua
@@ -537,7 +537,12 @@ t[#t + 1] =
 				if song and steps then
 					local goal = profile:GetEasiestGoalForChartAndRate(steps:GetChartKey(), getCurRateValue())
 					if goal then
-						self:settextf("%s\n%.2f%%", translated_info["GoalTarget"], goal:GetPercent() * 100)
+						local perc = notShit.round(goal:GetPercent() * 100000) / 1000
+						if (perc < 99.8) then
+							self:settextf("%s\n%.2f%%", translated_info["GoalTarget"], perc)
+						else
+							self:settextf("%s\n%.3f%%", translated_info["GoalTarget"], perc)
+						end
 					else
 						self:settext("")
 					end

--- a/Themes/Til Death/BGAnimations/goaldisplay.lua
+++ b/Themes/Til Death/BGAnimations/goaldisplay.lua
@@ -366,14 +366,16 @@ local function makeGoalDisplay(i)
 			{
 				--percent
 				InitCommand = function(self)
-					self:x(c1x):zoom(tzoom):halign(-0.5):valign(0)
+					self:x(c1x):zoom(tzoom):halign(-0.5):valign(0):maxwidth(capWideScale(10, 40) / tzoom)
 				end,
 				DisplayCommand = function(self)
-					local perc = notShit.floor(sg:GetPercent() * 10000) / 100
-					if perc < 99 then
+					local perc = notShit.round(sg:GetPercent() * 100000) / 1000
+					if perc <= 99 or perc == 100 then
 						self:settextf("%.f%%", perc)
-					else
+					elseif (perc < 99.8) then
 						self:settextf("%.2f%%", perc)
+					else
+						self:settextf("%.3f%%", perc)
 					end
 					self:diffuse(byAchieved(sg)):x(c1x + (2 * adjx) - self:GetZoomedWidth()) -- def doing this alignment wrong
 				end,

--- a/Themes/Til Death/BGAnimations/goaldisplay.lua
+++ b/Themes/Til Death/BGAnimations/goaldisplay.lua
@@ -366,7 +366,7 @@ local function makeGoalDisplay(i)
 			{
 				--percent
 				InitCommand = function(self)
-					self:x(c1x):zoom(tzoom):halign(-0.5):valign(0):maxwidth(capWideScale(10, 40) / tzoom)
+					self:x(c1x):zoom(tzoom):halign(-0.5):valign(0):maxwidth((50 - capWideScale(10, 10)) / tzoom)
 				end,
 				DisplayCommand = function(self)
 					local perc = notShit.round(sg:GetPercent() * 100000) / 1000

--- a/src/Etterna/Models/Misc/Profile.cpp
+++ b/src/Etterna/Models/Misc/Profile.cpp
@@ -1211,15 +1211,31 @@ class LunaScoreGoal : public Luna<ScoreGoal>
 	}
 
 	static int SetPercent(T* p, lua_State* L)
-	{
+	{	
 		if (!p->achieved) {
 			auto newpercent = FArg(1);
 			CLAMP(newpercent, .8f, 1.f);
-
-			if (p->percent < 0.995f && newpercent > 0.995f)
-				newpercent = 0.9975f;
-			if (p->percent < 0.9990f && newpercent > 0.9997f)
-				newpercent = 0.9997f;
+			if (newpercent > 0.99f)
+			{
+				if (p->percent < 0.99700f)
+					newpercent = 0.99700f; // AAA
+				else if (p->percent < 0.99955f)
+					newpercent = 0.99955f; // AAAA
+				else if (p->percent < 0.99996f)
+					newpercent = 0.99996f; // AAAAA
+			}
+			else if (newpercent > 0.985f)
+			{
+				if (p->percent > 0.99996f)
+					newpercent = 0.99996f; // AAAAA
+				else if (p->percent > 0.99955f)
+					newpercent = 0.99955f; // AAAA
+				else if (p->percent > 0.99700f)
+					newpercent = 0.99700f; // AAA
+				else
+					newpercent = 0.99f;
+			}
+			
 
 			p->percent = newpercent;
 			p->CheckVacuity();


### PR DESCRIPTION
Currently it goes from 99->99.75->99.97->100

This PR should also fix a bug when bringing a goal down from a number higher than 99 causing a different view to show (previous percentage - 1)

This PR should also expand the profile goals percentages and the screen select goals percentages decimal counts to 3 when necessary to hold 4A or 5A goals.