### PR TITLE
Fix cpack not working in GHA

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -227,6 +227,9 @@ jobs:
         if: ${{ matrix.cfg.arch == 'x64' }}
         run: choco install ninja nsis openssl curl -y
 
+      - name: Remove Chocolatey's CPack
+        run: rm "C:/ProgramData/Chocolatey/bin/cpack.exe"
+
       - name: Configure MSBuild
         uses: ilammy/msvc-dev-cmd@v1
         with:


### PR DESCRIPTION
Chocolatey and CMake both have a cpack command. They conflict and for some reason now chocolatey is being prioritized which fails the build. This fixes it