### PR TITLE
Fix visualizer crash

### DIFF
--- a/src/RageUtil/Sound/RageSound.cpp
+++ b/src/RageUtil/Sound/RageSound.cpp
@@ -63,8 +63,11 @@ RageSound::RageSound()
 
 RageSound::~RageSound()
 {
-	if (fftPlan)
-		mufft_free_plan_1d(fftPlan);
+	{
+		std::lock_guard<std::mutex> guard(recentSamplesMutex);
+		if (fftPlan)
+			mufft_free_plan_1d(fftPlan);
+	}
 	
 	Unload();
 }


### PR DESCRIPTION
Etterna used to randomly crash in the chart select screen every few days for me. The crash originated in the music visualizer code, and Nick12 managed to find a fix which seems to work ([Discord link](https://discord.com/channels/261758887152058368/261811430888570880/871028424674770944))