### PR TITLE
Fix more clang's compile-time warnings

### DIFF
--- a/src/Etterna/Actor/Gameplay/NoteDisplay.cpp
+++ b/src/Etterna/Actor/Gameplay/NoteDisplay.cpp
@@ -1121,7 +1121,7 @@ NoteDisplay::DrawHoldPart(vector<Sprite*>& vpSpr,
 
 		// (step 2 of vector handling)
 		RageVector3 render_left;
-		if (abs(render_forward.z) > 0.9f) // 0.9 arbitrariliy picked.
+		if (std::abs(render_forward.z) > 0.9f) // 0.9 arbitrariliy picked.
 		{
 			RageVec3Cross(&render_left, &pos_y_vec, &render_forward);
 		} else {

--- a/src/Etterna/Actor/Menus/MusicWheel.cpp
+++ b/src/Etterna/Actor/Menus/MusicWheel.cpp
@@ -120,7 +120,6 @@ MusicWheel::BeginScreen()
 	{
 		const auto& from = getWheelItemsData(SORT_MODE_MENU);
 		for (auto* i : from) {
-			assert(&*i->m_pAction != nullptr);
 			if (i->m_pAction->DescribesCurrentModeForAllPlayers()) {
 				m_sLastModeMenuItem = i->m_pAction->m_sName;
 				break;

--- a/src/Etterna/Actor/Menus/OptionRow.cpp
+++ b/src/Etterna/Actor/Menus/OptionRow.cpp
@@ -407,7 +407,6 @@ OptionRow::AfterImportOptions(PlayerNumber pn)
 		PlayerNumber pnCopyFrom = GAMESTATE->GetMasterPlayerNumber();
 		if (GAMESTATE->GetMasterPlayerNumber() == PLAYER_INVALID)
 			pnCopyFrom = PLAYER_1;
-		m_vbSelected = m_vbSelected; // haha this doesnt do anything -poco
 	}
 
 	switch (m_pHand->m_Def.m_selectType) {

--- a/src/Etterna/FileTypes/XmlFile.h
+++ b/src/Etterna/FileTypes/XmlFile.h
@@ -4,6 +4,8 @@
 #define XML_FILE_H
 
 #include <map>
+#include <string>
+#include <vector>
 
 struct DateTime;
 class RageFileBasic;

--- a/src/Etterna/Models/CMakeLists.txt
+++ b/src/Etterna/Models/CMakeLists.txt
@@ -157,7 +157,6 @@ list(APPEND REST_HPP
 	"Misc/DisplaySpec.h"
 	"Misc/Difficulty.h"
 	"Misc/EnumHelper.h"
-	"Misc/EnumHelper.h"
 	"Misc/Foreach.h"
 	"Misc/Game.h"
 	"Misc/GameCommand.h"

--- a/src/Etterna/Models/Lua/LuaBinding.cpp
+++ b/src/Etterna/Models/Lua/LuaBinding.cpp
@@ -51,7 +51,8 @@ RegisterTypes(lua_State* L)
 		mapToRegister.erase(pBinding->GetClassName());
 	}
 }
-} // namespace;
+} // namespace
+
 REGISTER_WITH_LUA_FUNCTION(RegisterTypes);
 
 LuaBinding::LuaBinding()

--- a/src/Etterna/Models/Lua/LuaBinding.h
+++ b/src/Etterna/Models/Lua/LuaBinding.h
@@ -62,7 +62,7 @@ class Luna : public LuaBinding
 
 		// fill method table with methods from class T
 		for (auto const& m : m_aMethods) {
-			lua_pushlightuserdata(L, (void*)m.mfunc);
+			lua_pushlightuserdata(L, reinterpret_cast<void*>(m.mfunc));
 			lua_pushcclosure(L, thunk, 1);
 			lua_setfield(L, iMethods, m.regName.c_str());
 		}
@@ -95,7 +95,7 @@ class Luna : public LuaBinding
 
 	static auto get(lua_State* L, int narg) -> T*
 	{
-		return (T*)GetPointerFromStack(L, m_sClassName, narg);
+		return reinterpret_cast<T*>(GetPointerFromStack(L, m_sClassName, narg));
 	}
 
 	/* Push a table or userdata for the given object.  This is called on the
@@ -118,7 +118,7 @@ class Luna : public LuaBinding
 		lua_remove(L,
 				   1); // remove self so member function args start at index 1
 		// get member function from upvalue
-		binding_t* pFunc = (binding_t*)lua_touserdata(L, lua_upvalueindex(1));
+		auto* pFunc = reinterpret_cast<binding_t*>(lua_touserdata(L, lua_upvalueindex(1)));
 		return pFunc(obj, L); // call member function
 	}
 

--- a/src/Etterna/Models/Misc/CubicSpline.cpp
+++ b/src/Etterna/Models/Misc/CubicSpline.cpp
@@ -234,9 +234,9 @@ loop_space_difference(float a, float b, float spatial_extent)
 	}
 	const auto plus_diff = a - (b + spatial_extent);
 	const auto minus_diff = a - (b - spatial_extent);
-	const auto abs_norm_diff = abs(norm_diff);
-	const auto abs_plus_diff = abs(plus_diff);
-	const auto abs_minus_diff = abs(minus_diff);
+	const auto abs_norm_diff = std::abs(norm_diff);
+	const auto abs_plus_diff = std::abs(plus_diff);
+	const auto abs_minus_diff = std::abs(minus_diff);
 	if (abs_norm_diff < abs_plus_diff) {
 		if (abs_norm_diff < abs_minus_diff) {
 			return norm_diff;

--- a/src/Etterna/Models/Misc/DBProfile.cpp
+++ b/src/Etterna/Models/Misc/DBProfile.cpp
@@ -143,7 +143,7 @@ DBProfile::LoadFavourites(SQLite::Database* db)
 		loadingProfile->FavoritedCharts.emplace(key);
 	}
 	SONGMAN->SetFavoritedStatus(loadingProfile->FavoritedCharts);
-	SONGMAN->MakePlaylistFromFavorites(loadingProfile->FavoritedCharts);
+	SongManager::MakePlaylistFromFavorites(loadingProfile->FavoritedCharts);
 }
 
 void

--- a/src/Etterna/Models/Misc/DBProfile.cpp
+++ b/src/Etterna/Models/Misc/DBProfile.cpp
@@ -20,14 +20,14 @@ const string PROFILE_DB = "profile.db";
 const string WRITE_ONLY_PROFILE_DB = "webprofile.db";
 
 ProfileLoadResult
-DBProfile::LoadDBFromDir(std::string dir, Profile* profile)
+DBProfile::LoadDBFromDir(const std::string& dir, Profile* profile)
 {
 	loadingProfile = profile;
 	return LoadDBFromDir(dir);
 }
 
 ProfileLoadResult
-DBProfile::LoadDBFromDir(std::string dir)
+DBProfile::LoadDBFromDir(const std::string& dir)
 {
 	SQLite::Database* db;
 	try {
@@ -450,7 +450,7 @@ DBProfile::LoadScoreGoals(SQLite::Database* db)
 }
 
 ProfileLoadResult
-DBProfile::SaveDBToDir(string dir,
+DBProfile::SaveDBToDir(const string& dir,
 					   const Profile* profile,
 					   DBProfileMode mode) const
 {
@@ -1013,7 +1013,7 @@ DBProfile::SavePlayerScores(SQLite::Database* db,
 	}
 }
 int
-DBProfile::GetChartKeyID(SQLite::Database* db, string key)
+DBProfile::GetChartKeyID(SQLite::Database* db, const string& key)
 {
 	SQLite::Statement query(*db, "SELECT * FROM chartkeys WHERE chartkey=?");
 	query.bind(1, key);
@@ -1033,17 +1033,17 @@ DBProfile::GetChartKeyByID(SQLite::Database* db, int id)
 }
 
 int
-DBProfile::FindOrCreateChartKey(SQLite::Database* db, string key)
+DBProfile::FindOrCreateChartKey(SQLite::Database* db, const string& key)
 {
 	const auto exists = GetChartKeyID(db, key);
-	if (exists)
+	if (exists != 0)
 		return exists;
 	db->exec("INSERT INTO chartkeys VALUES (NULL, \"" + key + "\")");
 	return static_cast<int>(sqlite3_last_insert_rowid(db->getHandle()));
 }
 
 int
-DBProfile::FindOrCreateSong(SQLite::Database* db, string pack, string song)
+DBProfile::FindOrCreateSong(SQLite::Database* db, const string& pack, const string& song)
 {
 	SQLite::Statement query(
 	  *db, "SELECT songs.id FROM songs WHERE song=? AND pack =?");
@@ -1063,9 +1063,9 @@ DBProfile::FindOrCreateSong(SQLite::Database* db, string pack, string song)
 
 int
 DBProfile::FindOrCreateChart(SQLite::Database* db,
-							 string chartkey,
-							 string pack,
-							 string song,
+							 const string& chartkey,
+							 const string& pack,
+							 const string& song,
 							 Difficulty diff)
 {
 	const auto chartKeyID = FindOrCreateChartKey(db, chartkey);
@@ -1094,7 +1094,7 @@ DBProfile::FindOrCreateChart(SQLite::Database* db,
 }
 
 int
-DBProfile::GetScoreKeyID(SQLite::Database* db, string key)
+DBProfile::GetScoreKeyID(SQLite::Database* db, const string& key)
 {
 	SQLite::Statement query(*db, "SELECT * FROM scorekeys WHERE scorekey=?");
 	query.bind(1, key);
@@ -1104,7 +1104,7 @@ DBProfile::GetScoreKeyID(SQLite::Database* db, string key)
 }
 
 int
-DBProfile::FindOrCreateScoreKey(SQLite::Database* db, string key)
+DBProfile::FindOrCreateScoreKey(SQLite::Database* db, const string& key)
 {
 	const auto exists = GetScoreKeyID(db, key);
 	if (exists)

--- a/src/Etterna/Models/Misc/DBProfile.cpp
+++ b/src/Etterna/Models/Misc/DBProfile.cpp
@@ -462,6 +462,8 @@ DBProfile::SaveDBToDir(const string& dir,
 		case LocalWithoutReplayData:
 			filename = FILEMAN->ResolvePath(dir) + PROFILE_DB;
 			break;
+		default:
+			break;
 	}
 	SQLite::Database* db = nullptr;
 	try {
@@ -637,6 +639,8 @@ DBProfile::MoveBackupToDir(const string& sFromDir,
 		case LocalWithReplayData:
 		case LocalWithoutReplayData:
 			filename = PROFILE_DB;
+			break;
+		default:
 			break;
 	}
 

--- a/src/Etterna/Models/Misc/DBProfile.cpp
+++ b/src/Etterna/Models/Misc/DBProfile.cpp
@@ -262,7 +262,6 @@ DBProfile::LoadPlayLists(SQLite::Database* db)
 	}
 	pls[lastPlayListName].courseruns.emplace_back(tmpCourseRun);
 	tmpCourseRun.clear();
-	return;
 }
 
 void

--- a/src/Etterna/Models/Misc/DBProfile.cpp
+++ b/src/Etterna/Models/Misc/DBProfile.cpp
@@ -570,8 +570,7 @@ DBProfile::SaveGeneralData(SQLite::Database* db, const Profile* profile)
 	insertGData.bind(4, profile->m_LastDifficulty);
 	insertGData.bind(
 	  5,
-	  ((profile->m_LastStepsType != StepsType_Invalid &&
-		profile->m_LastStepsType < NUM_StepsType)
+	  ((profile->m_LastStepsType < NUM_StepsType)
 		 ? GAMEMAN->GetStepsTypeInfo(profile->m_LastStepsType).szName
 		 : ""));
 	insertGData.bind(6, profile->m_lastSong.ToString());
@@ -1110,7 +1109,7 @@ int
 DBProfile::FindOrCreateScoreKey(SQLite::Database* db, const string& key)
 {
 	const auto exists = GetScoreKeyID(db, key);
-	if (exists)
+	if (exists != 0)
 		return exists;
 	db->exec("INSERT INTO scorekeys VALUES (NULL, \"" + key + "\")");
 	return static_cast<int>(sqlite3_last_insert_rowid(db->getHandle()));

--- a/src/Etterna/Models/Misc/DBProfile.cpp
+++ b/src/Etterna/Models/Misc/DBProfile.cpp
@@ -938,8 +938,8 @@ DBProfile::SavePlayerScores(SQLite::Database* db,
 						insertScore->bind(5, hs->GetWifeScore());
 						insertScore->bind(6, hs->GetSSRNormPercent());
 						insertScore->bind(7, hs->GetJudgeScale());
-						insertScore->bind(8, hs->GetChordCohesion());
-						insertScore->bind(9, hs->GetEtternaValid());
+						insertScore->bind(8, static_cast<int>(hs->GetChordCohesion()));
+						insertScore->bind(9, static_cast<int>(hs->GetEtternaValid()));
 						insertScore->bind(10, hs->GetPlayedSeconds());
 						insertScore->bind(11, hs->GetMaxCombo());
 						insertScore->bind(12, hs->GetModifiers());

--- a/src/Etterna/Models/Misc/DBProfile.cpp
+++ b/src/Etterna/Models/Misc/DBProfile.cpp
@@ -525,7 +525,7 @@ DBProfile::SaveDBToDir(const string& dir,
 }
 
 void
-DBProfile::SaveFavourites(SQLite::Database* db, const Profile* profile) const
+DBProfile::SaveFavourites(SQLite::Database* db, const Profile* profile)
 {
 
 	db->exec("DROP TABLE IF EXISTS favourites");
@@ -543,7 +543,7 @@ DBProfile::SaveFavourites(SQLite::Database* db, const Profile* profile) const
 }
 
 void
-DBProfile::SaveGeneralData(SQLite::Database* db, const Profile* profile) const
+DBProfile::SaveGeneralData(SQLite::Database* db, const Profile* profile)
 {
 
 	db->exec("DROP TABLE IF EXISTS generaldata");
@@ -649,7 +649,7 @@ DBProfile::MoveBackupToDir(const string& sFromDir,
 }
 
 void
-DBProfile::SavePermaMirrors(SQLite::Database* db, const Profile* profile) const
+DBProfile::SavePermaMirrors(SQLite::Database* db, const Profile* profile)
 {
 
 	db->exec("DROP TABLE IF EXISTS permamirrors");
@@ -667,7 +667,7 @@ DBProfile::SavePermaMirrors(SQLite::Database* db, const Profile* profile) const
 }
 
 void
-DBProfile::SaveScoreGoals(SQLite::Database* db, const Profile* profile) const
+DBProfile::SaveScoreGoals(SQLite::Database* db, const Profile* profile)
 {
 
 	db->exec("DROP TABLE IF EXISTS scoregoals");
@@ -710,7 +710,7 @@ DBProfile::SaveScoreGoals(SQLite::Database* db, const Profile* profile) const
 }
 
 void
-DBProfile::SavePlayLists(SQLite::Database* db, const Profile* profile) const
+DBProfile::SavePlayLists(SQLite::Database* db, const Profile* profile)
 {
 	db->exec("DROP TABLE IF EXISTS playlists");
 	db->exec("CREATE TABLE playlists (id INTEGER PRIMARY KEY, name TEXT)");
@@ -781,7 +781,7 @@ DBProfile::SavePlayLists(SQLite::Database* db, const Profile* profile) const
 void
 DBProfile::SavePlayerScores(SQLite::Database* db,
 							const Profile* profile,
-							DBProfileMode mode) const
+							DBProfileMode mode)
 {
 	if (mode != WriteOnlyWebExport) {
 		// Separate scorekeys table so we can not drop it when saving, and

--- a/src/Etterna/Models/Misc/DBProfile.cpp
+++ b/src/Etterna/Models/Misc/DBProfile.cpp
@@ -1090,9 +1090,9 @@ DBProfile::FindOrCreateChart(SQLite::Database* db,
 		insertChart.bind(3, diff);
 		insertChart.exec();
 		return static_cast<int>(sqlite3_last_insert_rowid(db->getHandle()));
-	} else {
-		return query.getColumn(0);
 	}
+
+	return query.getColumn(0);
 }
 
 int

--- a/src/Etterna/Models/Misc/DBProfile.cpp
+++ b/src/Etterna/Models/Misc/DBProfile.cpp
@@ -29,7 +29,7 @@ DBProfile::LoadDBFromDir(const std::string& dir, Profile* profile)
 ProfileLoadResult
 DBProfile::LoadDBFromDir(const std::string& dir)
 {
-	SQLite::Database* db;
+	SQLite::Database* db = nullptr;
 	try {
 		// Open a database file
 		db = new SQLite::Database(FILEMAN->ResolvePath(dir) + PROFILE_DB,
@@ -162,7 +162,7 @@ DBProfile::LoadPlayLists(SQLite::Database* db)
 	  "ORDER BY playlists.name, chartkeys.chartkey, chartplaylists.rate");
 	auto& pls = loadingProfile->allplaylists;
 
-	Playlist* tmp;
+	Playlist* tmp = nullptr;
 
 	// Read one row
 	if (query.executeStep()) {
@@ -230,7 +230,7 @@ DBProfile::LoadPlayLists(SQLite::Database* db)
 	  "ORDER BY runs.scorekey, courseruns.id, playlists.name");
 
 	string lastPlayListName;
-	int lastCourseRunID;
+	int lastCourseRunID = 0;
 	vector<string> tmpCourseRun;
 
 	// Read one row
@@ -464,7 +464,7 @@ DBProfile::SaveDBToDir(const string& dir,
 			filename = FILEMAN->ResolvePath(dir) + PROFILE_DB;
 			break;
 	}
-	SQLite::Database* db;
+	SQLite::Database* db = nullptr;
 	try {
 		// Open a database file
 		db = new SQLite::Database(filename,
@@ -875,7 +875,7 @@ DBProfile::SavePlayerScores(SQLite::Database* db,
 		for (auto& ratePair : chartPair.second.ScoresByRate) {
 			// first is rate int and second is ScoresAtRate
 			auto rate = ratePair.first;
-			int scoresAtRateID;
+			int scoresAtRateID = 0;
 			if (mode != WriteOnlyWebExport) {
 				SQLite::Statement insertScoresAtRate(
 				  *db, "INSERT INTO scoresatrates VALUES (NULL, ?, ?, ?, ?)");
@@ -897,8 +897,8 @@ DBProfile::SavePlayerScores(SQLite::Database* db,
 					if (i.second.GetWifeScore() > SCOREMAN->minpercent) {
 						const auto hs = &(i.second);
 						// Add scores
-						SQLite::Statement* insertScore;
-						int scorekeyID;
+						SQLite::Statement* insertScore = nullptr;
+						int scorekeyID = 0;
 						if (mode != WriteOnlyWebExport) {
 							insertScore = new SQLite::Statement(
 							  *db,
@@ -1120,7 +1120,7 @@ DBProfile::WriteReplayData(const HighScore* hs)
 	  PROFILEMAN->GetProfileDir(ProfileSlot_Player1).substr(1);
 	const auto filename = profiledir + PROFILE_DB;
 
-	SQLite::Database* db;
+	SQLite::Database* db = nullptr;
 	try {
 		// Open a database file
 		db = new SQLite::Database(filename,

--- a/src/Etterna/Models/Misc/DBProfile.h
+++ b/src/Etterna/Models/Misc/DBProfile.h
@@ -5,6 +5,8 @@
 #include "HighScore.h"
 #include <SQLiteCpp/SQLiteCpp.h>
 
+class Profile;
+
 enum DBProfileMode
 {
 	WriteOnlyWebExport,

--- a/src/Etterna/Models/Misc/DBProfile.h
+++ b/src/Etterna/Models/Misc/DBProfile.h
@@ -17,14 +17,14 @@ enum DBProfileMode
 class DBProfile
 {
   public:
-	enum ProfileLoadResult LoadDBFromDir(std::string dir);
-	ProfileLoadResult LoadDBFromDir(std::string dir, Profile* profile);
+	enum ProfileLoadResult LoadDBFromDir(const std::string& dir);
+	ProfileLoadResult LoadDBFromDir(const std::string& dir, Profile* profile);
 
-	ProfileLoadResult SaveDBToDir(std::string sDir,
+	ProfileLoadResult SaveDBToDir(const std::string& sDir,
 								  const Profile* profile,
 								  DBProfileMode mode) const;
 
-	void MoveBackupToDir(const std::string& sFromDir,
+	static void MoveBackupToDir(const std::string& sFromDir,
 						 const std::string& sToDir,
 						 DBProfileMode mode);
 
@@ -34,20 +34,20 @@ class DBProfile
 
   private:
 	Profile* loadingProfile{ nullptr };
-	static auto GetChartKeyID(SQLite::Database* db, std::string key) -> int;
+	static auto GetChartKeyID(SQLite::Database* db, const std::string& key) -> int;
 	static auto GetChartKeyByID(SQLite::Database* db, int id) -> std::string;
-	static auto FindOrCreateChartKey(SQLite::Database* db, std::string key)
+	static auto FindOrCreateChartKey(SQLite::Database* db, const std::string& key)
 	  -> int;
 	static auto FindOrCreateSong(SQLite::Database* db,
-								 std::string pack,
-								 std::string song) -> int;
+								 const std::string& pack,
+								 const std::string& song) -> int;
 	static auto FindOrCreateChart(SQLite::Database* db,
-								  std::string chartkey,
-								  std::string pack,
-								  std::string song,
+								  const std::string& chartkey,
+								  const std::string& pack,
+								  const std::string& song,
 								  Difficulty diff) -> int;
-	static auto GetScoreKeyID(SQLite::Database* db, std::string key) -> int;
-	static auto FindOrCreateScoreKey(SQLite::Database* db, std::string key)
+	static auto GetScoreKeyID(SQLite::Database* db, const std::string& key) -> int;
+	static auto FindOrCreateScoreKey(SQLite::Database* db, const std::string& key)
 	  -> int;
 
 	void LoadFavourites(SQLite::Database* db);

--- a/src/Etterna/Models/Misc/DBProfile.h
+++ b/src/Etterna/Models/Misc/DBProfile.h
@@ -52,19 +52,19 @@ class DBProfile
 
 	void LoadFavourites(SQLite::Database* db);
 	void LoadPlayLists(SQLite::Database* db);
-	void LoadPlayerScores(SQLite::Database* db);
+	static void LoadPlayerScores(SQLite::Database* db);
 	auto LoadGeneralData(SQLite::Database* db) -> bool;
 	void LoadPermaMirrors(SQLite::Database* db);
 	void LoadScoreGoals(SQLite::Database* db);
 
-	void SaveFavourites(SQLite::Database* db, const Profile* profile) const;
-	void SavePlayLists(SQLite::Database* db, const Profile* profile) const;
-	void SavePlayerScores(SQLite::Database* db,
+	static void SaveFavourites(SQLite::Database* db, const Profile* profile);
+	static void SavePlayLists(SQLite::Database* db, const Profile* profile);
+	static void SavePlayerScores(SQLite::Database* db,
 						  const Profile* profile,
-						  DBProfileMode mode) const;
-	void SaveGeneralData(SQLite::Database* db, const Profile* profile) const;
-	void SavePermaMirrors(SQLite::Database* db, const Profile* profile) const;
-	void SaveScoreGoals(SQLite::Database* db, const Profile* profile) const;
+						  DBProfileMode mode);
+	static void SaveGeneralData(SQLite::Database* db, const Profile* profile);
+	static void SavePermaMirrors(SQLite::Database* db, const Profile* profile);
+	static void SaveScoreGoals(SQLite::Database* db, const Profile* profile);
 };
 
 #endif

--- a/src/Etterna/Models/Misc/HighScore.cpp
+++ b/src/Etterna/Models/Misc/HighScore.cpp
@@ -928,17 +928,14 @@ HighScore::IsEmpty() const -> bool
 auto
 HighScore::IsEmptyNormalized() const -> bool
 {
-	if (m_Impl->iTapNoteScoresNormalized[TNS_W1] != 0 ||
+	return !(m_Impl->iTapNoteScoresNormalized[TNS_W1] != 0 ||
 		m_Impl->iTapNoteScoresNormalized[TNS_W2] != 0 ||
 		m_Impl->iTapNoteScoresNormalized[TNS_W3] != 0 ||
 		m_Impl->iTapNoteScoresNormalized[TNS_W4] != 0 ||
 		m_Impl->iTapNoteScoresNormalized[TNS_W5] != 0 ||
 		m_Impl->iTapNoteScoresNormalized[TNS_Miss] != 0 ||
 		m_Impl->iTapNoteScoresNormalized[TNS_HitMine] != 0 ||
-		m_Impl->iTapNoteScoresNormalized[TNS_AvoidMine] != 0) {
-		return false;
-	}
-	return true;
+		m_Impl->iTapNoteScoresNormalized[TNS_AvoidMine] != 0);
 }
 
 auto

--- a/src/Etterna/Models/Misc/HighScore.cpp
+++ b/src/Etterna/Models/Misc/HighScore.cpp
@@ -305,13 +305,13 @@ HighScoreImpl::LoadFromEttNode(const XNode* pNode)
 			uploaded.emplace_back(server.c_str());
 		}
 	}
-	
+
 	// Attempt to recover SurviveSeconds or otherwise try to
 	// load a correct number here
 	auto psSuccess = pNode->GetChildValue("PlayedSeconds", played_seconds);
 	if (!psSuccess || played_seconds <= 1.F) {
 		played_seconds = 0.F;
-		
+
 		// Attempt to use the chart length for PlayedSeconds
 		// Only if the grade is a fail
 		auto* steps = SONGMAN->GetStepsByChartkey(ChartKey);
@@ -321,7 +321,7 @@ HighScoreImpl::LoadFromEttNode(const XNode* pNode)
 			auto r = 1.F;
 			if (fMusicRate > 0.F)
 				r = fMusicRate;
-			
+
 			sLength = steps->GetLengthSeconds(r);
 		}
 		float survSeconds = 0.F;
@@ -342,7 +342,7 @@ HighScoreImpl::LoadFromEttNode(const XNode* pNode)
 		// (setting it to 0 grants potential to fix it later)
 	}
 
-	
+
 	pNode->GetChildValue("MaxCombo", iMaxCombo);
 	if (pNode->GetChildValue("Modifiers", s)) {
 		sModifiers = s;
@@ -542,7 +542,7 @@ HighScoreImpl::WriteInputData() -> bool
 		fileStream.close();
 		return false;
 	}
-	
+
 
 	// for writing binary output for "compression"
 	// write vector size, then dump vector data
@@ -585,7 +585,7 @@ HighScore::LoadInputData() -> bool
 		return false;
 	}
 	*/
-	
+
 	// read vector size, then read vector data
 	/*
 	try {
@@ -645,12 +645,12 @@ HighScore::LoadInputData() -> bool
 			ev.is_press = std::stoi(tokens[1]);
 			ev.songPositionSeconds = std::stof(tokens[2]);
 			m_Impl->InputData.push_back(ev);
-			
+
 			tokens.clear();
 		}
 
 		Locator::getLogger()->trace("Loaded input data at {}", path.c_str());
-		
+
 		if (FILEMAN->Remove(path))
 			Locator::getLogger()->trace("Deleted uncompressed input data");
 		else
@@ -1716,7 +1716,7 @@ HighScore::NormalizeJudgments() -> bool
 	}
 	// otherwise ....
 
-	
+
 	// exit early if no replay data to convert
 	// this will work if replay doesn't physically exist
 	// that case occurs if coming via FillInHighScore with PSS data
@@ -1790,7 +1790,7 @@ HighScore::NormalizeJudgments() -> bool
 		Locator::getLogger()->warn(
 		  "While converting score key {} a Miss mismatch was found.", GetScoreKey());
 	}
-	
+
 	return true;
 }
 
@@ -2096,7 +2096,7 @@ class LunaHighScore : public Luna<HighScore>
 		}
 		return 1;
 	}
-	
+
 	static auto GetJudgmentString(T* p, lua_State* L) -> int
 	{
 		const auto doot = ssprintf("%d I %d I %d I %d I %d I %d  x%d",

--- a/src/Etterna/Models/Misc/HighScore.cpp
+++ b/src/Etterna/Models/Misc/HighScore.cpp
@@ -509,7 +509,7 @@ HighScoreImpl::WriteInputData() -> bool
 		FILE* infile =
 		  fopen(path.c_str(), "rb");
 		gzFile outfile = gzopen(path_z.c_str(), "wb");
-		if (!infile || !outfile) {
+		if ((infile == nullptr) || (outfile == nullptr)) {
 			Locator::getLogger()->warn("Failed to compress new input data.");
 			return false;
 		}
@@ -604,7 +604,7 @@ HighScore::LoadInputData() -> bool
 		gzFile infile = gzopen(path_z.c_str(), "rb");
 		// hope nothing already exists here
 		FILE* outfile = fopen(path.c_str(), "wb");
-		if (!infile || !outfile) {
+		if ((infile == nullptr) || (outfile == nullptr)) {
 			Locator::getLogger()->warn("Failed to read input data at {}",
 									   path_z.c_str());
 			return false;

--- a/src/Etterna/Models/Misc/HighScore.cpp
+++ b/src/Etterna/Models/Misc/HighScore.cpp
@@ -644,7 +644,7 @@ HighScore::LoadInputData() -> bool
 			}
 
 			ev.column = std::stoi(tokens[0]);
-			ev.is_press = std::stoi(tokens[1]);
+			ev.is_press = (std::stoi(tokens[1]) != 0);
 			ev.songPositionSeconds = std::stof(tokens[2]);
 			m_Impl->InputData.push_back(ev);
 

--- a/src/Etterna/Models/Misc/HighScore.cpp
+++ b/src/Etterna/Models/Misc/HighScore.cpp
@@ -570,7 +570,7 @@ HighScoreImpl::WriteInputData() -> bool
 auto
 HighScore::LoadInputData() -> bool
 {
-	if (m_Impl->InputData.size() > 0)
+	if (!m_Impl->InputData.empty())
 		return true;
 
 	auto path = INPUT_DATA_DIR + m_Impl->ScoreKey;
@@ -1723,7 +1723,7 @@ HighScore::NormalizeJudgments() -> bool
 	// replaydata loading "fails" if size isnt more than 4
 	// we don't really want that to happen
 	// this is because replays dont save for the same reason
-	if (!LoadReplayData() && m_Impl->vOffsetVector.size() == 0) {
+	if (!LoadReplayData() && m_Impl->vOffsetVector.empty()) {
 		return false;
 	}
 

--- a/src/Etterna/Models/Misc/Profile.h
+++ b/src/Etterna/Models/Misc/Profile.h
@@ -73,12 +73,12 @@ class ScoreGoal
 	bool achieved = false;
 	DateTime timeassigned;
 	DateTime timeachieved;
-	std::string comment = "";
-	std::string chartkey = "";
+	std::string comment;
+	std::string chartkey;
 
 	// which specific score was this goal achieved by, reminder to consider
 	// what happens when individual score deletion is possibly added -mina
-	std::string scorekey = "";
+	std::string scorekey;
 
 	[[nodiscard]] auto CreateNode() const -> XNode*;
 	void LoadFromNode(const XNode* pNode);
@@ -126,13 +126,7 @@ class Profile
 	// added to SwapExceptPriority won't be swapped correctly when the user
 	// changes the list priority of a profile. -Kyz
 	Profile()
-	  :
-
-	  m_sDisplayName("")
-	  , m_sLastUsedHighScoreName("")
-	  , m_sGuid(MakeGuid())
-	  , m_sLastPlayedMachineGuid("")
-	  , profiledir("")
+	  : m_sGuid(MakeGuid())
 	{
 		m_lastSong.Unset();
 		m_fPlayerRating = 0.F;

--- a/src/Etterna/Models/Misc/Profile.h
+++ b/src/Etterna/Models/Misc/Profile.h
@@ -252,7 +252,7 @@ class Profile
 	int filtermode = 1; // 1=all, 2=completed, 3=uncompleted
 	bool asc = false;
 
-	auto HasGoal(const std::string& ck) -> bool
+	auto HasGoal(const std::string& ck) const -> bool
 	{
 		return goalmap.count(ck) == 1;
 	}
@@ -271,7 +271,7 @@ class Profile
 	// Screenshot Data
 	std::vector<Screenshot> m_vScreenshots;
 	void AddScreenshot(const Screenshot& screenshot);
-	auto GetNextScreenshotIndex() -> int { return m_vScreenshots.size(); }
+	int GetNextScreenshotIndex() const { return static_cast<int>(m_vScreenshots.size()); }
 
 	// Init'ing
 	void InitAll()

--- a/src/Etterna/Models/Misc/TimingData.cpp
+++ b/src/Etterna/Models/Misc/TimingData.cpp
@@ -8,6 +8,7 @@
 
 #include <cfloat>
 #include <algorithm>
+#include <cmath>
 
 #include "AdjustSync.h"
 
@@ -133,8 +134,8 @@ FindEntryInLookup(const TimingData::beat_start_lookup_t& lookup, float entry)
 	if (lookup.empty()) {
 		return lookup.end();
 	}
-	size_t lower = 0;
-	auto upper = lookup.size() - 1;
+	long lower = 0;
+	long upper = static_cast<long>(lookup.size() - 1);
 	if (lookup[lower].first > entry) {
 		return lookup.end();
 	}
@@ -342,8 +343,10 @@ TimingData::GetSegmentIndexAtRow(TimingSegmentType tst, int iRow) const
 	if (vSegs.empty())
 		return INVALID_INDEX;
 
-	const int min = 0, max = vSegs.size() - 1;
-	auto l = min, r = max;
+	const int min = 0;
+	const int max = static_cast<int>(vSegs.size() - 1);
+	auto l = min;
+	auto r = max;
 	while (l <= r) {
 		const auto m = (l + r) / 2;
 		if ((m == min || vSegs[m]->GetRow() <= iRow) &&
@@ -944,7 +947,7 @@ float
 TimingData::GetDisplayedBeat(float fBeat) const
 {
 	float fOutBeat = 0;
-	unsigned i;
+	unsigned i = 0;
 	const auto& scrolls = m_avpTimingSegments[SEGMENT_SCROLL];
 	for (i = 0; i < scrolls.size() - 1; i++) {
 		if (scrolls[i + 1]->GetBeat() > fBeat)
@@ -1094,7 +1097,7 @@ TimingData::GetDisplayedSpeedPercent(float fSongBeat, float fMusicSeconds) const
 	const auto fStartBeat = seg->GetBeat();
 	const auto fStartTime =
 	  WhereUAtBro(fStartBeat) - GetDelayAtBeat(fStartBeat);
-	float fEndTime;
+	float fEndTime = 0.f;
 	const auto fCurTime = fMusicSeconds;
 
 	if (seg->GetUnit() == SpeedSegment::UNIT_SECONDS) {
@@ -1259,9 +1262,9 @@ void
 TimingSegmentSetToLuaTable(TimingData* td, TimingSegmentType tst, lua_State* L)
 {
 	const auto segs = td->GetTimingSegments(tst);
-	lua_createtable(L, segs.size(), 0);
+	lua_createtable(L, static_cast<int>(segs.size()), 0);
 	if (tst == SEGMENT_LABEL) {
-		for (size_t i = 0; i < segs.size(); ++i) {
+		for (int i = 0; i < segs.size(); ++i) {
 			lua_createtable(L, 2, 0);
 			lua_pushnumber(L, segs[i]->GetBeat());
 			lua_rawseti(L, -2, 1);
@@ -1270,12 +1273,12 @@ TimingSegmentSetToLuaTable(TimingData* td, TimingSegmentType tst, lua_State* L)
 			lua_rawseti(L, -2, i + 1);
 		}
 	} else {
-		for (size_t i = 0; i < segs.size(); ++i) {
+		for (int i = 0; i < segs.size(); ++i) {
 			auto values = segs[i]->GetValues();
-			lua_createtable(L, values.size() + 1, 0);
+			lua_createtable(L, static_cast<int>(values.size()) + 1, 0);
 			lua_pushnumber(L, segs[i]->GetBeat());
 			lua_rawseti(L, -2, 1);
-			for (size_t v = 0; v < values.size(); ++v) {
+			for (int v = 0; v < values.size(); ++v) {
 				lua_pushnumber(L, values[v]);
 				lua_rawseti(L, -2, v + 2);
 			}
@@ -1421,7 +1424,7 @@ TimingData::BuildAndGetEtaner(const vector<int>& nerv)
 			if (bps <= 0)
 				Locator::getLogger()->warn("Found {} bps in file {} - Very likely to crash.", bps, m_sFile);
 			while (idx < nerv.size() && nerv[idx] <= event_row) {
-				const auto perc = (nerv[idx] - lastbpmrow) /
+				const auto perc = static_cast<float>(nerv[idx] - lastbpmrow) /
 								  static_cast<float>(event_row - lastbpmrow);
 				ElapsedTimesAtNonEmptyRows.emplace_back(
 				  last_time + time_to_next_event * perc -
@@ -1438,7 +1441,7 @@ TimingData::BuildAndGetEtaner(const vector<int>& nerv)
 		// fill out any timestamps that lie beyond the last bpm change
 		time_to_next_event = NoteRowToBeat(nerv.back() - lastbpmrow) / bps;
 		while (idx < nerv.size()) {
-			const auto perc = (nerv[idx] - lastbpmrow) /
+			const auto perc = static_cast<float>(nerv[idx] - lastbpmrow) /
 							  static_cast<float>(nerv.back() - lastbpmrow);
 			ElapsedTimesAtNonEmptyRows.emplace_back(
 			  last_time + time_to_next_event * perc - m_fBeat0OffsetInSeconds);
@@ -1470,43 +1473,43 @@ class LunaTimingData : public Luna<TimingData>
   public:
 	static int HasStops(T* p, lua_State* L)
 	{
-		lua_pushboolean(L, p->HasStops());
+		lua_pushboolean(L, static_cast<int>(p->HasStops()));
 		return 1;
 	}
 
 	static int HasDelays(T* p, lua_State* L)
 	{
-		lua_pushboolean(L, p->HasDelays());
+		lua_pushboolean(L, static_cast<int>(p->HasDelays()));
 		return 1;
 	}
 
 	static int HasBPMChanges(T* p, lua_State* L)
 	{
-		lua_pushboolean(L, p->HasBpmChanges());
+		lua_pushboolean(L, static_cast<int>(p->HasBpmChanges()));
 		return 1;
 	}
 
 	static int HasWarps(T* p, lua_State* L)
 	{
-		lua_pushboolean(L, p->HasWarps());
+		lua_pushboolean(L, static_cast<int>(p->HasWarps()));
 		return 1;
 	}
 
 	static int HasFakes(T* p, lua_State* L)
 	{
-		lua_pushboolean(L, p->HasFakes());
+		lua_pushboolean(L, static_cast<int>(p->HasFakes()));
 		return 1;
 	}
 
 	static int HasSpeedChanges(T* p, lua_State* L)
 	{
-		lua_pushboolean(L, p->HasSpeedChanges());
+		lua_pushboolean(L, static_cast<int>(p->HasSpeedChanges()));
 		return 1;
 	}
 
 	static int HasScrollChanges(T* p, lua_State* L)
 	{
-		lua_pushboolean(L, p->HasScrollChanges());
+		lua_pushboolean(L, static_cast<int>(p->HasScrollChanges()));
 		return 1;
 	}
 
@@ -1550,7 +1553,8 @@ class LunaTimingData : public Luna<TimingData>
 	static int GetActualBPM(T* p, lua_State* L)
 	{
 		// certainly there's a better way to do it than this? -aj
-		float fMinBPM, fMaxBPM;
+		float fMinBPM = 0.f;
+		float fMaxBPM = 0.f;
 		p->GetActualBPM(fMinBPM, fMaxBPM);
 		vector<float> fBPMs;
 		fBPMs.push_back(fMinBPM);
@@ -1561,7 +1565,7 @@ class LunaTimingData : public Luna<TimingData>
 
 	static int HasNegativeBPMs(T* p, lua_State* L)
 	{
-		lua_pushboolean(L, p->HasWarps());
+		lua_pushboolean(L, static_cast<int>(p->HasWarps()));
 		return 1;
 	}
 

--- a/src/Etterna/Models/Misc/TimingData.cpp
+++ b/src/Etterna/Models/Misc/TimingData.cpp
@@ -816,6 +816,8 @@ TimingData::GetBeatInternal(GetBeatStarts& start,
 				INC_INDEX(start.warp);
 				break;
 			}
+			default:
+				break;
 		}
 		start.last_row = event_row;
 	}
@@ -909,6 +911,8 @@ TimingData::GetElapsedTimeInternal(GetBeatStarts& start,
 				INC_INDEX(start.warp);
 				break;
 			}
+			default:
+				break;
 		}
 		start.last_row = event_row;
 	}

--- a/src/Etterna/Models/Misc/TimingData.h
+++ b/src/Etterna/Models/Misc/TimingData.h
@@ -16,7 +16,7 @@ struct lua_State;
 /* convenience functions to handle static casting */
 template<class T>
 auto
-ToDerived(const TimingSegment* t, TimingSegmentType tst) -> T
+ToDerived(const TimingSegment* t, TimingSegmentType /*tst*/) -> T
 {
 	return static_cast<T>(t);
 }

--- a/src/Etterna/Models/Misc/TimingData.h
+++ b/src/Etterna/Models/Misc/TimingData.h
@@ -56,7 +56,7 @@ class TimingData
 	/**
 	 * @brief Sets up initial timing data with a defined offset.
 	 * @param fOffset the offset from the 0th beat. */
-	TimingData(float fOffset = 0.F);
+	explicit TimingData(float fOffset = 0.F);
 	~TimingData();
 
 	void Copy(const TimingData& other);

--- a/src/Etterna/Models/Misc/TimingData.h
+++ b/src/Etterna/Models/Misc/TimingData.h
@@ -760,7 +760,7 @@ class TimingData
 		auto& stops = m_avpTimingSegments[SEGMENT_STOP];
 
 		for (auto& i : bpms) {
-			auto bpm = ToBPM(i);
+			auto* bpm = ToBPM(i);
 			if (0 > bpm->GetBPM()) {
 				Locator::getLogger()->warn("Sequential Assumption Invalidated.");
 				ValidSequentialAssumption = false;
@@ -769,7 +769,7 @@ class TimingData
 		}
 
 		for (auto& stop : stops) {
-			auto s = ToStop(stop);
+			auto* s = ToStop(stop);
 			if (0 > s->GetPause()) {
 				Locator::getLogger()->warn("Sequential Assumption Invalidated.");
 				ValidSequentialAssumption = false;

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderBMS.cpp
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderBMS.cpp
@@ -1675,7 +1675,7 @@ BMSSongLoader::AddToSong()
 
 		// Preview file only if it's different from one specified on #MUSIC so
 		// that previewStart is valid. -az
-		if (main.info.previewFile.length() &&
+		if ((main.info.previewFile.length() != 0u) &&
 			main.info.previewFile != main.info.musicFile) {
 			out->m_PreviewFile = main.info.previewFile;
 			out->m_fMusicSampleLengthSeconds =

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderBMS.cpp
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderBMS.cpp
@@ -186,9 +186,9 @@ struct BMSMeasure
 	float size;
 };
 
-typedef std::map<std::string, std::string> BMSHeaders;
-typedef std::map<int, BMSMeasure> BMSMeasures;
-typedef std::vector<BMSObject> BMSObjects;
+using BMSHeaders = std::map<std::string, std::string>;
+using BMSMeasures = std::map<int, BMSMeasure>;
+using BMSObjects = std::vector<BMSObject>;
 
 class BMSChart
 {

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderBMS.cpp
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderBMS.cpp
@@ -853,9 +853,7 @@ BMSChartReader::Read()
 {
 	ReadHeaders();
 	CalculateStepsType();
-	if (!ReadNoteData())
-		return false;
-	return true;
+	return ReadNoteData();
 }
 
 void
@@ -1730,10 +1728,7 @@ BMSLoader::LoadNoteDataFromSimfile(const std::string& cachePath, Steps& out)
 	BMSSong song(pSong);
 
 	BMSChartReader reader(&chart, &out, &song);
-	if (!reader.Read())
-		return false;
-
-	return true;
+	return reader.Read();
 }
 
 bool

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderBMS.cpp
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderBMS.cpp
@@ -82,11 +82,11 @@ SearchForDifficulty(std::string sTag, Steps* pOut)
 	sTag = make_lower(sTag);
 
 	// Only match "Light" in parentheses.
-	if (sTag.find("(light") != sTag.npos) {
+	if (sTag.find("(light") != std::string::npos) {
 		pOut->SetDifficulty(Difficulty_Easy);
-	} else if (sTag.find("another") != sTag.npos) {
+	} else if (sTag.find("another") != std::string::npos) {
 		pOut->SetDifficulty(Difficulty_Hard);
-	} else if (sTag.find("(solo)") != sTag.npos) {
+	} else if (sTag.find("(solo)") != std::string::npos) {
 		pOut->SetDescription("Solo");
 		pOut->SetDifficulty(Difficulty_Edit);
 	}
@@ -430,7 +430,7 @@ struct bmsCommandTree
 		std::string name = make_lower(statement.substr(0, space));
 		std::string value;
 
-		if (space != statement.npos)
+		if (space != std::string::npos)
 			value = statement.substr(space + 1);
 
 		if (name == "#if") {
@@ -1594,7 +1594,7 @@ BMSSongLoader::AddToSong()
 
 				// XXX: This matches (double), but I haven't seen it used.
 				// Again, MORE EXAMPLES NEEDED
-				if (tag.find('l') != tag.npos) {
+				if (tag.find('l') != std::string::npos) {
 					unsigned pos = tag.find('l');
 					if (pos > 2 && tag.substr(pos - 2, 4) == "solo") {
 						// (solo) -- an edit, apparently (Thanks Glenn!)
@@ -1606,14 +1606,14 @@ BMSSongLoader::AddToSong()
 					}
 				}
 				// [x] [Expert]
-				else if (tag.find('x') != tag.npos)
+				else if (tag.find('x') != std::string::npos)
 					steps->SetDifficulty(Difficulty_Challenge);
 				// [A] <A> (A) [ANOTHER] <ANOTHER> (ANOTHER) (ANOTHER7) Another
 				// (DP ANOTHER) (Another) -ANOTHER- [A7] [A14] etc etc etc
-				else if (tag.find('a') != tag.npos)
+				else if (tag.find('a') != std::string::npos)
 					steps->SetDifficulty(Difficulty_Hard);
 				// XXX: Can also match (double), but should match [B] or [B7]
-				else if (tag.find('b') != tag.npos)
+				else if (tag.find('b') != std::string::npos)
 					steps->SetDifficulty(Difficulty_Beginner);
 				// Other tags I've seen here include (5KEYS) (10KEYS) (7keys)
 				// (14keys) (dp) [MIX] [14] (14 Keys Mix)

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderBMS.cpp
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderBMS.cpp
@@ -1679,7 +1679,7 @@ BMSSongLoader::AddToSong()
 			main.info.previewFile != main.info.musicFile) {
 			out->m_PreviewFile = main.info.previewFile;
 			out->m_fMusicSampleLengthSeconds =
-			  0.00f; // to ensure whole preview file is heard
+			  0.f; // to ensure whole preview file is heard
 		}
 
 		out->m_fMusicSampleStartSeconds = main.info.previewStart;

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderBMS.h
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderBMS.h
@@ -15,6 +15,6 @@ bool
 LoadFromDir(const std::string& sDir, Song& out);
 bool
 LoadNoteDataFromSimfile(const std::string& cachePath, Steps& out);
-}
+} // namespace BMSLoader
 
 #endif

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderBMS.h
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderBMS.h
@@ -1,12 +1,16 @@
 #ifndef NOTES_LOADER_BMS_H
 #define NOTES_LOADER_BMS_H
 
+#include <string>
+#include <vector>
+
 class Song;
 class Steps;
+
 /** @brief Reads a Song from a set of .BMS files. */
 namespace BMSLoader {
 void
-GetApplicableFiles(const std::string& sPath, vector<std::string>& out);
+GetApplicableFiles(const std::string& sPath, std::vector<std::string>& out);
 bool
 LoadFromDir(const std::string& sDir, Song& out);
 bool

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderOSU.cpp
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderOSU.cpp
@@ -183,7 +183,7 @@ OsuLoader::SetTimingData(map<string, map<string, string>> parsedData, Song& out)
 		}
 		lastoffset = offset;
 	}
-	if (bpms.size() > 0) {
+	if (!bpms.empty()) {
 		out.m_SongTiming.AddSegment(
 		  BPMSegment(0, bpms[0].second)); // set bpm at beat 0 (osu files don't
 										  // make this required)
@@ -325,9 +325,9 @@ OsuLoader::LoadNoteDataFromParsedData(
 	});
 
 	int firstTap = 0;
-	if (taps.size() > 0 && holds.size() > 0) {
+	if (!taps.empty() && !holds.empty()) {
 		firstTap = std::min(taps[0].ms, holds[0].msStart);
-	} else if (taps.size() > 0) {
+	} else if (!taps.empty()) {
 		firstTap = taps[0].ms;
 	} else {
 		firstTap = holds[0].msStart;
@@ -405,8 +405,8 @@ OsuLoader::LoadFromDir(const std::string& sPath_, Song& out)
 		}
 		std::string fileContents;
 		f.Read(fileContents, -1);
-		parsedData = ParseFileString(fileContents.c_str());
-		if (parsedData.size() == 0) {
+		parsedData = ParseFileString(fileContents);
+		if (parsedData.empty()) {
 			continue;
 		}
 		if (out.m_SongTiming.empty()) {

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderOSU.cpp
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderOSU.cpp
@@ -50,7 +50,8 @@ OsuLoader::ParseFileString(const string& fileContents)
 			for (auto& content : contents[i]) {
 				auto& str = content;
 				int pos = str.find_first_of(':');
-				string value = str.substr(pos + 1), tag = str.substr(0, pos);
+				string value = str.substr(pos + 1);
+				string tag = str.substr(0, pos);
 				parsedData[sections[i]][tag] = value;
 			}
 		}

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderOSU.cpp
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderOSU.cpp
@@ -15,7 +15,7 @@ using std::map;
 using std::string;
 
 vector<string>
-split(string str, string token)
+split(string str, const string& token)
 {
 	vector<string> result;
 	while (str.size()) {
@@ -34,7 +34,7 @@ split(string str, string token)
 }
 
 map<string, map<string, string>>
-OsuLoader::ParseFileString(string fileContents)
+OsuLoader::ParseFileString(const string& fileContents)
 {
 	vector<string> sections;
 	vector<vector<string>> contents;

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderOSU.h
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderOSU.h
@@ -72,6 +72,7 @@ LoadChartData(
 
 int
 MsToNoteRow(int ms, Song* song);
-}
+
+} // namespace OsuLoader
 
 #endif

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderOSU.h
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderOSU.h
@@ -32,7 +32,7 @@ namespace OsuLoader {
 // these are not organised AT ALL
 
 std::map<std::string, std::map<std::string, std::string>>
-ParseFileString(std::string fileContents);
+ParseFileString(const std::string& fileContents);
 
 void
 SeparateTagsAndContents(std::string fileContents,

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderOSU.h
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderOSU.h
@@ -1,6 +1,10 @@
 #ifndef NOTES_LOADER_OSU_H
 #define NOTES_LOADER_OSU_H
 
+#include <map>
+#include <string>
+#include <vector>
+
 class Song;
 class Steps;
 
@@ -36,8 +40,8 @@ ParseFileString(const std::string& fileContents);
 
 void
 SeparateTagsAndContents(std::string fileContents,
-						vector<std::string>& tagsOut,
-						vector<vector<std::string>>& contentsOut);
+						std::vector<std::string>& tagsOut,
+						std::vector<std::vector<std::string>>& contentsOut);
 
 void
 SetMetadata(std::map<std::string, std::map<std::string, std::string>>,
@@ -47,7 +51,7 @@ SetTimingData(std::map<std::string, std::map<std::string, std::string>>,
 			  Song& out);
 
 void
-GetApplicableFiles(const std::string& sPath, vector<std::string>& out);
+GetApplicableFiles(const std::string& sPath, std::vector<std::string>& out);
 
 bool
 LoadFromDir(const std::string& sPath, Song& out);

--- a/src/Etterna/Singletons/MessageManager.cpp
+++ b/src/Etterna/Singletons/MessageManager.cpp
@@ -251,7 +251,7 @@ MessageManager::Broadcast(MessageID m) const
 
 bool
 MessageManager::IsSubscribedToMessage(IMessageSubscriber* pSubscriber,
-									  const std::string& sMessage) const
+									  const std::string& sMessage)
 {
 	auto& subs = g_MessageToSubscribers[sMessage];
 	return subs.find(pSubscriber) != subs.end();

--- a/src/Etterna/Singletons/MessageManager.cpp
+++ b/src/Etterna/Singletons/MessageManager.cpp
@@ -87,7 +87,7 @@ XToString(MessageID);
 
 static RageMutex g_Mutex("MessageManager");
 
-typedef std::set<IMessageSubscriber*> SubscribersSet;
+using SubscribersSet = std::set<IMessageSubscriber *>;
 static std::map<std::string, SubscribersSet> g_MessageToSubscribers;
 
 Message::Message(const std::string& s)

--- a/src/Etterna/Singletons/MessageManager.cpp
+++ b/src/Etterna/Singletons/MessageManager.cpp
@@ -225,8 +225,7 @@ MessageManager::Broadcast(Message& msg) const
 
 	LockMut(g_Mutex);
 
-	std::map<std::string, SubscribersSet>::const_iterator iter =
-	  g_MessageToSubscribers.find(msg.GetName());
+	auto iter = g_MessageToSubscribers.find(msg.GetName());
 	if (iter == g_MessageToSubscribers.end())
 		return;
 

--- a/src/Etterna/Singletons/MessageManager.h
+++ b/src/Etterna/Singletons/MessageManager.h
@@ -192,20 +192,20 @@ class MessageManager
 	MessageManager();
 	~MessageManager();
 
-	void Subscribe(IMessageSubscriber* pSubscriber,
+	static void Subscribe(IMessageSubscriber* pSubscriber,
 				   const std::string& sMessage);
-	void Subscribe(IMessageSubscriber* pSubscriber, MessageID m);
-	void Unsubscribe(IMessageSubscriber* pSubscriber,
+	static void Subscribe(IMessageSubscriber* pSubscriber, MessageID m);
+	static void Unsubscribe(IMessageSubscriber* pSubscriber,
 					 const std::string& sMessage);
-	void Unsubscribe(IMessageSubscriber* pSubscriber, MessageID m);
+	static void Unsubscribe(IMessageSubscriber* pSubscriber, MessageID m);
 	void Broadcast(Message& msg) const;
 	void Broadcast(const std::string& sMessage) const;
 	void Broadcast(MessageID m) const;
-	auto IsSubscribedToMessage(IMessageSubscriber* pSubscriber,
-							   const std::string& sMessage) const -> bool;
+	static auto IsSubscribedToMessage(IMessageSubscriber* pSubscriber,
+							   const std::string& sMessage) -> bool;
 
-	auto IsSubscribedToMessage(IMessageSubscriber* pSubscriber,
-							   const MessageID message) const -> bool
+	static auto IsSubscribedToMessage(IMessageSubscriber* pSubscriber,
+							   const MessageID message) -> bool
 	{
 		return IsSubscribedToMessage(pSubscriber, MessageIDToString(message));
 	}


### PR DESCRIPTION
There are still two warnings about a no-discard function return values being discarded and like 50 `undefined-var-template` warnings about 3 static members: `EnumTraits<Type>::Invalid`, `EnumTraits<Type>::szName`, `Luna<Type>::m_sClassName`.