### PR TITLE
🔑 macOS Auto-Untranslocation

### DIFF
--- a/src/Core/Misc/PlogLogger.cpp
+++ b/src/Core/Misc/PlogLogger.cpp
@@ -48,22 +48,6 @@ public:
 };
 
 PlogLogger::PlogLogger() {
-    // Get current time for log file name. Format: YYYY_MM_DD-HH_MM_SS.log
-    char timeString[20]; // Date and time portion only
-    std::time_t t = std::time(nullptr);
-    std::strftime(timeString, sizeof(timeString), "%Y_%m_%d-%H_%M_%S", std::localtime(&t));
-    auto logDirectory = Core::Platform::getAppDirectory() / "Logs";
-
-    // Ensure log directory exists before initializing logger.
-    if(!ghc::filesystem::exists(logDirectory))
-        ghc::filesystem::create_directory(logDirectory);
-
-    auto logFilePath = logDirectory / fmt::format(FMT_STRING("{}.log"), timeString);
-
-    // File Appender
-    static plog::RollingFileAppender<EtternaFormatter, plog::UTF8Converter> rollingFileAppender{logFilePath.c_str()};
-    plog::init(plog::Severity::info, &rollingFileAppender);
-
     // Console Appender. One for windows, and another for other operating systems.
     #ifdef _WIN32
         static plog::WindowsAppender<EtternaFormatter> consoleAppender;
@@ -71,6 +55,31 @@ PlogLogger::PlogLogger() {
         static plog::ColorConsoleAppender<EtternaFormatter> consoleAppender;
     #endif
     plog::init(plog::Severity::info, &consoleAppender);
+
+
+    // Get current time for log file name. Format: YYYY_MM_DD-HH_MM_SS.log
+    char timeString[20]; // Date and time portion only
+    std::time_t t = std::time(nullptr);
+    std::strftime(timeString, sizeof(timeString), "%Y_%m_%d-%H_%M_%S", std::localtime(&t));
+    auto logDirectory = Core::Platform::getAppDirectory() / "Logs";
+
+    namespace fs = ghc::filesystem;
+    // Ensure log directory exists and is writable before initializing logger.
+    auto appDirPerms = fs::status(Core::Platform::getAppDirectory()).permissions();
+    auto writable = (appDirPerms & (fs::perms::owner_write )) != fs::perms::none;
+
+    // If not writable, only output to console.
+    if(!writable)
+        return;
+
+    if(!fs::exists(logDirectory))
+        fs::create_directory(logDirectory);
+
+    auto logFilePath = logDirectory / fmt::format(FMT_STRING("{}.log"), timeString);
+
+    // File Appender
+    static plog::RollingFileAppender<EtternaFormatter, plog::UTF8Converter> rollingFileAppender{logFilePath.c_str()};
+    plog::init(plog::Severity::info, &rollingFileAppender);
 }
 
 void PlogLogger::log(Core::ILogger::Severity logLevel, const std::string_view message) {

--- a/src/Core/Platform/PlatformMac.mm
+++ b/src/Core/Platform/PlatformMac.mm
@@ -22,6 +22,13 @@ static std::string getSysctlName(const char* name) {
 }
 
 // Apple API Translocation variables
+// Apple introduced app translocation in macOS Sierra v10.12, which prevents apps from accessing files outside
+// their own .app directory (via a relative reference). This is a problem for Etterna since all files are accessed with
+// relative references to where the .app directory is located. Apple moves the app to a secure location, then
+// attempts to run the program. Etterna fails right away as it requires those local files. The code in init()
+// will load Apple's private security API, load the functions, and call on them to untranslocate by removing
+// the quarantine restriction on the original binary location. Apple will not accept the app into their app store
+// unless this code is removed.
 void (*mySecTranslocateIsTranslocatedURL)(CFURLRef path, bool *isTranslocated, CFErrorRef* __nullable error);
 CFURLRef __nullable (*mySecTranslocateCreateOriginalPathForURL)(CFURLRef translocatedPath, CFErrorRef * __nullable error);
 


### PR DESCRIPTION
# Getting around Apple Security
Apple introduced app translocation in macOS Sierra v10.12, which prevents apps from accessing files outside their own .app directory (via a relative reference). This is a problem for Etterna since all files are accessed with relative references to where the .app directory is located. Apple moves the app to a secure location, then attempts to run the program. Etterna fails right away as it requires those local files. The code in init() will load Apple's private security API, load the functions, and call on them to untranslocate by removing the quarantine restriction on the original binary location. Apple will not accept the app into their app store unless this code is removed.

# Requirements before merge
- [x] Testing on macOS Catalina
- [x] Testing on macOS Big Sur