### PR TITLE
Fix macOS SetupFFMPEG Cmake issue which lead to build failing

### DIFF
--- a/CMake/Helpers/SetupFFMPEG.cmake
+++ b/CMake/Helpers/SetupFFMPEG.cmake
@@ -5,6 +5,7 @@ set(FFMPEG_BIN  "${PROJECT_BINARY_DIR}/ffmpeg_dl/ffmpeg_dl-build")
 
 list(APPEND FFMPEG_CONFIGURE
   "rm"
+  "-f"
   "${FFMPEG_ROOT}/VERSION"
   "&&"  
   "${FFMPEG_ROOT}/configure"


### PR DESCRIPTION
The FFMPEG Setup Cmake deletes the file VERSION from the ffmpeg generated folder, as it conflicts with the C++20 <version> header.

However, the cmake uses rm without flags, which errors out if the file has already been deleted by a previously succesful run of the cmake.
Adding the "-f" flag makes it proceed even if the file does not exist to be deleted.