### PR TITLE
Fix 404 error parsing of top/25 API answer

### DIFF
--- a/src/Etterna/Singletons/DownloadManager.cpp
+++ b/src/Etterna/Singletons/DownloadManager.cpp
@@ -2019,8 +2019,9 @@ DownloadManager::RefreshTop25(Skillset ss)
 	auto done = [ss](HTTPRequest& req, CURLMsg*) {
 		Document d;
 		if (d.Parse(req.result.c_str()).HasParseError() ||
-			(d.HasMember("errors") && d["errors"].HasMember("status") &&
-			 d["errors"]["status"].GetInt() == 404) ||
+			(d.HasMember("errors") && d["errors"].IsArray() &&
+			 d["errors"][0].HasMember("status") &&
+			 d["errors"][0]["status"].GetInt() == 404) ||
 			!d.HasMember("data") || !d["data"].IsArray()) {
 			Locator::getLogger()->trace(
 			  "Malformed top25 scores request response: {}", req.result);


### PR DESCRIPTION
In the JSON returned by the API, "errors" is an array, not an object: this lead to a failed assert in the d["errors"].HasMember() call.

I got this crash while loging in, as a new user with no score on etternaonline, this probably affects every new user.

The handling of API returned "errors" is inconsistent in the download manager at this point, this should probably get worked on in the future.