### PR TITLE
Mount /rootfs so linux audio drivers work

### DIFF
--- a/src/Etterna/Globals/StepMania.cpp
+++ b/src/Etterna/Globals/StepMania.cpp
@@ -995,6 +995,13 @@ sm_main(int argc, char* argv[])
 	FILEMAN = new RageFileManager(argv[0]);
 	FILEMAN->Mount("dir", Core::Platform::getAppDirectory(), "/");
 
+#ifdef __unix__
+	/* Mount the root filesystem, so we can read files in /proc, /etc, and so
+	 * on. This is /rootfs, not /root, to avoid confusion with root's home
+	 * directory. */
+	FILEMAN->Mount("dir", "/", "/rootfs");
+#endif
+
 	// load preferences and mount any alternative trees.
 	PREFSMAN = new PrefsManager;
 


### PR DESCRIPTION
The ALSA-sw driver needs to be able to access /proc/asound in order to work. This was previously done by mounting / as /rootfs and then accessing "/rootfs/proc/asound".
Ex:
https://github.com/etternagame/etterna/blob/021eae5f9ffe1a0c9edf3003c129b48ac636cf6c/src/arch/Sound/ALSA9Dynamic.cpp#L34
 In 52dcd2c769dd2b6780f0f210360a8ac33a2c6334, the /rootfs mount was removed, which broke all linux audio.

In this pr, I put the /rootfs mount back as close as I could to where it was before - but the code structure has changed enough that there may be a better place for it.