### PR TITLE
Fix Compilation of Etterna on M1 Macs

### DIFF
--- a/CMake/Helpers/SetupFFMPEG.cmake
+++ b/CMake/Helpers/SetupFFMPEG.cmake
@@ -32,7 +32,7 @@ endif()
 if(APPLE)
   list(APPEND FFMPEG_CONFIGURE
     "--arch=x86_64"
-    "--cc=clang -m64"
+    "--cc=clang -arch x86_64"
     "--enable-sse")
 endif()
 list(APPEND FFMPEG_CONFIGURE "--enable-gpl")


### PR DESCRIPTION
Etterna currently *needs* to be compiled as a x86_64 program, even on M1 macs.
This is for a number of reasons, including the fact that we directly use x86_64 vector instructions in the calc code.

Without this change, the clang -m64 switch in the ffmpeg cmake will cause us to attempt to build ffmpeg as an aarch64 binary, which can't be linked
 with the x86_64 architecture code generated by the rest of our build process.

Explicitly adding in the flag to compile for x86_64 fixes this problem,
 and lets us build Etterna on M1 macs to produce a binary runnable with Rosetta V2