### PR TITLE
Add C++ Backend For New Filter Option -- Chart Clear %

### DIFF
--- a/src/Etterna/Actor/Menus/MusicWheel.cpp
+++ b/src/Etterna/Actor/Menus/MusicWheel.cpp
@@ -286,8 +286,9 @@ MusicWheel::SelectSongOrCourse() -> bool
 		}
 	}
 
-	Locator::getLogger()->trace("MusicWheel::MusicWheel() - No selectable songs or courses "
-			   "found in WheelData");
+	Locator::getLogger()->trace(
+	  "MusicWheel::MusicWheel() - No selectable songs or courses "
+	  "found in WheelData");
 	return false;
 }
 
@@ -693,7 +694,8 @@ void
 MusicWheel::FilterByAndAgainstStepKeys(vector<Song*>& inv)
 {
 	vector<Song*> tmp;
-	const std::function<bool(Song*, vector<string>&)> check = [this](Song* x, vector<string>& hl) {
+	const std::function<bool(Song*, vector<string>&)> check =
+	  [this](Song* x, vector<string>& hl) {
 		  for (auto& ck : hl) {
 			  if (x->HasChartByHash(ck)) {
 				  return true;
@@ -754,7 +756,7 @@ MusicWheel::FilterBySkillsets(vector<Song*>& inv)
 			 currate -= 0.1F) { /* Iterate over all possible rates.
 								 * The .01f delta is because floating points
 								 * don't like exact equivalency*/
-			if (song->MatchesFilter(currate + 0.001F)) {
+			if (song->MatchesFilter(currate)) {
 				addsong = true;
 				break; // We don't need to keep checking rates
 			}
@@ -1074,7 +1076,7 @@ MusicWheel::readyWheelItemsData(SortOrder so,
 
 		if (PREFSMAN->m_verbose_log > 0) {
 			Locator::getLogger()->trace("MusicWheel sorting took: {}",
-					   RageTimer::GetTimeSinceStart());
+										RageTimer::GetTimeSinceStart());
 		}
 	}
 }
@@ -1576,11 +1578,14 @@ MusicWheel::JumpToPrevGroup() -> std::string
 		// in case it wasn't found above:
 		for (auto i = static_cast<int>(m_CurWheelItemData.size() - 1U); i > 0;
 			 --i) {
-			Locator::getLogger()->trace("JumpToPrevGroup iteration 2 | i = {}", i);
+			Locator::getLogger()->trace("JumpToPrevGroup iteration 2 | i = {}",
+										i);
 			if (m_CurWheelItemData[i]->m_Type == WheelItemDataType_Section) {
 				m_iSelection = i;
-				Locator::getLogger()->trace("finding it in #2 | i = {} | text = {}",
-						   i, m_CurWheelItemData[i]->m_sText.c_str());
+				Locator::getLogger()->trace(
+				  "finding it in #2 | i = {} | text = {}",
+				  i,
+				  m_CurWheelItemData[i]->m_sText.c_str());
 				return m_CurWheelItemData[i]->m_sText;
 			}
 		}
@@ -1776,7 +1781,7 @@ class LunaMusicWheel : public Luna<MusicWheel>
 		LuaHelpers::ReadArrayFromTable(newHashList, L);
 		lua_pop(L, 1);
 		p->SetHashList(newHashList);
-		
+
 		std::vector<string> newOutHashList;
 		p->SetOutHashList(newOutHashList);
 

--- a/src/Etterna/Models/Songs/Song.cpp
+++ b/src/Etterna/Models/Songs/Song.cpp
@@ -1662,7 +1662,7 @@ Song::GetChartsMatchingFilter() const
 			// converting the rate to an index within GetMSD
 			// TODO: less hacky solution for this (this isnt the only place we
 			// do this)
-			if (ChartMatchesFilter(i, currate + 0.001F)) {
+			if (ChartMatchesFilter(i, currate)) {
 				// chart matched on a rate, add it only once
 				matches.push_back(i);
 				break;
@@ -1709,7 +1709,6 @@ Song::MatchesFilter(const float rate,
 
 	for (auto* const chart : charts) {
 		// Iterate over all charts of the given type
-
 		bool addchart = ChartMatchesFilter(chart, rate);
 
 		// terminate early if not grabbing each matching chart
@@ -1730,7 +1729,6 @@ Song::MatchesFilter(const float rate,
 bool
 Song::ChartMatchesFilter(Steps* chart, float rate) const
 {
-	// TODO: ADD CHECKS FOR CLEAR %
 	auto matches_skills = FILTERMAN->ExclusiveFilter;
 	/* The default behaviour of an exclusive filter is to accept
 	 * by default, (i.e. matches_skills=true) and reject if any skill
@@ -1753,14 +1751,14 @@ Song::ChartMatchesFilter(Steps* chart, float rate) const
 				 */
 				if (FILTERMAN->HighestSkillsetsOnly && ss < NUM_Skillset) {
 					if (!chart->IsSkillsetHighestOfChart(
-						  static_cast<Skillset>(ss), rate)) {
+						  static_cast<Skillset>(ss), rate + 0.001F)) {
 						// The current skill is not the highest of the chart
 						continue;
 					}
 				}
 				if (FILTERMAN->HighestDifficultyOnly && ss < NUM_Skillset) {
 					if (!IsChartHighestDifficulty(
-						  chart, static_cast<Skillset>(ss), rate)) {
+						  chart, static_cast<Skillset>(ss), rate + 0.001F)) {
 						// The song has a more difficult chart of the given
 						// skillset
 						continue;
@@ -1769,7 +1767,7 @@ Song::ChartMatchesFilter(Steps* chart, float rate) const
 			}
 			float val;
 			if (ss < NUM_Skillset) {
-				val = chart->GetMSD(rate, ss);
+				val = chart->GetMSD(rate + 0.001F, ss);
 			} else if (ss == NUM_Skillset) {
 				// If we are on the first placeholder skillset, look at chart
 				// length instead of a skill
@@ -1777,9 +1775,17 @@ Song::ChartMatchesFilter(Steps* chart, float rate) const
 			} else { // ss == NUM_Skillset + 1
 				// If we are on the second placeholder skillset, look at best
 				// clear percent instead of a skill
-				// TODO: ADD IN MAGIC "GET BEST CLEAR% VALUE HERE"
-				continue; // Unimplemented
+				const auto score =
+				  SCOREMAN->GetChartPBAt(chart->GetChartKey(), rate);
+				if (score == nullptr) {
+					val = 0;
+				} else if (PREFSMAN->m_bSortBySSRNorm) {
+					val = 100 * score->GetSSRNormPercent();
+				} else {
+					val = 100 * score->GetWifeScore();
+				}
 			}
+
 			if (FILTERMAN->ExclusiveFilter) {
 				/* Our behaviour is to accept by default,
 				 * but reject if any filters don't match.*/

--- a/src/Etterna/Models/Songs/SongUtil.cpp
+++ b/src/Etterna/Models/Songs/SongUtil.cpp
@@ -71,7 +71,7 @@ SongUtil::GetSteps(const Song* pSong,
 			for (auto currate = FILTERMAN->MaxFilterRate;
 				 currate > FILTERMAN->MinFilterRate - .01f;
 				 currate -= 0.1f) {
-				if (pSong->ChartMatchesFilter(pSteps, currate + 0.001f)) {
+				if (pSong->ChartMatchesFilter(pSteps, currate)) {
 					success = true;
 					break;
 				}
@@ -293,14 +293,15 @@ SongUtil::DeleteDuplicateSteps(Song* pSong, vector<Steps*>& vSteps)
 				RemoveInitialWhitespace(sSMNoteData2))
 				continue;
 
-			Locator::getLogger()->trace("Removed {} duplicate steps in song \"{}\" with "
-					   "description \"{}\", step author \"{}\", and meter "
-					   "\"{}\"",
-					   (void*)s2,
-					   pSong->GetSongDir().c_str(),
-					   s1->GetDescription().c_str(),
-					   s1->GetCredit().c_str(),
-					   s1->GetMeter());
+			Locator::getLogger()->trace(
+			  "Removed {} duplicate steps in song \"{}\" with "
+			  "description \"{}\", step author \"{}\", and meter "
+			  "\"{}\"",
+			  (void*)s2,
+			  pSong->GetSongDir().c_str(),
+			  s1->GetDescription().c_str(),
+			  s1->GetCredit().c_str(),
+			  s1->GetMeter());
 
 			pSong->DeleteSteps(s2, false);
 

--- a/src/Etterna/Singletons/FilterManager.cpp
+++ b/src/Etterna/Singletons/FilterManager.cpp
@@ -52,7 +52,8 @@ FilterManager::SetSSFilter(float v, Skillset ss, int bound)
 void
 FilterManager::ResetSSFilters()
 {
-	for (int ss = 0; ss < NUM_Skillset + 1; ss++) {
+	for (int ss = 0; ss < NUM_Skillset + 2; ss++) {
+		// Skillsets + 2 other values (time, clear %)
 		SSFilterLowerBounds[ss] = 0;
 		SSFilterUpperBounds[ss] = 0;
 	}
@@ -65,7 +66,6 @@ FilterManager::ResetAllFilters()
 	ExclusiveFilter = false;
 	HighestSkillsetsOnly = false;
 	HighestDifficultyOnly = false;
-
 	MinFilterRate = 1.F;
 	MaxFilterRate = 1.F;
 }
@@ -74,7 +74,8 @@ FilterManager::ResetAllFilters()
 bool
 FilterManager::AnyActiveFilter()
 {
-	for (int ss = 0; ss < NUM_Skillset + 1; ss++) {
+	for (int ss = 0; ss < NUM_Skillset + 2; ss++) {
+		// Skillsets + 2 other values (time, clear %)
 		if (SSFilterLowerBounds[ss] > 0)
 			return true;
 		if (SSFilterUpperBounds[ss] > 0)

--- a/src/Etterna/Singletons/FilterManager.h
+++ b/src/Etterna/Singletons/FilterManager.h
@@ -13,8 +13,19 @@ class FilterManager
 
 	PlayerState* m_pPlayerState;
 
-	float SSFilterLowerBounds[NUM_Skillset + 1];
-	float SSFilterUpperBounds[NUM_Skillset + 1];
+	float SSFilterLowerBounds[NUM_Skillset + 2] = { 0 }; // Zero-initialize
+	float SSFilterUpperBounds[NUM_Skillset + 2] = { 0 }; // Zero-initialize
+	/* Skill_Overall,
+	 * Skill_Stream,
+	 * Skill_Jumpstream,
+	 * Skill_Handstream,
+	 * Skill_Stamina,
+	 * Skill_JackSpeed,
+	 * Skill_Chordjack,
+	 * Skill_Technical,
+	 * Length, //REQUIRED in non-exclusive filter if set
+	 * Clear % //REQUIRED in non-exclusive filter if set
+	 */
 	float MaxFilterRate = 1.F;
 	float MinFilterRate = 1.F;
 	bool ExclusiveFilter = false; // if true the filter system will only match


### PR DESCRIPTION
This adds in a new filter option -- a clear % range.

Charts are only matched in the filter if the player's best score percent on a chart falls between the lower and upper bounds.
This also respects the SSRNormSort option -- if it is enabled, that clear % is used, if it is disabled, the % of the judge used when the song was played is used instead.

This also introduces a small filter change -- certain filter options (currently duration and clear %) must be matched, even in a non-exclusive filter.
This is done because no-one wants to filter for "Charts that are (between 21-23 JS), (between 20-22 HS), or (have been cleared with at least 60%)", they want "Charts that are ((between 21-23 JS) or (between 20-22 HS)) *and* (have been cleared with at least 60%)".

The easiest way to test this new filter option is to modify `FilterManager::ResetSSFilters()` by temporarily adding in lines like the following at the end for testing:
```	
SSFilterLowerBounds[NUM_Skillset+1] = 70;
SSFilterUpperBounds[NUM_Skillset+1] = 90;
```
