### PR TITLE
Add new sort mode -- Ungrouped

### DIFF
--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic overlay/currentsort.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic overlay/currentsort.lua
@@ -39,7 +39,8 @@ local sortTable = {
 	SortOrder_Stamina = THEME:GetString("SortOrder", "Stamina"),
 	SortOrder_JackSpeed = THEME:GetString("SortOrder", "JackSpeed"),
 	SortOrder_Chordjack = THEME:GetString("SortOrder", "Chordjack"),
-	SortOrder_Technical = THEME:GetString("SortOrder", "Technical")
+	SortOrder_Technical = THEME:GetString("SortOrder", "Technical"),
+	SortOrder_Ungrouped = THEME:GetString("SortOrder", "Ungrouped")
 }
 
 local translated_info = {

--- a/Themes/_fallback/Languages/en.ini
+++ b/Themes/_fallback/Languages/en.ini
@@ -343,6 +343,7 @@ ChordjackText=Chordjack
 TechnicalText=Technical
 LengthText=Length
 TopGradesText=Top Grades
+UngroupedText=Ungrouped
 
 [NetworkSyncManager]
 LoginTimeout=Login timed out.
@@ -2046,6 +2047,7 @@ BPM=BPM
 Genre=Genre
 Group=Group
 Length=Length
+Ungrouped=Ungrouped
 ModeMenu=Mode Menu
 Popularity=Players' Best
 Preferred=Preferred

--- a/Themes/_fallback/metrics.ini
+++ b/Themes/_fallback/metrics.ini
@@ -592,7 +592,7 @@ SortOrders={ "SortOrder_Group", "SortOrder_Title", "SortOrder_BPM", "SortOrder_A
 ShowSectionsInBPMSort=true
 SortBPMDivision=20
 
-ModeMenuChoiceNames="Group,Title,Bpm,TopGrades,Artist,Genre,Favorites,Overall,Stream,Jumpstream,Handstream,Stamina,JackSpeed,Chordjack,Technical,Length"
+ModeMenuChoiceNames="Group,Title,Bpm,TopGrades,Artist,Genre,Favorites,Overall,Stream,Jumpstream,Handstream,Stamina,JackSpeed,Chordjack,Technical,Length,Ungrouped"
 ChoiceGroup="sort,Group"
 ChoiceTitle="sort,Title"
 ChoiceBpm="sort,BPM"
@@ -609,6 +609,7 @@ ChoiceJackSpeed="sort,JackSpeed"
 ChoiceChordjack="sort,Chordjack"
 ChoiceTechnical="sort,Technical"
 ChoiceLength="sort,Length"
+ChoiceUngrouped="sort,Ungrouped"
 
 CustomWheelItemNames=""
 

--- a/src/Etterna/Actor/Menus/MusicWheel.cpp
+++ b/src/Etterna/Actor/Menus/MusicWheel.cpp
@@ -853,6 +853,8 @@ MusicWheel::BuildWheelItemDatas(
 					  GAMESTATE->m_sPreferredSongGroup == GROUP_ALL;
 				}
 				break;
+			case SORT_Ungrouped:
+				[[fallthrough]];
 			case SORT_TITLE:
 				SongUtil::SortSongPointerArrayByTitle(arraySongs);
 				break;
@@ -1749,7 +1751,7 @@ class LunaMusicWheel : public Luna<MusicWheel>
 		p->ReloadSongList(true, SArg(1));
 		return 1;
 	}
-	static auto ReloadSongList(T* p, lua_State * /*L*/) -> int
+	static auto ReloadSongList(T* p, lua_State* /*L*/) -> int
 	{
 		p->ReloadSongList(false, "");
 		return 1;

--- a/src/Etterna/Models/Misc/GameConstantsAndTypes.cpp
+++ b/src/Etterna/Models/Misc/GameConstantsAndTypes.cpp
@@ -85,12 +85,12 @@ static const char* GameplayModeNames[] = {
 XToString(GameplayMode);
 LuaXType(GameplayMode);
 
-static const char* SortOrderNames[] = { "Group",	 "Title",	   "BPM",
-										"TopGrades", "Artist",	   "Genre",
-										"ModeMenu",	 "Favorites",  "Overall",
-										"Stream",	 "Jumpstream", "Handstream",
-										"Stamina",	 "JackSpeed",  "Chordjack",
-										"Technical", "Length" };
+static const char* SortOrderNames[] = {
+	"Group",	  "Title",		"BPM",		 "TopGrades", "Artist",
+	"Genre",	  "ModeMenu",	"Favorites", "Overall",	  "Stream",
+	"Jumpstream", "Handstream", "Stamina",	 "JackSpeed", "Chordjack",
+	"Technical",  "Length",		"Ungrouped"
+};
 XToString(SortOrder);
 StringToX(SortOrder);
 LuaXType(SortOrder);
@@ -269,7 +269,7 @@ LuaXType(CalcDiffValue);
 static const char* CalcDebugMiscNames[] = { "Pts",
 											"PtLoss",
 											//"JackPtLoss",
-											"StamMod"};
+											"StamMod" };
 XToString(CalcDebugMisc);
 LuaXType(CalcDebugMisc);
 

--- a/src/Etterna/Models/Misc/GameConstantsAndTypes.h
+++ b/src/Etterna/Models/Misc/GameConstantsAndTypes.h
@@ -147,6 +147,8 @@ enum SortOrder
 	SORT_Chordjack,
 	SORT_Technical,
 	SORT_LENGTH,
+	SORT_Ungrouped, /**< Sort by the song title, putting all songs into single
+					   group. */
 	NUM_SortOrder,
 	SortOrder_Invalid
 };

--- a/src/Etterna/Models/Songs/SongUtil.cpp
+++ b/src/Etterna/Models/Songs/SongUtil.cpp
@@ -737,6 +737,8 @@ SongUtil::GetSectionNameFromSongAndSort(const Song* pSong, SortOrder so)
 		}
 		case SORT_MODE_MENU:
 			return std::string();
+		case SORT_Ungrouped:
+			return "";
 		default:
 			FAIL_M(ssprintf("Invalid SortOrder: %i", so));
 	}


### PR DESCRIPTION
The Ungrouped sort sorts song by title, placing every song into a single group.
This is mainly intended to be used with filters and/or playlists.

TODO: Add non-English translations for new Ungrouped Sort Mode text.