### PR TITLE
Fix buggy multi leaderboard entries

### DIFF
--- a/Themes/Til Death/BGAnimations/ScreenGameplay overlay/leaderboard.lua
+++ b/Themes/Til Death/BGAnimations/ScreenGameplay overlay/leaderboard.lua
@@ -66,7 +66,7 @@ local onlineScores = {}
 local isMulti = NSMAN:IsETTP() and SCREENMAN:GetTopScreen() and SCREENMAN:GetTopScreen():GetName() == "ScreenNetStageInformation" or false
 if isMulti then
 	multiScores = NSMAN:GetMPLeaderboard()
-	for i = 1, 5 do
+	for i = 1, NUM_ENTRIES do
 		onlineScores[i] = scoreUsingMultiScore(i)
 	end
 else
@@ -138,7 +138,8 @@ function scoreEntry(i)
 			entryActor = self
 			entryActors[i]["container"] = self
 			self.update = function(self, hs)
-				self:visible(not (not hs))
+				local hs_and_name = hs and hs:GetDisplayName()
+				self:visible(not (not hs_and_name))
 			end
 			self:update(scoreboard[i])
 		end
@@ -165,7 +166,8 @@ function scoreEntry(i)
 					self = self.actor
 					entryActors[i][name] = self
 					self.update = function(self, hs)
-						if hs then
+						local hs_and_name = hs and hs:GetDisplayName()
+						if (not (not hs_and_name)) then
 							self:visible(true)
 							fn(self, hs)
 						else


### PR DESCRIPTION
The entries in question are highlighted in green here:
![imagen](https://user-images.githubusercontent.com/24706838/142752367-4dd18e2d-68ab-4627-a398-2bd6199f6d47.png)

I tested this in a local multi server and with the EO leaderboard, seemed to work fine