### PR TITLE
Fix macOS platform function openFolder

### DIFF
--- a/src/Core/Platform/PlatformMac.mm
+++ b/src/Core/Platform/PlatformMac.mm
@@ -87,9 +87,10 @@ namespace Core::Platform {
             Locator::getLogger()->warn("Could not open folder. Note a folder. Path: \"{}\"", path.string());
             return false;
         }
-        int res = system(fmt::format("open {}", path.string()).c_str());
-        if(res != 0){
-            Locator::getLogger()->warn("Unable to open folder. \"open\" command return code: {}. URL: {}", res, path.string());
+		NSURL* directory = [NSURL fileURLWithPath:@(path.c_str())];
+		bool succeeded = [[NSWorkspace sharedWorkspace]openURL:directory];
+		if(!succeeded){
+            Locator::getLogger()->warn("Unable to open folder: {}", path.string());
             return false;
         }
         return true;


### PR DESCRIPTION
This replaces the earlier broken way with the correct Objective-C way to do it.

Note: I'm not familiar with Objective C, and this solution was created with 15 mins of googling.
It's possible that there's some subtle mistake I'm missing here.

It does work properly with odd UTF filenames including non-ascii characters from my limited testing.