### PR TITLE
High precision timer frame timing

### DIFF
--- a/src/Etterna/Screen/Gameplay/ScreenGameplay.cpp
+++ b/src/Etterna/Screen/Gameplay/ScreenGameplay.cpp
@@ -778,11 +778,11 @@ ScreenGameplay::UpdateSongPosition(float fDeltaTime)
 		return;
 	}
 
-	RageTimer tm;
+	RageTimer tm = RageZeroTimer;
 	const auto fSeconds = m_pSoundMusic->GetPositionSeconds(nullptr, &tm);
 	const auto fAdjust = SOUND->GetFrameTimingAdjustment(fDeltaTime);
 	GAMESTATE->UpdateSongPosition(
-	  fSeconds + fAdjust, GAMESTATE->m_pCurSong->m_SongTiming, tm + fAdjust);
+	  fSeconds, fAdjust, GAMESTATE->m_pCurSong->m_SongTiming, tm);
 }
 
 void

--- a/src/Etterna/Screen/Others/ScreenSelectMusic.cpp
+++ b/src/Etterna/Screen/Others/ScreenSelectMusic.cpp
@@ -1330,6 +1330,7 @@ ScreenSelectMusic::AfterStepsOrTrailChange(const std::vector<PlayerNumber>& vpns
 
 		if (pSteps) {
 			GAMESTATE->UpdateSongPosition(pSong->m_fMusicSampleStartSeconds,
+										  0,
 										  *pSteps->GetTimingData());
 			delayedchartupdatewaiting = true;
 		}
@@ -1883,7 +1884,7 @@ class LunaScreenSelectMusic : public Luna<ScreenSelectMusic>
 				   score->GetScoreKey().c_str());
 		p->SetNextScreenName("ScreenEvaluationNormal");
 		p->StartTransitioningScreen(SM_BeginFadingOut);
-		
+
 		// set rate back to what it was before
 		GAMEMAN->m_bResetModifiers = true;
 		GAMEMAN->m_fPreviousRate = oldRate;

--- a/src/Etterna/Singletons/GameSoundManager.cpp
+++ b/src/Etterna/Singletons/GameSoundManager.cpp
@@ -543,14 +543,16 @@ GameSoundManager::GetFrameTimingAdjustment(float fDeltaTime)
 	 * by more than that, we probably had a frame skip, in which case we have
 	 * bigger skip problems, so don't adjust.
 	 */
-	static int iLastFPS = 0;
-	int iThisFPS = DISPLAY->GetFPS();
 
-	if (iThisFPS != (*DISPLAY->GetActualVideoModeParams()).rate ||
-		iThisFPS != iLastFPS) {
-		iLastFPS = iThisFPS;
+	if (DISPLAY->GetActualVideoModeParams()->vsync == false) {
 		return 0;
 	}
+
+	if (DISPLAY->IsPredictiveFrameLimit()) {
+		return 0;
+	}
+
+	int iThisFPS = DISPLAY->GetActualVideoModeParams()->rate;
 
 	const float fExpectedDelay = 1.0f / iThisFPS;
 	const float fExtraDelay = fDeltaTime - fExpectedDelay;

--- a/src/Etterna/Singletons/GameSoundManager.cpp
+++ b/src/Etterna/Singletons/GameSoundManager.cpp
@@ -642,6 +642,7 @@ GameSoundManager::Update(float fDeltaTime)
 		GAMESTATE->UpdateSongPosition(GAMESTATE->m_Position.m_fMusicSeconds +
 										fDeltaTime *
 										  g_Playing->m_Music->GetPlaybackRate(),
+									  fAdjust,
 									  g_Playing->m_Timing);
 		return;
 	}
@@ -688,12 +689,12 @@ GameSoundManager::Update(float fDeltaTime)
 	if (g_Playing->m_bTimingDelayed) {
 		/* We're still waiting for the new sound to start playing, so keep using
 		 * the old timing data and fake the time. */
-		GAMESTATE->UpdateSongPosition(GAMESTATE->m_Position.m_fMusicSeconds +
-										fDeltaTime,
+		GAMESTATE->UpdateSongPosition(GAMESTATE->m_Position.m_fMusicSeconds + fDeltaTime,
+									  fAdjust,
 									  g_Playing->m_Timing);
 	} else {
 		GAMESTATE->UpdateSongPosition(
-		  fSeconds + fAdjust, g_Playing->m_Timing, tm + fAdjust);
+		  fSeconds, fAdjust, g_Playing->m_Timing, tm);
 	}
 
 	// Send crossed messages

--- a/src/Etterna/Singletons/GameState.cpp
+++ b/src/Etterna/Singletons/GameState.cpp
@@ -755,8 +755,9 @@ GameState::ResetStageStatistics()
 
 void
 GameState::UpdateSongPosition(float fPositionSeconds,
+							  float fAdjust,
 							  const TimingData& timing,
-							  const RageTimer& timestamp)
+							  RageTimer timestamp)
 {
 	/* It's not uncommon to get a lot of duplicated positions from the sound
 	 * driver, like so: 13.120953,13.130975,13.130975,13.130975,13.140998,...
@@ -764,19 +765,15 @@ GameState::UpdateSongPosition(float fPositionSeconds,
 	 * RageTimer since the last change and multiply the delta by the current
 	 * rate when applied. */
 	if (fPositionSeconds == m_LastPositionSeconds && !m_paused) {
-		// LOG->Info("Time unchanged, adding: %+f",
-		//	m_LastPositionTimer.Ago()*m_SongOptions.GetSong().m_fMusicRate
-		//);
 		fPositionSeconds +=
 		  m_LastPositionTimer.Ago() * m_SongOptions.GetSong().m_fMusicRate;
 	} else {
-		// LOG->Info("Time difference: %+f",
-		//	m_LastPositionTimer.Ago() - (fPositionSeconds -
-		// m_LastPositionSeconds)
-		//);
 		m_LastPositionTimer.Touch();
 		m_LastPositionSeconds = fPositionSeconds;
 	}
+
+	fPositionSeconds += fAdjust;
+	timestamp += fAdjust;
 
 	if (m_pCurSteps) {
 		m_Position.UpdateSongPosition(
@@ -791,8 +788,6 @@ GameState::UpdateSongPosition(float fPositionSeconds,
 					  GAMESTATE->m_Position.m_fSongBeatVisible,
 					  fPositionSeconds,
 					  GAMESTATE->m_Position.m_fSongBeatNoOffset);
-	//	LOG->Trace( "m_fMusicSeconds = %f, m_fSongBeat = %f, m_fCurBPS = %f,
-	// m_bFreeze = %f", m_fMusicSeconds, m_fSongBeat, m_fCurBPS, m_bFreeze );
 }
 
 float

--- a/src/Etterna/Singletons/GameState.cpp
+++ b/src/Etterna/Singletons/GameState.cpp
@@ -759,6 +759,8 @@ GameState::UpdateSongPosition(float fPositionSeconds,
 							  const TimingData& timing,
 							  RageTimer timestamp)
 {
+	const float fMusicRate = m_SongOptions.GetSong().m_fMusicRate;
+
 	/* It's not uncommon to get a lot of duplicated positions from the sound
 	 * driver, like so: 13.120953,13.130975,13.130975,13.130975,13.140998,...
 	 * This causes visual stuttering of the arrows. To compensate, keep a
@@ -766,13 +768,13 @@ GameState::UpdateSongPosition(float fPositionSeconds,
 	 * rate when applied. */
 	if (fPositionSeconds == m_LastPositionSeconds && !m_paused) {
 		fPositionSeconds +=
-		  m_LastPositionTimer.Ago() * m_SongOptions.GetSong().m_fMusicRate;
+		  m_LastPositionTimer.Ago() * fMusicRate;
 	} else {
 		m_LastPositionTimer.Touch();
 		m_LastPositionSeconds = fPositionSeconds;
 	}
 
-	fPositionSeconds += fAdjust;
+	fPositionSeconds += fAdjust * fMusicRate;
 	timestamp += fAdjust;
 
 	if (m_pCurSteps) {

--- a/src/Etterna/Singletons/GameState.h
+++ b/src/Etterna/Singletons/GameState.h
@@ -243,8 +243,9 @@ class GameState
 	void SetPaused(bool p) { m_paused = p; }
 	[[nodiscard]] auto GetPaused() const -> bool { return m_paused; }
 	void UpdateSongPosition(float fPositionSeconds,
+							float fAdjust,
 							const TimingData& timing,
-							const RageTimer& timestamp = RageZeroTimer);
+							RageTimer timestamp = RageTimer(0));
 	[[nodiscard]] auto GetSongPercent(float beat) const -> float;
 
 	[[nodiscard]] auto AllAreInDangerOrWorse() const -> bool;

--- a/src/RageUtil/Graphics/RageDisplay.cpp
+++ b/src/RageUtil/Graphics/RageDisplay.cpp
@@ -12,7 +12,6 @@
 #include "RageSurface_Save_BMP.h"
 #include "RageSurface_Save_JPEG.h"
 #include "RageSurface_Save_PNG.h"
-#include "RageUtil/Misc/RageTimer.h"
 #include "RageUtil/Utils/RageUtil.h"
 #include "Etterna/Screen/Others/Screen.h"
 #include "Etterna/Singletons/ScreenManager.h"
@@ -48,8 +47,11 @@ RageDisplay::GetCumFPS() const
 
 static int g_iFramesRenderedSinceLastCheck, g_iFramesRenderedSinceLastReset,
   g_iVertsRenderedSinceLastCheck, g_iNumChecksSinceLastReset;
-static RageTimer g_LastFrameEndedAtRage(RageZeroTimer);
 static auto g_LastFrameEndedAt = std::chrono::steady_clock::now();
+static std::chrono::nanoseconds g_LastFrameDuration =
+  std::chrono::duration<int64_t>();
+static std::chrono::nanoseconds g_FrameCorrection =
+  std::chrono::duration<int64_t>(0);
 static auto g_FrameRenderTime = std::chrono::steady_clock::now();
 static std::chrono::nanoseconds g_LastFrameRenderTime;
 static std::chrono::nanoseconds g_LastFramePresentTime;
@@ -958,9 +960,7 @@ RageDisplay::UpdateCentering()
 bool
 RageDisplay::SaveScreenshot(const std::string& sPath, GraphicsFileFormat format)
 {
-	RageTimer timer;
 	auto surface = this->CreateScreenshot();
-	//	LOG->Trace( "CreateScreenshot took %f seconds", timer.GetDeltaTime() );
 	/* Unless we're in lossless, resize the image to 640x480.  If we're saving
 	 * lossy, there's no sense in saving 1280x960 screenshots, and we don't want
 	 * to output screenshots in a strange (non-1) sample aspect ratio. */
@@ -972,12 +972,7 @@ RageDisplay::SaveScreenshot(const std::string& sPath, GraphicsFileFormat format)
 		// 639x480 (4:3) and 853x480 (16:9). ceilf gives correct values. -aj
 		const auto iWidth = static_cast<int>(
 		  ceilf(iHeight * (*GetActualVideoModeParams()).fDisplayAspectRatio));
-		timer.Touch();
 		RageSurfaceUtils::Zoom(surface, iWidth, iHeight);
-		//		LOG->Trace( "%ix%i -> %ix%i (%.3f) in %f seconds", surface->w,
-		// surface->h, iWidth, iHeight,
-		// GetActualVideoModeParams().fDisplayAspectRatio, timer.GetDeltaTime()
-		//);
 	}
 
 	RageFile out;
@@ -988,7 +983,6 @@ RageDisplay::SaveScreenshot(const std::string& sPath, GraphicsFileFormat format)
 	}
 
 	auto bSuccess = false;
-	timer.Touch();
 	std::string strError = "";
 	switch (format) {
 		case SAVE_LOSSLESS:
@@ -1005,8 +999,6 @@ RageDisplay::SaveScreenshot(const std::string& sPath, GraphicsFileFormat format)
 			break;
 			DEFAULT_FAIL(format);
 	}
-	//	LOG->Trace( "Saving Screenshot file took %f seconds.",
-	// timer.GetDeltaTime() );
 
 	SAFE_DELETE(surface);
 
@@ -1128,32 +1120,61 @@ RageDisplay::DrawCircle(const RageSpriteVertex& v, float radius)
 	this->DrawCircleInternal(v, radius);
 }
 
+static auto
+targetFrameTime() -> double
+{
+	auto result = 0.0;
+	if ((SCREENMAN != nullptr) && (SCREENMAN->GetTopScreen() != nullptr)) {
+		auto inGameplay =
+		  SCREENMAN->GetTopScreen()->GetScreenType() == gameplay;
+		if (inGameplay && g_fFrameLimitGameplay.Get() > 0) {
+			result = 1.0 / g_fFrameLimitGameplay.Get();
+		} else if (!inGameplay && g_fFrameLimit.Get() > 0) {
+			result = 1.0 / g_fFrameLimit.Get();
+		}
+	}
+	return result;
+}
+
 void
 RageDisplay::FrameLimitBeforeVsync()
 {
+	auto waitTime = targetFrameTime();
 	if (g_fPredictiveFrameLimit.Get()) {
 		const auto afterRender = std::chrono::steady_clock::now();
 		const auto endTime = afterRender - g_FrameRenderTime;
 
 		g_LastFrameRenderTime = endTime;
-	} else if (!g_fPredictiveFrameLimit.Get() &&
-			   !g_LastFrameEndedAtRage.IsZero() &&
-			   (g_fFrameLimit.Get() != 0 || g_fFrameLimitGameplay.Get() != 0)) {
-		auto expectedDelta = 0.0;
-		if ((SCREENMAN != nullptr) && (SCREENMAN->GetTopScreen() != nullptr)) {
-			if (SCREENMAN->GetTopScreen()->GetScreenType() == gameplay &&
-				g_fFrameLimitGameplay.Get() > 0)
-				expectedDelta = 1.0 / g_fFrameLimitGameplay.Get();
-			else if (SCREENMAN->GetTopScreen()->GetScreenType() != gameplay &&
-					 g_fFrameLimit.Get() > 0)
-				expectedDelta = 1.0 / g_fFrameLimit.Get();
-		}
+	} else if (!PREFSMAN->m_bVsync.Get() && waitTime > 0.0) {
+		auto waitNanoseconds =
+		  std::chrono::duration_cast<std::chrono::nanoseconds>(
+			std::chrono::duration<double>(waitTime));
 
-		auto advanceDelay =
-		  expectedDelta - g_LastFrameEndedAtRage.GetDeltaTime();
-		while (advanceDelay > 0.0) {
-			advanceDelay -= g_LastFrameEndedAtRage.GetDeltaTime();
+		// Estimate how long to wait to meet our frame time.
+		// Rationale: the following
+		//
+		//  auto t = g_LastFrameEndedAt + waitTime;
+		//  while (t > now());
+		//
+		// is too tight and waits slightly too long (trivially, by at least
+		// the amount of time required to exit the loop). In practice this
+		// effect noticeably reduces measured FPS. To account for it, measure
+		// the frame times we are actually getting and gradually adjust the
+		// delay to bring it in line with the target frame time.
+		auto adjustment = (g_LastFrameDuration - waitNanoseconds).count() / 16;
+		g_FrameCorrection -= std::chrono::nanoseconds(adjustment);
+		CLAMP(g_FrameCorrection,
+			  std::chrono::milliseconds(-8),
+			  std::chrono::milliseconds(0));
+
+		auto estimatedTimeToWait = waitNanoseconds + g_FrameCorrection;
+		auto t = g_LastFrameEndedAt + estimatedTimeToWait;
+		while (t > std::chrono::steady_clock::now()) {
+			std::this_thread::yield();
 		}
+	} else {
+		// Ignore frame limit preferences if v-sync is enabled without
+		// predictive frame limit.
 	}
 
 	if (!GameLoop::isGameFocused())
@@ -1172,25 +1193,18 @@ RageDisplay::FrameLimitBeforeVsync()
 void
 RageDisplay::FrameLimitAfterVsync(int iFPS)
 {
+	const auto frameEndedAt = std::chrono::steady_clock::now();
+	g_LastFrameDuration = frameEndedAt - g_LastFrameEndedAt;
+	g_LastFrameEndedAt = frameEndedAt;
+
 	if (!g_fPredictiveFrameLimit.Get()) {
-		g_LastFrameEndedAtRage.Touch();
 		return;
 	}
-	if (!PREFSMAN->m_bVsync.Get() && g_fFrameLimit.Get() == 0 &&
-		g_fFrameLimitGameplay.Get() == 0)
+
+	auto waitTime = targetFrameTime();
+
+	if (!PREFSMAN->m_bVsync.Get() && waitTime == 0.0) {
 		return;
-
-	g_LastFrameEndedAt = std::chrono::steady_clock::now();
-
-	// Get the target frame time
-	auto waitTime = 0.0;
-	if ((SCREENMAN != nullptr) && (SCREENMAN->GetTopScreen() != nullptr)) {
-		if (SCREENMAN->GetTopScreen()->GetScreenType() == gameplay &&
-			g_fFrameLimitGameplay.Get() > 0)
-			waitTime = 1.0 / g_fFrameLimitGameplay.Get();
-		else if (SCREENMAN->GetTopScreen()->GetScreenType() != gameplay &&
-				 g_fFrameLimit.Get() > 0)
-			waitTime = 1.0 / g_fFrameLimit.Get();
 	}
 
 	// Not using frame limiter and vsync is enabled


### PR DESCRIPTION
I'm PRing this separately from the audio timing because it's a bit more opinionated and technically changes existing behaviour that maybe some people prefer somehow.

The current implementation is effectively flooring `now()` to milliseconds, and estimating frame times in microseconds, which has the effect of underestimating the time it has to wait to hit the desired fps.  You can think of it as subtracting a random value between 0 and 1000 microseconds in such a way that the average of the random values makes the measured FPS hit the desired FPS with however much resolution it had (looks like 1ms).

Replacing everything with high precision timers you get the opposite problem: if the current time is specified in high accuracy then waiting for the entire frame time to elapse means we definitely wait too long. I haven't thought too deeply about it but I'm pretty sure the amount of overshoot is machine and workload dependent so you can't just slap -250 microseconds on there and call it done. To hit the desired frame time you have to measure the frame times you are actually getting and compensate. The implementation I did was 1) the first thing I thought of 2) not researched in anyway. But it works and is low overhead, so, you know

Now, the opinionated part: v-sync is busted. First, `GameSoundManager::GetFrameTimingAdjustment` was supposed to account for thread scheduling lag by taking advantage of the reference time vsync gives you but didn't check for vsync correctly (that is, it was broken, but even if it wasn't broken, it was still wrong, and why on earth is it in GameSoundManager?). This is fixed.

Next, the current v-sync behavior if a frame limit is set is to _always busy wait before presenting a frame_. This is bad in one probably common case: setting v-sync on and the frame limit to the monitor refresh rate. All this can do is add a frame of lag.

My guess is this happened because the interaction between frame timing, v-sync, and predictive v-sync (also busted) is not obvious, so I moved all frame timing logic off the non-predictive v-sync and framelimit=0 paths. This means normal v-sync ignores any framelimit settings. Predictive v-sync I left alone.

Both of these things can change how the game feels for people who use vsync. imo for the better, but, eh