### PR TITLE
Make external builds not break from local CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ add_subdirectory(src/Core)
 
 ## The source_group line creates the full visual studio filter layout
 get_target_property(sources Etterna SOURCES)
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} PREFIX "Etterna" FILES ${sources})
+source_group(TREE ${CMAKE_SOURCE_DIR} PREFIX "Etterna" FILES ${sources})
 
 # Static Analysis
 include(CMake/Helpers/StaticAnalysis.cmake)

--- a/src/Etterna/CMakeLists.txt
+++ b/src/Etterna/CMakeLists.txt
@@ -15,4 +15,4 @@ add_subdirectory(Singletons)
 
 # Generated Source Code
 include(${PROJECT_SOURCE_DIR}/CMake/Helpers/SetupGit.cmake)
-configure_file(config.in.hpp ${CMAKE_BINARY_DIR}/generated/config.hpp)
+configure_file(config.in.hpp ${PROJECT_BINARY_DIR}/generated/config.hpp)


### PR DESCRIPTION
This commit **should** allow using Etterna's CMake structures externally for projects that depend on certain library-like functionalities within Etterna like NoteLoader or MinaCalc without removing the ability to build or functionalities of the CMakeLists altered.

The CI passes, however I have only tested this change in linux