### PR TITLE
Fix bug with non-exclusive filters and required Length/Clear% ranges

### DIFF
--- a/src/Etterna/Models/Songs/Song.cpp
+++ b/src/Etterna/Models/Songs/Song.cpp
@@ -1539,7 +1539,8 @@ Song::GetForegroundChanges()
 }
 
 std::vector<std::string>
-Song::GetChangesToVectorString(const std::vector<BackgroundChange>& changes) const
+Song::GetChangesToVectorString(
+  const std::vector<BackgroundChange>& changes) const
 {
 	std::vector<std::string> ret;
 	ret.reserve(changes.size());
@@ -1739,6 +1740,7 @@ bool
 Song::ChartMatchesFilter(Steps* chart, float rate) const
 {
 	auto matches_skills = FILTERMAN->ExclusiveFilter;
+	bool foundActiveSkillset = false;
 	/* The default behaviour of an exclusive filter is to accept
 	 * by default, (i.e. matches_skills=true) and reject if any skill
 	 * filters fail. The default behaviour of a non-exclusive filter is
@@ -1753,6 +1755,10 @@ Song::ChartMatchesFilter(Steps* chart, float rate) const
 		const auto lb = FILTERMAN->GetFilter(static_cast<Skillset>(ss), 0);
 		const auto ub = FILTERMAN->GetFilter(static_cast<Skillset>(ss), 1);
 		if (lb > 0.F || ub > 0.F) { // If either bound is active, continue
+			if (ss < NUM_Skillset) {
+				// We have at least one active filter that is a skillset
+				foundActiveSkillset = true;
+			}
 			if (!FILTERMAN->ExclusiveFilter) {
 				/* Non-Exclusive filter
 				 * (It doesn't make sense for either to trigger on exclusive
@@ -1810,7 +1816,13 @@ Song::ChartMatchesFilter(Steps* chart, float rate) const
 				if ((val > lb || !(lb > 0.F)) && (val < ub || !(ub > 0.F))) {
 					/* If we're above the lower bound or it's not set
 					 * and also below the upper bound or it isn't set*/
-					matches_skills = true;
+					if (ss < NUM_Skillset || !foundActiveSkillset) {
+						/* If this is a skillset range, we're set.
+						 * If it's one of the values that must be
+						 * matched always, don't count it unless
+						 * only those are active*/
+						matches_skills = true;
+					}
 				} else if ((ss == NUM_Skillset) || (ss == NUM_Skillset + 1)) {
 					// This is an always-required filter,
 					// but we didn't match it.


### PR DESCRIPTION
Both Length and Clear% must always be matched, even in non-exlusive mode.
However, this has the effect of non-exlusive mode just becoming any chart
that matches either of those ranges, regardless of skillsets.

This changes them to require a skillset to be matched if any are set; if
no skillset ranges are set, a non-exclusive filter using only length/clear%
behaves identically to an exclusive one.