### PR TITLE
Butter

### DIFF
--- a/src/Etterna/Actor/Base/Actor.cpp
+++ b/src/Etterna/Actor/Base/Actor.cpp
@@ -900,7 +900,7 @@ Actor::UpdateInternal(float delta_time)
 			break;
 		case CLOCK_TIMER_GLOBAL:
 			generic_global_timer_update(
-			  static_cast<float>(RageTimer::GetUsecsSinceStart()),
+			  RageTimer::GetTimeSinceStart(),
 			  m_fEffectDelta,
 			  m_fSecsIntoEffect);
 			break;

--- a/src/Etterna/Actor/Gameplay/Player.cpp
+++ b/src/Etterna/Actor/Gameplay/Player.cpp
@@ -1928,25 +1928,15 @@ Player::Step(int col,
 			 bool bRelease,
 			 float padStickSeconds)
 {
-	// Do everything that depends on a timer here;
-	// set your breakpoints somewhere after this block.
-	std::chrono::duration<float> stepDelta =
-	  std::chrono::steady_clock::now() - tm;
-	auto stepAgo = stepDelta.count() - padStickSeconds;
-
-	const auto fLastBeatUpdate = GAMESTATE->m_Position.m_LastBeatUpdate.Ago();
-	const auto fPositionSeconds =
-	  GAMESTATE->m_Position.m_fMusicSeconds - stepAgo;
-	const auto fTimeSinceStep = stepAgo;
-
-	// input data
-	//m_pPlayerStageStats->InputData.emplace_back(!bRelease, col, fPositionSeconds);
-
-	auto fSongBeat = GAMESTATE->m_Position.m_fSongBeat;
-
-	if (GAMESTATE->m_pCurSteps != nullptr) {
-		fSongBeat = m_Timing->GetBeatFromElapsedTime(fPositionSeconds);
-	}
+	const auto fMusicRate =
+		GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate;
+	const auto fHitUpdateDelta =
+		(GAMESTATE->m_Position.m_LastBeatUpdate - RageTimer(tm)) - padStickSeconds;
+	const auto fMusicSeconds =
+		GAMESTATE->m_Position.m_fMusicSeconds - (fHitUpdateDelta * fMusicRate);
+	const auto fSongBeat =
+		GAMESTATE->m_pCurSteps ? m_Timing->GetBeatFromElapsedTime(fMusicSeconds)
+							   : GAMESTATE->m_Position.m_fSongBeat;
 
 	const auto iSongRow = row == -1 ? BeatToNoteRow(fSongBeat) : row;
 
@@ -2104,41 +2094,12 @@ Player::Step(int col,
 	if (iRowOfOverlappingNoteOrRow != -1 && col != -1) {
 		// compute the score for this hit
 		auto fNoteOffset = 0.F;
-		// only valid if
-		auto fMusicSeconds = 0.F;
 		// we need this later if we are autosyncing
 		const auto fStepBeat = NoteRowToBeat(iRowOfOverlappingNoteOrRow);
 		const auto fStepSeconds = m_Timing->WhereUAtBro(fStepBeat);
 
 		if (row == -1) {
-			// We actually stepped on the note this long ago:
-			// fTimeSinceStep
-
-			/* GAMESTATE->m_fMusicSeconds is the music time as of
-			 * GAMESTATE->m_LastBeatUpdate. Figure out what the music time
-			 * is as of now. */
-			const auto fCurrentMusicSeconds =
-			  GAMESTATE->m_Position.m_fMusicSeconds +
-			  (fLastBeatUpdate *
-			   GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate);
-
-			// ... which means it happened at this point in the music:
-			fMusicSeconds =
-			  fCurrentMusicSeconds -
-			  fTimeSinceStep *
-				GAMESTATE->m_SongOptions.GetCurrent().m_fMusicRate;
-
-			// The offset from the actual step in seconds:
-			fNoteOffset = (fStepSeconds - fMusicSeconds) /
-						  GAMESTATE->m_SongOptions.GetCurrent()
-							.m_fMusicRate; // account for music rate
-										   /*
-										   LOG->Trace("step was %.3f ago, music is off by %f: %f vs %f,
-										   step							    was %f off",
-										   fTimeSinceStep,
-										   GAMESTATE->m_LastBeatUpdate.Ago()/GAMESTATE->m_SongOptions.m_fMusicRate,
-											   fStepSeconds, fMusicSeconds, fNoteOffset );
-										   */
+			fNoteOffset = (fStepSeconds - fMusicSeconds) / fMusicRate;
 		}
 
 		NOTESKIN->SetLastSeenColor(

--- a/src/Etterna/Screen/Gameplay/ScreenGameplay.cpp
+++ b/src/Etterna/Screen/Gameplay/ScreenGameplay.cpp
@@ -778,11 +778,13 @@ ScreenGameplay::UpdateSongPosition(float fDeltaTime)
 		return;
 	}
 
+	const auto rate = GAMESTATE->m_SongOptions.GetSong().m_fMusicRate;
+
 	RageTimer tm = RageZeroTimer;
 	const auto fSeconds = m_pSoundMusic->GetPositionSeconds(nullptr, &tm);
-	const auto fAdjust = SOUND->GetFrameTimingAdjustment(fDeltaTime);
+	const auto vsyncAdjust = SOUND->GetFrameTimingAdjustment(fDeltaTime);
 	GAMESTATE->UpdateSongPosition(
-	  fSeconds, fAdjust, GAMESTATE->m_pCurSong->m_SongTiming, tm);
+	  fSeconds + vsyncAdjust * rate, GAMESTATE->m_pCurSong->m_SongTiming, tm + vsyncAdjust);
 }
 
 void

--- a/src/Etterna/Screen/Gameplay/ScreenGameplay.cpp
+++ b/src/Etterna/Screen/Gameplay/ScreenGameplay.cpp
@@ -778,11 +778,11 @@ ScreenGameplay::UpdateSongPosition(float fDeltaTime)
 		return;
 	}
 
-	RageTimer tm;
+	RageTimer tm = RageZeroTimer;
 	const auto fSeconds = m_pSoundMusic->GetPositionSeconds(nullptr, &tm);
 	const auto fAdjust = SOUND->GetFrameTimingAdjustment(fDeltaTime);
 	GAMESTATE->UpdateSongPosition(
-	  fSeconds + fAdjust, GAMESTATE->m_pCurSong->m_SongTiming, tm + fAdjust);
+	  fSeconds, fAdjust, GAMESTATE->m_pCurSong->m_SongTiming, tm);
 }
 
 void

--- a/src/Etterna/Screen/Gameplay/ScreenGameplay.cpp
+++ b/src/Etterna/Screen/Gameplay/ScreenGameplay.cpp
@@ -723,7 +723,7 @@ ScreenGameplay::StartPlayingSong(float fMinTimeToNotes, float fMinTimeToMusic)
 
 	/* Make sure GAMESTATE->m_fMusicSeconds is set up. */
 	GAMESTATE->m_Position.m_fMusicSeconds = -5000;
-	UpdateSongPosition(0);
+	UpdateSongPosition();
 
 	ASSERT(GAMESTATE->m_Position.m_fMusicSeconds >
 		   -4000); /* make sure the "fake timer" code doesn't trigger */
@@ -772,7 +772,7 @@ ScreenGameplay::PlayAnnouncer(const std::string& type,
 }
 
 void
-ScreenGameplay::UpdateSongPosition(float fDeltaTime)
+ScreenGameplay::UpdateSongPosition()
 {
 	if (!m_pSoundMusic->IsPlaying()) {
 		return;
@@ -782,9 +782,8 @@ ScreenGameplay::UpdateSongPosition(float fDeltaTime)
 
 	RageTimer tm = RageZeroTimer;
 	const auto fSeconds = m_pSoundMusic->GetPositionSeconds(nullptr, &tm);
-	const auto vsyncAdjust = SOUND->GetFrameTimingAdjustment(fDeltaTime);
 	GAMESTATE->UpdateSongPosition(
-	  fSeconds + vsyncAdjust * rate, GAMESTATE->m_pCurSong->m_SongTiming, tm + vsyncAdjust);
+	  fSeconds, GAMESTATE->m_pCurSong->m_SongTiming, tm);
 }
 
 void
@@ -889,7 +888,7 @@ ScreenGameplay::Update(float fDeltaTime)
 		return;
 	}
 
-	UpdateSongPosition(fDeltaTime);
+	UpdateSongPosition();
 
 	if (m_bZeroDeltaOnNextUpdate) {
 		ScreenWithMenuElements::Update(0);

--- a/src/Etterna/Screen/Gameplay/ScreenGameplay.h
+++ b/src/Etterna/Screen/Gameplay/ScreenGameplay.h
@@ -100,7 +100,7 @@ class ScreenGameplay : public ScreenWithMenuElements
 
 	void PlayTicks();
 	// Used to update some pointers
-	void UpdateSongPosition(float fDeltaTime);
+	void UpdateSongPosition();
 	void SongFinished();
 	virtual void SaveStats();
 	virtual void StageFinished(bool bBackedOut);

--- a/src/Etterna/Screen/Gameplay/ScreenGameplayPractice.cpp
+++ b/src/Etterna/Screen/Gameplay/ScreenGameplayPractice.cpp
@@ -163,7 +163,7 @@ ScreenGameplayPractice::Update(const float fDeltaTime)
 		return;
 	}
 
-	UpdateSongPosition(fDeltaTime);
+	UpdateSongPosition();
 
 	if (m_bZeroDeltaOnNextUpdate) {
 		ScreenWithMenuElements::Update(0); // NOLINT(bugprone-parent-virtual-call)
@@ -382,7 +382,7 @@ ScreenGameplayPractice::SetSongPosition(float newSongPositionSeconds,
 
 	// Set the final position
 	SOUND->SetSoundPosition(m_pSoundMusic, newSongPositionSeconds - noteDelay);
-	UpdateSongPosition(0);
+	UpdateSongPosition();
 
 	// Unpause the music if we want it unpaused
 	if (unpause && isPaused) {

--- a/src/Etterna/Screen/Gameplay/ScreenGameplayReplay.cpp
+++ b/src/Etterna/Screen/Gameplay/ScreenGameplayReplay.cpp
@@ -143,7 +143,7 @@ ScreenGameplayReplay::Update(const float fDeltaTime)
 		return;
 	}
 
-	UpdateSongPosition(fDeltaTime);
+	UpdateSongPosition();
 
 	if (m_bZeroDeltaOnNextUpdate) {
 		ScreenWithMenuElements::Update(0); // NOLINT(bugprone-parent-virtual-call)
@@ -359,7 +359,7 @@ ScreenGameplayReplay::SetRate(const float newRate) -> float
 
 	// misc info update
 	GAMESTATE->m_Position.m_fMusicSeconds = fSeconds;
-	UpdateSongPosition(0);
+	UpdateSongPosition();
 	MESSAGEMAN->Broadcast(
 	  "CurrentRateChanged"); // Tell the theme we changed the rate
 

--- a/src/Etterna/Screen/Others/ScreenSelectMusic.cpp
+++ b/src/Etterna/Screen/Others/ScreenSelectMusic.cpp
@@ -1330,6 +1330,7 @@ ScreenSelectMusic::AfterStepsOrTrailChange(const std::vector<PlayerNumber>& vpns
 
 		if (pSteps) {
 			GAMESTATE->UpdateSongPosition(pSong->m_fMusicSampleStartSeconds,
+										  0,
 										  *pSteps->GetTimingData());
 			delayedchartupdatewaiting = true;
 		}
@@ -1884,7 +1885,7 @@ class LunaScreenSelectMusic : public Luna<ScreenSelectMusic>
 				   score->GetScoreKey().c_str());
 		p->SetNextScreenName("ScreenEvaluationNormal");
 		p->StartTransitioningScreen(SM_BeginFadingOut);
-		
+
 		// set rate back to what it was before
 		GAMEMAN->m_bResetModifiers = true;
 		GAMEMAN->m_fPreviousRate = oldRate;

--- a/src/Etterna/Screen/Others/ScreenSelectMusic.cpp
+++ b/src/Etterna/Screen/Others/ScreenSelectMusic.cpp
@@ -1330,7 +1330,6 @@ ScreenSelectMusic::AfterStepsOrTrailChange(const std::vector<PlayerNumber>& vpns
 
 		if (pSteps) {
 			GAMESTATE->UpdateSongPosition(pSong->m_fMusicSampleStartSeconds,
-										  0,
 										  *pSteps->GetTimingData());
 			delayedchartupdatewaiting = true;
 		}

--- a/src/Etterna/Singletons/GameSoundManager.cpp
+++ b/src/Etterna/Singletons/GameSoundManager.cpp
@@ -543,14 +543,16 @@ GameSoundManager::GetFrameTimingAdjustment(float fDeltaTime)
 	 * by more than that, we probably had a frame skip, in which case we have
 	 * bigger skip problems, so don't adjust.
 	 */
-	static int iLastFPS = 0;
-	int iThisFPS = DISPLAY->GetFPS();
 
-	if (iThisFPS != (*DISPLAY->GetActualVideoModeParams()).rate ||
-		iThisFPS != iLastFPS) {
-		iLastFPS = iThisFPS;
+	if (DISPLAY->GetActualVideoModeParams()->vsync == false) {
 		return 0;
 	}
+
+	if (DISPLAY->IsPredictiveFrameLimit()) {
+		return 0;
+	}
+
+	int iThisFPS = DISPLAY->GetActualVideoModeParams()->rate;
 
 	const float fExpectedDelay = 1.0f / iThisFPS;
 	const float fExtraDelay = fDeltaTime - fExpectedDelay;

--- a/src/Etterna/Singletons/GameSoundManager.cpp
+++ b/src/Etterna/Singletons/GameSoundManager.cpp
@@ -637,12 +637,11 @@ GameSoundManager::Update(float fDeltaTime)
 		return;
 
 	const float fAdjust = GetFrameTimingAdjustment(fDeltaTime);
+	const float fRate = g_Playing->m_Music->GetPlaybackRate();
 	if (!g_Playing->m_Music->IsPlaying()) {
 		/* There's no song playing.  Fake it. */
 		GAMESTATE->UpdateSongPosition(GAMESTATE->m_Position.m_fMusicSeconds +
-										fDeltaTime *
-										  g_Playing->m_Music->GetPlaybackRate(),
-									  fAdjust,
+										(fDeltaTime + fAdjust) * fRate,
 									  g_Playing->m_Timing);
 		return;
 	}
@@ -659,8 +658,7 @@ GameSoundManager::Update(float fDeltaTime)
 	// Check for song timing skips.
 	if (PREFSMAN->m_bLogSkips && !g_Playing->m_bTimingDelayed) {
 		const float fExpectedTimePassed =
-		  (tm - GAMESTATE->m_Position.m_LastBeatUpdate) *
-		  g_Playing->m_Music->GetPlaybackRate();
+		  (tm - GAMESTATE->m_Position.m_LastBeatUpdate) * fRate;
 		const float fSoundTimePassed =
 		  fSeconds - GAMESTATE->m_Position.m_fMusicSeconds;
 		const float fDiff = fExpectedTimePassed - fSoundTimePassed;
@@ -689,12 +687,12 @@ GameSoundManager::Update(float fDeltaTime)
 	if (g_Playing->m_bTimingDelayed) {
 		/* We're still waiting for the new sound to start playing, so keep using
 		 * the old timing data and fake the time. */
-		GAMESTATE->UpdateSongPosition(GAMESTATE->m_Position.m_fMusicSeconds + fDeltaTime,
-									  fAdjust,
+		GAMESTATE->UpdateSongPosition(GAMESTATE->m_Position.m_fMusicSeconds
+									 + (fDeltaTime + fAdjust) * fRate,
 									  g_Playing->m_Timing);
 	} else {
 		GAMESTATE->UpdateSongPosition(
-		  fSeconds, fAdjust, g_Playing->m_Timing, tm);
+		  fSeconds + fAdjust * fRate, g_Playing->m_Timing, tm + fAdjust);
 	}
 
 	// Send crossed messages

--- a/src/Etterna/Singletons/GameSoundManager.cpp
+++ b/src/Etterna/Singletons/GameSoundManager.cpp
@@ -642,6 +642,7 @@ GameSoundManager::Update(float fDeltaTime)
 		GAMESTATE->UpdateSongPosition(GAMESTATE->m_Position.m_fMusicSeconds +
 										fDeltaTime *
 										  g_Playing->m_Music->GetPlaybackRate(),
+									  fAdjust,
 									  g_Playing->m_Timing);
 		return;
 	}
@@ -688,12 +689,12 @@ GameSoundManager::Update(float fDeltaTime)
 	if (g_Playing->m_bTimingDelayed) {
 		/* We're still waiting for the new sound to start playing, so keep using
 		 * the old timing data and fake the time. */
-		GAMESTATE->UpdateSongPosition(GAMESTATE->m_Position.m_fMusicSeconds +
-										fDeltaTime,
+		GAMESTATE->UpdateSongPosition(GAMESTATE->m_Position.m_fMusicSeconds + fDeltaTime,
+									  fAdjust,
 									  g_Playing->m_Timing);
 	} else {
 		GAMESTATE->UpdateSongPosition(
-		  fSeconds + fAdjust, g_Playing->m_Timing, tm + fAdjust);
+		  fSeconds, fAdjust, g_Playing->m_Timing, tm);
 	}
 
 	// Send crossed messages

--- a/src/Etterna/Singletons/GameSoundManager.h
+++ b/src/Etterna/Singletons/GameSoundManager.h
@@ -71,7 +71,6 @@ class GameSoundManager : MessageSubscriber
 	void PlayOnceFromAnnouncer(const std::string& sFolderName);
 
 	void HandleSongTimer(bool on = true);
-	auto GetFrameTimingAdjustment(float fDeltaTime) -> float;
 
 	static auto GetPlayerBalance(PlayerNumber pn) -> float;
 	void WithRageSoundPlaying(std::function<void(RageSound*)> f);

--- a/src/Etterna/Singletons/GameState.cpp
+++ b/src/Etterna/Singletons/GameState.cpp
@@ -755,28 +755,9 @@ GameState::ResetStageStatistics()
 
 void
 GameState::UpdateSongPosition(float fPositionSeconds,
-							  float fAdjust,
 							  const TimingData& timing,
-							  RageTimer timestamp)
+							  const RageTimer& timestamp)
 {
-	const float fMusicRate = m_SongOptions.GetSong().m_fMusicRate;
-
-	/* It's not uncommon to get a lot of duplicated positions from the sound
-	 * driver, like so: 13.120953,13.130975,13.130975,13.130975,13.140998,...
-	 * This causes visual stuttering of the arrows. To compensate, keep a
-	 * RageTimer since the last change and multiply the delta by the current
-	 * rate when applied. */
-	if (fPositionSeconds == m_LastPositionSeconds && !m_paused) {
-		fPositionSeconds +=
-		  m_LastPositionTimer.Ago() * fMusicRate;
-	} else {
-		m_LastPositionTimer.Touch();
-		m_LastPositionSeconds = fPositionSeconds;
-	}
-
-	fPositionSeconds += fAdjust * fMusicRate;
-	timestamp += fAdjust;
-
 	if (m_pCurSteps) {
 		m_Position.UpdateSongPosition(
 		  fPositionSeconds, *m_pCurSteps->GetTimingData(), timestamp);

--- a/src/Etterna/Singletons/GameState.cpp
+++ b/src/Etterna/Singletons/GameState.cpp
@@ -755,8 +755,9 @@ GameState::ResetStageStatistics()
 
 void
 GameState::UpdateSongPosition(float fPositionSeconds,
+							  float fAdjust,
 							  const TimingData& timing,
-							  const RageTimer& timestamp)
+							  RageTimer timestamp)
 {
 	/* It's not uncommon to get a lot of duplicated positions from the sound
 	 * driver, like so: 13.120953,13.130975,13.130975,13.130975,13.140998,...
@@ -764,19 +765,15 @@ GameState::UpdateSongPosition(float fPositionSeconds,
 	 * RageTimer since the last change and multiply the delta by the current
 	 * rate when applied. */
 	if (fPositionSeconds == m_LastPositionSeconds && !m_paused) {
-		// LOG->Info("Time unchanged, adding: %+f",
-		//	m_LastPositionTimer.Ago()*m_SongOptions.GetSong().m_fMusicRate
-		//);
 		fPositionSeconds +=
 		  m_LastPositionTimer.Ago() * m_SongOptions.GetSong().m_fMusicRate;
 	} else {
-		// LOG->Info("Time difference: %+f",
-		//	m_LastPositionTimer.Ago() - (fPositionSeconds -
-		// m_LastPositionSeconds)
-		//);
 		m_LastPositionTimer.Touch();
 		m_LastPositionSeconds = fPositionSeconds;
 	}
+
+	fPositionSeconds += fAdjust;
+	timestamp += fAdjust;
 
 	if (m_pCurSteps) {
 		m_Position.UpdateSongPosition(
@@ -791,8 +788,6 @@ GameState::UpdateSongPosition(float fPositionSeconds,
 					  GAMESTATE->m_Position.m_fSongBeatVisible,
 					  fPositionSeconds,
 					  GAMESTATE->m_Position.m_fSongBeatNoOffset);
-	//	LOG->Trace( "m_fMusicSeconds = %f, m_fSongBeat = %f, m_fCurBPS = %f,
-	// m_bFreeze = %f", m_fMusicSeconds, m_fSongBeat, m_fCurBPS, m_bFreeze );
 }
 
 float

--- a/src/Etterna/Singletons/GameState.cpp
+++ b/src/Etterna/Singletons/GameState.cpp
@@ -759,6 +759,8 @@ GameState::UpdateSongPosition(float fPositionSeconds,
 							  const TimingData& timing,
 							  RageTimer timestamp)
 {
+	const float fMusicRate = m_SongOptions.GetSong().m_fMusicRate;
+
 	/* It's not uncommon to get a lot of duplicated positions from the sound
 	 * driver, like so: 13.120953,13.130975,13.130975,13.130975,13.140998,...
 	 * This causes visual stuttering of the arrows. To compensate, keep a
@@ -766,13 +768,13 @@ GameState::UpdateSongPosition(float fPositionSeconds,
 	 * rate when applied. */
 	if (fPositionSeconds == m_LastPositionSeconds && !m_paused) {
 		fPositionSeconds +=
-		  m_LastPositionTimer.Ago() * m_SongOptions.GetSong().m_fMusicRate;
+		  m_LastPositionTimer.Ago() * fMusicRate;
 	} else {
 		m_LastPositionTimer.Touch();
 		m_LastPositionSeconds = fPositionSeconds;
 	}
 
-	fPositionSeconds += fAdjust;
+	fPositionSeconds += fAdjust * fMusicRate;
 	timestamp += fAdjust;
 
 	if (m_pCurSteps) {

--- a/src/Etterna/Singletons/GameState.h
+++ b/src/Etterna/Singletons/GameState.h
@@ -243,8 +243,9 @@ class GameState
 	void SetPaused(bool p) { m_paused = p; }
 	[[nodiscard]] auto GetPaused() const -> bool { return m_paused; }
 	void UpdateSongPosition(float fPositionSeconds,
+							float fAdjust,
 							const TimingData& timing,
-							const RageTimer& timestamp = RageZeroTimer);
+							RageTimer timestamp = RageTimer(0));
 	[[nodiscard]] auto GetSongPercent(float beat) const -> float;
 
 	[[nodiscard]] auto AllAreInDangerOrWorse() const -> bool;

--- a/src/Etterna/Singletons/GameState.h
+++ b/src/Etterna/Singletons/GameState.h
@@ -243,9 +243,8 @@ class GameState
 	void SetPaused(bool p) { m_paused = p; }
 	[[nodiscard]] auto GetPaused() const -> bool { return m_paused; }
 	void UpdateSongPosition(float fPositionSeconds,
-							float fAdjust,
 							const TimingData& timing,
-							RageTimer timestamp = RageTimer(0));
+							const RageTimer& timestamp = RageZeroTimer);
 	[[nodiscard]] auto GetSongPercent(float beat) const -> float;
 
 	[[nodiscard]] auto AllAreInDangerOrWorse() const -> bool;

--- a/src/RageUtil/Graphics/RageDisplay.cpp
+++ b/src/RageUtil/Graphics/RageDisplay.cpp
@@ -12,7 +12,6 @@
 #include "RageSurface_Save_BMP.h"
 #include "RageSurface_Save_JPEG.h"
 #include "RageSurface_Save_PNG.h"
-#include "RageUtil/Misc/RageTimer.h"
 #include "RageUtil/Utils/RageUtil.h"
 #include "Etterna/Screen/Others/Screen.h"
 #include "Etterna/Singletons/ScreenManager.h"
@@ -48,8 +47,11 @@ RageDisplay::GetCumFPS() const
 
 static int g_iFramesRenderedSinceLastCheck, g_iFramesRenderedSinceLastReset,
   g_iVertsRenderedSinceLastCheck, g_iNumChecksSinceLastReset;
-static RageTimer g_LastFrameEndedAtRage(RageZeroTimer);
 static auto g_LastFrameEndedAt = std::chrono::steady_clock::now();
+static std::chrono::nanoseconds g_LastFrameDuration =
+  std::chrono::duration<int64_t>();
+static std::chrono::nanoseconds g_FrameCorrection =
+  std::chrono::duration<int64_t>(0);
 static auto g_FrameRenderTime = std::chrono::steady_clock::now();
 static std::chrono::nanoseconds g_LastFrameRenderTime;
 static std::chrono::nanoseconds g_LastFramePresentTime;
@@ -958,9 +960,7 @@ RageDisplay::UpdateCentering()
 bool
 RageDisplay::SaveScreenshot(const std::string& sPath, GraphicsFileFormat format)
 {
-	RageTimer timer;
 	auto surface = this->CreateScreenshot();
-	//	LOG->Trace( "CreateScreenshot took %f seconds", timer.GetDeltaTime() );
 	/* Unless we're in lossless, resize the image to 640x480.  If we're saving
 	 * lossy, there's no sense in saving 1280x960 screenshots, and we don't want
 	 * to output screenshots in a strange (non-1) sample aspect ratio. */
@@ -972,12 +972,7 @@ RageDisplay::SaveScreenshot(const std::string& sPath, GraphicsFileFormat format)
 		// 639x480 (4:3) and 853x480 (16:9). ceilf gives correct values. -aj
 		const auto iWidth = static_cast<int>(
 		  ceilf(iHeight * (*GetActualVideoModeParams()).fDisplayAspectRatio));
-		timer.Touch();
 		RageSurfaceUtils::Zoom(surface, iWidth, iHeight);
-		//		LOG->Trace( "%ix%i -> %ix%i (%.3f) in %f seconds", surface->w,
-		// surface->h, iWidth, iHeight,
-		// GetActualVideoModeParams().fDisplayAspectRatio, timer.GetDeltaTime()
-		//);
 	}
 
 	RageFile out;
@@ -988,7 +983,6 @@ RageDisplay::SaveScreenshot(const std::string& sPath, GraphicsFileFormat format)
 	}
 
 	auto bSuccess = false;
-	timer.Touch();
 	std::string strError = "";
 	switch (format) {
 		case SAVE_LOSSLESS:
@@ -1005,8 +999,6 @@ RageDisplay::SaveScreenshot(const std::string& sPath, GraphicsFileFormat format)
 			break;
 			DEFAULT_FAIL(format);
 	}
-	//	LOG->Trace( "Saving Screenshot file took %f seconds.",
-	// timer.GetDeltaTime() );
 
 	SAFE_DELETE(surface);
 
@@ -1128,32 +1120,61 @@ RageDisplay::DrawCircle(const RageSpriteVertex& v, float radius)
 	this->DrawCircleInternal(v, radius);
 }
 
+static auto
+targetFrameTime() -> double
+{
+	auto result = 0.0;
+	if ((SCREENMAN != nullptr) && (SCREENMAN->GetTopScreen() != nullptr)) {
+		auto inGameplay =
+		  SCREENMAN->GetTopScreen()->GetScreenType() == gameplay;
+		if (inGameplay && g_fFrameLimitGameplay.Get() > 0) {
+			result = 1.0 / g_fFrameLimitGameplay.Get();
+		} else if (!inGameplay && g_fFrameLimit.Get() > 0) {
+			result = 1.0 / g_fFrameLimit.Get();
+		}
+	}
+	return result;
+}
+
 void
 RageDisplay::FrameLimitBeforeVsync()
 {
+	auto waitTime = targetFrameTime();
 	if (g_fPredictiveFrameLimit.Get()) {
 		const auto afterRender = std::chrono::steady_clock::now();
 		const auto endTime = afterRender - g_FrameRenderTime;
 
 		g_LastFrameRenderTime = endTime;
-	} else if (!g_fPredictiveFrameLimit.Get() &&
-			   !g_LastFrameEndedAtRage.IsZero() &&
-			   (g_fFrameLimit.Get() != 0 || g_fFrameLimitGameplay.Get() != 0)) {
-		auto expectedDelta = 0.0;
-		if ((SCREENMAN != nullptr) && (SCREENMAN->GetTopScreen() != nullptr)) {
-			if (SCREENMAN->GetTopScreen()->GetScreenType() == gameplay &&
-				g_fFrameLimitGameplay.Get() > 0)
-				expectedDelta = 1.0 / g_fFrameLimitGameplay.Get();
-			else if (SCREENMAN->GetTopScreen()->GetScreenType() != gameplay &&
-					 g_fFrameLimit.Get() > 0)
-				expectedDelta = 1.0 / g_fFrameLimit.Get();
-		}
+	} else if (!PREFSMAN->m_bVsync.Get() && waitTime > 0.0) {
+		auto waitNanoseconds =
+		  std::chrono::duration_cast<std::chrono::nanoseconds>(
+			std::chrono::duration<double>(waitTime));
 
-		auto advanceDelay =
-		  expectedDelta - g_LastFrameEndedAtRage.GetDeltaTime();
-		while (advanceDelay > 0.0) {
-			advanceDelay -= g_LastFrameEndedAtRage.GetDeltaTime();
+		// Estimate how long to wait to meet our frame time.
+		// Rationale: the following
+		//
+		//  auto t = g_LastFrameEndedAt + waitTime;
+		//  while (t > now());
+		//
+		// is too tight and waits slightly too long (trivially, by at least
+		// the amount of time required to exit the loop). In practice this
+		// effect noticeably reduces measured FPS. To account for it, measure
+		// the frame times we are actually getting and gradually adjust the
+		// delay to bring it in line with the target frame time.
+		auto adjustment = (g_LastFrameDuration - waitNanoseconds).count() / 16;
+		g_FrameCorrection -= std::chrono::nanoseconds(adjustment);
+		CLAMP(g_FrameCorrection,
+			  std::chrono::milliseconds(-8),
+			  std::chrono::milliseconds(0));
+
+		auto estimatedTimeToWait = waitNanoseconds + g_FrameCorrection;
+		auto t = g_LastFrameEndedAt + estimatedTimeToWait;
+		while (t > std::chrono::steady_clock::now()) {
+			std::this_thread::yield();
 		}
+	} else {
+		// Ignore frame limit preferences if v-sync is enabled without
+		// predictive frame limit.
 	}
 
 	if (!GameLoop::isGameFocused())
@@ -1172,25 +1193,18 @@ RageDisplay::FrameLimitBeforeVsync()
 void
 RageDisplay::FrameLimitAfterVsync(int iFPS)
 {
+	const auto frameEndedAt = std::chrono::steady_clock::now();
+	g_LastFrameDuration = frameEndedAt - g_LastFrameEndedAt;
+	g_LastFrameEndedAt = frameEndedAt;
+
 	if (!g_fPredictiveFrameLimit.Get()) {
-		g_LastFrameEndedAtRage.Touch();
 		return;
 	}
-	if (!PREFSMAN->m_bVsync.Get() && g_fFrameLimit.Get() == 0 &&
-		g_fFrameLimitGameplay.Get() == 0)
+
+	auto waitTime = targetFrameTime();
+
+	if (!PREFSMAN->m_bVsync.Get() && waitTime == 0.0) {
 		return;
-
-	g_LastFrameEndedAt = std::chrono::steady_clock::now();
-
-	// Get the target frame time
-	auto waitTime = 0.0;
-	if ((SCREENMAN != nullptr) && (SCREENMAN->GetTopScreen() != nullptr)) {
-		if (SCREENMAN->GetTopScreen()->GetScreenType() == gameplay &&
-			g_fFrameLimitGameplay.Get() > 0)
-			waitTime = 1.0 / g_fFrameLimitGameplay.Get();
-		else if (SCREENMAN->GetTopScreen()->GetScreenType() != gameplay &&
-				 g_fFrameLimit.Get() > 0)
-			waitTime = 1.0 / g_fFrameLimit.Get();
 	}
 
 	// Not using frame limiter and vsync is enabled

--- a/src/RageUtil/Graphics/RageDisplay.cpp
+++ b/src/RageUtil/Graphics/RageDisplay.cpp
@@ -1121,7 +1121,7 @@ RageDisplay::DrawCircle(const RageSpriteVertex& v, float radius)
 }
 
 float
-RageDisplay::GetFrameTimingAdjustment()
+RageDisplay::GetFrameTimingAdjustment(std::chrono::steady_clock::time_point now)
 {
 	/*
 	 * We get one update per frame, and we're updated early, almost immediately
@@ -1152,14 +1152,16 @@ RageDisplay::GetFrameTimingAdjustment()
 	const int iThisFPS = GetActualVideoModeParams()->rate;
 
 	std::chrono::duration<float> dDelta = g_LastFrameDuration;
+	std::chrono::duration<float> dTimeIntoFrame = now - g_LastFrameEndedAt;
 	const float fExpectedDelay = 1.0f / iThisFPS;
 	const float fDeltaTime = dDelta.count();
 	const float fExtraDelay = fDeltaTime - fExpectedDelay;
+	const float fAdjustTo = -dTimeIntoFrame.count();
 
 	if (fabsf(fExtraDelay) >= fExpectedDelay / 2)
-		return 0;
+		return fAdjustTo;
 
-	return std::min(-fExtraDelay, 0.0f);
+	return fAdjustTo + std::min(-fExtraDelay, 0.0f);
 }
 
 static auto

--- a/src/RageUtil/Graphics/RageDisplay.h
+++ b/src/RageUtil/Graphics/RageDisplay.h
@@ -278,7 +278,7 @@ class RageDisplay
 	  -> const ActualVideoModeParams* = 0;
 	auto IsWindowed() -> bool { return (*GetActualVideoModeParams()).windowed; }
 
-	auto GetFrameTimingAdjustment()
+	auto GetFrameTimingAdjustment(std::chrono::steady_clock::time_point now)
 		-> float;
 
 	virtual void SetBlendMode(BlendMode mode) = 0;

--- a/src/RageUtil/Graphics/RageDisplay.h
+++ b/src/RageUtil/Graphics/RageDisplay.h
@@ -278,6 +278,9 @@ class RageDisplay
 	  -> const ActualVideoModeParams* = 0;
 	auto IsWindowed() -> bool { return (*GetActualVideoModeParams()).windowed; }
 
+	auto GetFrameTimingAdjustment()
+		-> float;
+
 	virtual void SetBlendMode(BlendMode mode) = 0;
 
 	virtual auto SupportsTextureFormat(RagePixelFormat pixfmt,

--- a/src/RageUtil/Graphics/RageDisplay_OGL.cpp
+++ b/src/RageUtil/Graphics/RageDisplay_OGL.cpp
@@ -919,14 +919,14 @@ RageDisplay_Legacy::EndFrame()
 	g_pWind->SwapBuffers();
 	glFlush();
 
-	g_pWind->Update();
-
 	const auto afterPresent = std::chrono::steady_clock::now();
 	const auto endTime = afterPresent - beforePresent;
 
 	SetPresentTime(endTime);
 
 	FrameLimitAfterVsync((*GetActualVideoModeParams()).rate);
+
+	g_pWind->Update();
 
 	RageDisplay::EndFrame();
 }

--- a/src/RageUtil/Misc/RageTimer.cpp
+++ b/src/RageUtil/Misc/RageTimer.cpp
@@ -23,44 +23,24 @@
 
 #include "RageTimer.h"
 #include "RageUtil/Utils/RageUtil.h"
-#include "Core/Platform/Platform.hpp"
 
 #include <chrono>
 
-// let this henceforth be referred to as the difference between a second and a
-// microsecond *kingly fanfare*
-#define TIMESTAMP_RESOLUTION 1000000
-
 const RageTimer RageZeroTimer(0);
-static std::chrono::microseconds g_iStartTime = Core::Platform::Time::GetChronoDurationSinceStart();
-
-static uint64_t GetTime() {
-    return Core::Platform::Time::GetChronoDurationSinceStart().count();
-}
-
-static std::chrono::microseconds GetChronoTime() {
-	return Core::Platform::Time::GetChronoDurationSinceStart();
-}
+static auto g_iStartTime = std::chrono::steady_clock::now();
 
 float
 RageTimer::GetTimeSinceStart()
 {
-	const auto usecs = GetChronoTime();
-	const std::chrono::microseconds g = usecs - g_iStartTime;
-
-	return static_cast<float>(g.count()) / TIMESTAMP_RESOLUTION;
+	std::chrono::duration<float> t = std::chrono::steady_clock::now() - g_iStartTime;
+	return t.count();
 }
 
-uint64_t
-RageTimer::GetUsecsSinceStart()
+static double
+GetTimeSinceStart64()
 {
-	return GetTime() - g_iStartTime.count();
-}
-
-void
-RageTimer::Touch()
-{
-	this->c_dur = GetChronoTime();
+	std::chrono::duration<double> t = std::chrono::steady_clock::now() - g_iStartTime;
+	return t.count();
 }
 
 float
@@ -79,22 +59,6 @@ RageTimer::GetDeltaTime()
 	return diff;
 }
 
-/*
- * Get a timer representing half of the time ago as this one.  This is
- * useful for averaging time.  For example,
- *
- * RageTimer tm;
- * ... do stuff ...
- * RageTimer AverageTime = tm.Half();
- * printf( "Something happened approximately %f seconds ago.\n", tm.Ago() );
- */
-RageTimer
-RageTimer::Half() const
-{
-	const float fProbableDelay = Ago() / 2;
-	return *this + fProbableDelay;
-}
-
 RageTimer
 RageTimer::operator+(float tm) const
 {
@@ -110,28 +74,23 @@ RageTimer::operator-(const RageTimer& rhs) const
 bool
 RageTimer::operator<(const RageTimer& rhs) const
 {
-	return c_dur < rhs.c_dur;
+	return tm < rhs.tm;
 }
 
 RageTimer
 RageTimer::Sum(const RageTimer& lhs, float tm)
 {
-	const uint64_t usecs = static_cast<uint64_t>(tm * TIMESTAMP_RESOLUTION);
-	const std::chrono::microseconds period(usecs);
-
-	RageTimer ret(0); // Prevent unnecessarily checking the time
-	ret.c_dur = period + lhs.c_dur;
-
-	return ret;
+	const std::chrono::steady_clock::time_point ret =
+		lhs.tm + std::chrono::duration_cast<std::chrono::steady_clock::duration>(std::chrono::duration<float>(tm));
+	return RageTimer(ret);
 }
 
 float
 RageTimer::Difference(const RageTimer& lhs, const RageTimer& rhs)
 {
-	const std::chrono::microseconds diff = lhs.c_dur - rhs.c_dur;
-
-	return static_cast<float>(diff.count()) / TIMESTAMP_RESOLUTION;
+	const std::chrono::duration<float> diff = lhs.tm - rhs.tm;
+	return diff.count();
 }
 
 #include "Etterna/Singletons/LuaManager.h"
-LuaFunction(GetTimeSinceStart, RageTimer::GetTimeSinceStart())
+LuaFunction(GetTimeSinceStart, GetTimeSinceStart64())

--- a/src/RageUtil/Misc/RageTimer.h
+++ b/src/RageUtil/Misc/RageTimer.h
@@ -9,25 +9,26 @@ class RageTimer
 {
   public:
 	RageTimer() { Touch(); }
-	RageTimer(unsigned microseconds)
+	RageTimer(std::chrono::steady_clock::time_point tm) : tm(tm) {};
+	RageTimer(unsigned microseconds) : tm()
 	{
-		this->c_dur = std::chrono::microseconds(microseconds);
+		tm += std::chrono::microseconds(microseconds);
 	}
-	RageTimer(unsigned secs, unsigned microseconds)
+	RageTimer(unsigned secs, unsigned microseconds) : tm()
 	{
 		auto seconds = std::chrono::seconds(secs);
 		auto microsecs = std::chrono::microseconds(microseconds);
-		this->c_dur = seconds + microsecs;
+		tm += seconds + microsecs;
 	}
 
 	/* Time ago this RageTimer represents. */
 	[[nodiscard]] auto Ago() const -> float;
-	void Touch();
+	void Touch() { tm = std::chrono::steady_clock::now(); }
 	[[nodiscard]] auto IsZero() const -> bool
 	{
-		return this->c_dur == std::chrono::microseconds::zero();
+		return tm == std::chrono::steady_clock::time_point();
 	}
-	void SetZero() { this->c_dur = std::chrono::microseconds::zero(); }
+	void SetZero() { tm = std::chrono::steady_clock::time_point(); }
 
 	/* Time between last call to GetDeltaTime() (Ago() + Touch()): */
 	auto GetDeltaTime() -> float;
@@ -36,11 +37,6 @@ class RageTimer
 
 	static auto GetTimeSinceStart()
 	  -> float; // seconds since the program was started
-	static auto GetUsecsSinceStart()
-	  -> uint64_t; // microseconds since the program was started
-
-	/* Get a timer representing half of the time ago as this one. */
-	[[nodiscard]] auto Half() const -> RageTimer;
 
 	/* Add (or subtract) a duration from a timestamp.  The result is another
 	 * timestamp. */
@@ -54,7 +50,7 @@ class RageTimer
 	auto operator-(const RageTimer& rhs) const -> float;
 
 	auto operator<(const RageTimer& rhs) const -> bool;
-	std::chrono::microseconds c_dur{};
+	std::chrono::steady_clock::time_point tm;
 
   private:
 	static auto Sum(const RageTimer& lhs, float tm) -> RageTimer;
@@ -62,53 +58,5 @@ class RageTimer
 };
 
 extern const RageTimer RageZeroTimer;
-
-// For profiling how long some chunk of code takes. -Kyz
-#define START_TIME(name)                                                       \
-	uint64_t name##_start_time = RageTimer::GetUsecsSinceStart();
-#define START_TIME_CALL_COUNT(name)                                            \
-	START_TIME(name);                                                          \
-	++name##_call_count;
-#define END_TIME(name)                                                         \
-	uint64_t name##_end_time = RageTimer::GetUsecsSinceStart();                \
-	LOG->Time(#name " time: %zu to %zu = %zu",                                 \
-			  name##_start_time,                                               \
-			  name##_end_time,                                                 \
-			  name##_end_time - name##_start_time);
-#define END_TIME_ADD_TO(name)                                                  \
-	uint64_t name##_end_time = RageTimer::GetUsecsSinceStart();                \
-	name##_total += name##_end_time - name##_start_time;
-#define END_TIME_CALL_COUNT(name)                                              \
-	END_TIME_ADD_TO(name);                                                     \
-	++name##_end_count;
-
-#define DECL_TOTAL_TIME(name) extern uint64_t name##_total;
-#define DEF_TOTAL_TIME(name) uint64_t name##_total = 0;
-#define PRINT_TOTAL_TIME(name)                                                 \
-	LOG->Time(#name " total time: %zu", name##_total);
-#define DECL_TOT_CALL_PAIR(name)                                               \
-	extern uint64_t name##_total;                                              \
-	extern uint64_t name##_call_count;
-#define DEF_TOT_CALL_PAIR(name)                                                \
-	uint64_t name##_total = 0;                                                 \
-	uint64_t name##_call_count = 0;
-#define PRINT_TOT_CALL_PAIR(name)                                              \
-	LOG->Time(#name " calls: %zu, time: %zu, per: %f",                         \
-			  name##_call_count,                                               \
-			  name##_total,                                                    \
-			  static_cast<float>(name##_total) / name##_call_count);
-#define DECL_TOT_CALL_END(name)                                                \
-	DECL_TOT_CALL_PAIR(name);                                                  \
-	extern uint64_t name##_end_count;
-#define DEF_TOT_CALL_END(name)                                                 \
-	DEF_TOT_CALL_PAIR(name);                                                   \
-	uint64_t name##_end_count = 0;
-#define PRINT_TOT_CALL_END(name)                                               \
-	LOG->Time(#name " calls: %zu, time: %zu, early end: %zu, per: %f",         \
-			  name##_call_count,                                               \
-			  name##_total,                                                    \
-			  name##_end_count,                                                \
-			  static_cast<float>(name##_total) /                               \
-				(name##_call_count - name##_end_count));
 
 #endif

--- a/src/RageUtil/Sound/RageSound.cpp
+++ b/src/RageUtil/Sound/RageSound.cpp
@@ -28,6 +28,7 @@
 #include "RageSoundUtil.h"
 #include "Etterna/Models/Lua/LuaReference.h"
 #include "RageUtil/Utils/RageUtil.h"
+#include "RageUtil/Graphics/RageDisplay.h"
 #include "RageSoundReader_Extend.h"
 #include "RageSoundReader_FileReader.h"
 #include "RageSoundReader_Pan.h"
@@ -707,6 +708,7 @@ RageSound::GetPositionSeconds(bool* bApproximate, RageTimer* pTimestamp)
 	}
 
 	const auto correctedPosition = extrapolatedPosition + correction;
+	const auto vsyncAdjust = DISPLAY->GetFrameTimingAdjustment();
 
 #if defined(TRACY_ENABLE) && defined(TRACE_BUTTER)
 	TracyPlot("acc ms", 1000.0f * (correction));
@@ -714,6 +716,7 @@ RageSound::GetPositionSeconds(bool* bApproximate, RageTimer* pTimestamp)
 	TracyPlot("extrapolatedPosition error from rdtsc ms", 1000.0f * err);
 	TracyPlot("correctedPosition error from rdtsc ms", 1000.0f *
 		((tm - syncTime) * rate - (correctedPosition - syncPosition)));
+	TracyPlot("vsyncAdjust ms", 1000.0f * vsyncAdjust);
 #endif
 
 	m_Pasteurizer.tm = tm;
@@ -723,7 +726,8 @@ RageSound::GetPositionSeconds(bool* bApproximate, RageTimer* pTimestamp)
 	m_Pasteurizer.syncPosition = syncPosition;
 	m_Pasteurizer.acc = acc;
 
-	return correctedPosition;
+	*pTimestamp += vsyncAdjust;
+	return correctedPosition + vsyncAdjust * rate;
 }
 
 bool

--- a/src/RageUtil/Sound/RageSound.cpp
+++ b/src/RageUtil/Sound/RageSound.cpp
@@ -708,7 +708,7 @@ RageSound::GetPositionSeconds(bool* bApproximate, RageTimer* pTimestamp)
 	}
 
 	const auto correctedPosition = extrapolatedPosition + correction;
-	const auto vsyncAdjust = DISPLAY->GetFrameTimingAdjustment();
+	const auto vsyncAdjust = DISPLAY->GetFrameTimingAdjustment(tm.tm);
 
 #if defined(TRACY_ENABLE) && defined(TRACE_BUTTER)
 	TracyPlot("acc ms", 1000.0f * (correction));

--- a/src/RageUtil/Sound/RageSound.h
+++ b/src/RageUtil/Sound/RageSound.h
@@ -12,6 +12,16 @@
 class RageSoundReader;
 struct lua_State;
 
+struct Butter
+{
+	RageTimer tm;
+	RageTimer hwTime;
+	RageTimer syncTime;
+	float hwPosition;
+	float syncPosition;
+	float acc;
+};
+
 /* Driver interface for sounds: this is what drivers see. */
 class RageSoundBase
 {
@@ -102,7 +112,7 @@ class MufftAllocator
   public:
 	typedef T value_type;
 	MufftAllocator() noexcept {};
-	
+
 	T* allocate(size_t n) {	return static_cast<T*>(mufft_alloc(n * sizeof(T)));	}
 	void deallocate(T* p, size_t n) { mufft_free(p); }
 
@@ -175,7 +185,7 @@ class RageSound : public RageSoundBase
 
 	auto GetLengthSeconds() -> float;
 	auto GetPositionSeconds(bool* approximate = nullptr,
-							RageTimer* Timestamp = nullptr) const -> float;
+							RageTimer* Timestamp = nullptr) -> float;
 	auto GetLoadedFilePath() const -> std::string override
 	{
 		return m_sFilePath;
@@ -240,6 +250,8 @@ class RageSound : public RageSoundBase
 	bool m_bDeleteWhenFinished{ false };
 
 	std::string m_sError;
+
+	Butter m_Pasteurizer{};
 
 	auto GetSourceFrameFromHardwareFrame(int64_t iHardwareFrame,
 										 bool* bApproximate = nullptr) const

--- a/src/arch/Threads/Threads_Pthreads.cpp
+++ b/src/arch/Threads/Threads_Pthreads.cpp
@@ -360,8 +360,8 @@ EventImpl_Pthreads::Wait(float timeout)
 		float fSecondsInFuture = timeout;
 		timeofday += fSecondsInFuture;
 
-		auto nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(timeofday.c_dur);
-		auto sec = std::chrono::duration_cast<std::chrono::seconds>(timeofday.c_dur);
+		auto nsec = timeofday.tm.time_since_epoch();
+		auto sec = std::chrono::duration_cast<std::chrono::seconds>(nsec);
 		nsec -= sec;
 		abstime.tv_sec = sec.count();
 		abstime.tv_nsec = nsec.count();


### PR DESCRIPTION
This PR includes the changes in my frame timing PR because I change the RageTimer implementation, which screws up the old RageTimer-based frame pacing. (I didn't think too hard about the ragetimer changes cause I know james wants to junk it eventually.)

Brief history: You can't really trust RageSound's `GetPositionSeconds` on (afaict) anything other than WaveOut. Shakesoda first noticed this with pulseaudio here bfba3a6fe8b3d3d9209e0c4b4b75fe7520d450f5 and xwidghet on directsound later here 427f9f0ff2648a4d2281995f814cde331f66e372

Those changes appear to fix the issue at high frame rates because they reduce the jitter to the reciprocal of your frame rate. (But even, the error scales linearly with audio rate). Since etterna makes use of `steady_clock` now it's pretty straight forward to clean up the resulting jitter, see the comments in `RageSound` for an explanation.

I moved shakesoda's old fix from `GameState` to `RageSound` (and appended my new fix there) because it turns out that every time `GetPositionSeconds` was called, the calling code was doing at least one thing wrong. That's including my code in the previous PR. So, it is no longer the callers responsibility to do anything clever with the value from `GetPositionSeconds` because nobody is clever.

Anyway since I was looking so closely at this I thought I'd go through all the input timing code to see if I could turn up anything and I did 0803206e6d014138cf9773993119b59246e361f1. It's extremely minor. But: someone [_actually went through the trouble_](https://github.com/etternagame/etterna/blob/master/src/arch/Sound/RageSoundDriver_Generic_Software.cpp#L546) however many decades ago of making sure the timestamp you get from soundman does actually correspond to the audio position at that time. This finishes what they started. Combined with my other changes to `RageSound` this means every hit judgement is computed using exactly two calls to `steady_clock::now()`, instead of the up to 5 before.

Since both of these affect how hits are judged I've isolated them in two commits you can easily read and not just take my word for it that I've tested it thoroughly (I have tested it thoroughly.) 

This incidentally fixes vsync