### PR TITLE
Update microsoft/ms-build from v1.0.0 to v1.0.2

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -79,7 +79,7 @@ jobs:
           path: dxsdk
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.0
+        uses: microsoft/setup-msbuild@v1.0.2
 
       - name: Install chocolatey packages (i386)
         if: ${{ matrix.cfg.arch == 'Win32' }}


### PR DESCRIPTION
This fixes the currently broken Windows CI by updating https://github.com/microsoft/setup-msbuild to v1.0.2 which removes the deprecated usage of add-path in CI.

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/