### PR TITLE
Fix audio thread wait screwing up rated audio

### DIFF
--- a/src/arch/Threads/Threads_Win32.cpp
+++ b/src/arch/Threads/Threads_Win32.cpp
@@ -385,13 +385,7 @@ EventImpl_Win32::Wait(float timeout)
 
 	unsigned iMilliseconds = INFINITE;
 	if (timeout > 0.F) {
-		// Does this break threads?
-		//   No. (???)
-		// Is this correct?
-		//   Quite the opposite.
-		// Why do we do this here but not the same in PThreads?
-		//   Because in PThreads Mac black screens completely
-		float fSecondsInFuture = -timeout;
+		float fSecondsInFuture = timeout;
 		iMilliseconds = static_cast<unsigned>(
 		  std::max(0, static_cast<int>(fSecondsInFuture * 1000)));
 	}


### PR DESCRIPTION
On develop, `RageSoundReader_ThreadedBuffer::BufferingThread` is currently never sleeping due to the inverted wait time. The fix is to call `timeBeginPeriod` which was lost in some shuffle. Without this but with the correct wait time, it wasn't being scheduled often enough by the OS and high rates caused its buffer to underrun. The call to `timeBeginPeriod` was maybe assumed to be for increasing the resolution of `timeGetTime`, but it achieves that through setting the timer resolution of the OS thread scheduler, which affects every thread in the process. 

Aside from this apparently fixing it, you can verify this was the issue in two ways:
 1) Remove `RageSoundReader_ThreadedBuffer` from the DSP chain, and high non-pitch rates work again. Who knows what the other consequences of this are
 2) Change `g_iMinFillFrames = 1024 * 4` to `1024 * 8` in `RageSoundReader_ThreadedBuffer.cpp`. This makes the buffering thread read ahead enough that the default scheduler period is not too large for it. Why 4 is bad and 8 is okay is fairly straightforward: `ThreadedBuffer` waits until it has 4096 samples (i.e, frames, a frame has one sample per channel) left before it reads in more samples. At 44.1kHz, 4096 samples takes ~90ms, and at 3x rate, that is exhausted in 30ms. The default scheduler period is 15.625ms. This means by the time the thread has realised it needs to buffer more audio, its already up to 15.625ms late, and any reading thread blocked waiting on an update will have to wait up to 15.625ms to start reading again. That's 31ms potential delay, and that's with no contention. So you got that buffer underrun right there. Even `timeBeginPeriod(15)` is enough to fix this on my machine!? 

Oh yeah its hard to tell listening to it but I'm pretty sure pitch rates were busted too