### PR TITLE
Avoid stack overflow caused by ChartMatchesFilter calling HighestMSDOfSkillset which called ChartMatchesFilter itself

### DIFF
--- a/src/Etterna/Models/Songs/Song.h
+++ b/src/Etterna/Models/Songs/Song.h
@@ -339,7 +339,9 @@ class Song
 
 	// Get the highest value for a specific skillset across all the steps
 	// objects for the song at a given rate
-	[[nodiscard]] auto HighestMSDOfSkillset(Skillset x, float rate) const
+	[[nodiscard]] auto HighestMSDOfSkillset(Skillset x,
+											float rate,
+											bool filtered_charts_only) const
 	  -> float;
 	[[nodiscard]] auto IsSkillsetHighestOfChart(Steps* chart,
 												Skillset skill,

--- a/src/Etterna/Models/Songs/SongUtil.cpp
+++ b/src/Etterna/Models/Songs/SongUtil.cpp
@@ -293,14 +293,15 @@ SongUtil::DeleteDuplicateSteps(Song* pSong, vector<Steps*>& vSteps)
 				RemoveInitialWhitespace(sSMNoteData2))
 				continue;
 
-			Locator::getLogger()->trace("Removed {} duplicate steps in song \"{}\" with "
-					   "description \"{}\", step author \"{}\", and meter "
-					   "\"{}\"",
-					   (void*)s2,
-					   pSong->GetSongDir().c_str(),
-					   s1->GetDescription().c_str(),
-					   s1->GetCredit().c_str(),
-					   s1->GetMeter());
+			Locator::getLogger()->trace(
+			  "Removed {} duplicate steps in song \"{}\" with "
+			  "description \"{}\", step author \"{}\", and meter "
+			  "\"{}\"",
+			  (void*)s2,
+			  pSong->GetSongDir().c_str(),
+			  s1->GetDescription().c_str(),
+			  s1->GetCredit().c_str(),
+			  s1->GetMeter());
 
 			pSong->DeleteSteps(s2, false);
 
@@ -388,9 +389,9 @@ CompareSongPointersByMSD(const Song* pSong1, const Song* pSong2, Skillset ss)
 {
 	// Prefer transliterations to full titles
 	const auto msd1 = pSong1->HighestMSDOfSkillset(
-	  ss, GAMESTATE->m_SongOptions.Get(ModsLevel_Current).m_fMusicRate);
+	  ss, GAMESTATE->m_SongOptions.Get(ModsLevel_Current).m_fMusicRate, true);
 	const auto msd2 = pSong2->HighestMSDOfSkillset(
-	  ss, GAMESTATE->m_SongOptions.Get(ModsLevel_Current).m_fMusicRate);
+	  ss, GAMESTATE->m_SongOptions.Get(ModsLevel_Current).m_fMusicRate, true);
 
 	if (msd1 < msd2)
 		return true;


### PR DESCRIPTION

This was caused by a previous change which made HighestMSDOfSkillset only consider filter-matching charts, in order to fix sorting by skillset difficulties.
This had the side effect of breaking the filter option of highest difficulty only, which also used the same function.

This commit fixes the issue by adding in a boolean flag to HighestMSDOfSkillset, which toggles between considering filtered charts and charts of the current game mode.