### PR TITLE
🔨 Update macOS Build and CI

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -40,8 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         cfg:
-          - { os: macos-10.15,  name: "Big Sur" }
-          - { os: macos-11,     name: "Catalina" }
+          - { os: macos-10.15,  name: "Catalina" }
 
     steps:
       - name: Checkout Etterna

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install apt packages
-        run: sudo apt update && sudo apt install ${{ matrix.cfg.cpp-version }} nasm ninja-build libglew-dev libxrandr-dev libxtst-dev libpulse-dev libasound-dev libogg-dev libvorbis-dev
+        run: sudo apt update && sudo apt install ${{ matrix.cfg.cpp-version }} nasm ninja-build libglew-dev libxrandr-dev libxtst-dev libpulse-dev libasound-dev libogg-dev libvorbis-dev xorg-dev
 
       - name: Print gcc + clang version
         run: ${{matrix.cfg.cpp-version}} --version
@@ -34,8 +34,15 @@ jobs:
         run: cd build && ninja
 
   macos:
-    name: macOS x64
-    runs-on: macos-latest
+    name: macOS x64 ${{matrix.cfg.name}}
+    runs-on: ${{matrix.cfg.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        cfg:
+          - { os: macos-10.15,  name: "Big Sur" }
+          - { os: macos-11,     name: "Catalina" }
+
     steps:
       - name: Checkout Etterna
         uses: actions/checkout@v2

--- a/CMake/Helpers/CMakeMacOS.cmake
+++ b/CMake/Helpers/CMakeMacOS.cmake
@@ -1,7 +1,7 @@
 # TODO: Remove CPU_X86_64, CPU_X86, and CRASH_HANDLER
 #       CRASH_HANDLER is unnecessary as the game should have that as an option component
 #       CPU_X86_64, CPU_X86 already exists as compiler predefined macros. Use those instead.
-list(APPEND cdefs _XOPEN_SOURCE CPU_X86_64)
+list(APPEND cdefs _XOPEN_SOURCE CPU_X86_64 GL_SILENCE_DEPRECATION)
 set_target_properties(Etterna PROPERTIES COMPILE_DEFINITIONS "${cdefs}")
 set_target_properties(Etterna PROPERTIES MACOSX_BUNDLE TRUE)
 set(CMAKE_EXE_LINKER_FLAGS "-pagezero_size 10000 -image_base 100000000")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ target_include_directories(Etterna PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)      
 ## Package Includes
 ### OpenSSL is not used directly by our program, but we have to use OpenSSL first
 ### in order to statically link. Once find_package is run once, it's results are cached
-if (WIN32)
+if (WIN32 OR APPLE)
     set(OPENSSL_USE_STATIC_LIBS ON CACHE BOOL "" FORCE)
 endif()
 set(OPENSSL_MSVC_STATIC_RT ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
- Update macOS CI to have OS name label. Attempted to add macOS Big Sur, but Github doesn't currently allow them for public use.
- Link OpenSSL statically on binary on macOS.