### PR TITLE
Fix audio callback deadlock

### DIFF
--- a/src/RageUtil/Misc/RageThreads.cpp
+++ b/src/RageUtil/Misc/RageThreads.cpp
@@ -454,11 +454,6 @@ RageMutex::Lock()
 			OtherSlotName = ssprintf("%s (%i)",
 									 OtherSlot->GetThreadName(),
 									 static_cast<int>(OtherSlot->m_iID));
-		const std::string sReason =
-		  ssprintf("Thread deadlock on mutex %s between %s and %s",
-				   GetName().c_str(),
-				   ThisSlotName.c_str(),
-				   OtherSlotName.c_str());
 
 		/* Don't leave GetThreadSlotsLock() locked when we call
 		 * ForceCrashHandlerDeadlock. */
@@ -466,9 +461,14 @@ RageMutex::Lock()
 		const uint64_t CrashHandle = OtherSlot ? OtherSlot->m_iID : 0;
 		GetThreadSlotsLock().Unlock();
 
-		/* Pass the crash handle of the other thread, so it can backtrace that
-		 * thread. */
-//		CrashHandler::ForceDeadlock(sReason, CrashHandle);
+		const std::string sReason =
+		  ssprintf("Thread deadlock on mutex %s between %s and %s CrashHandle %d",
+				   GetName().c_str(),
+				   ThisSlotName.c_str(),
+				   OtherSlotName.c_str(),
+				   CrashHandle);
+
+		sm_crash(sReason.c_str());
 	}
 
 	m_LockedBy = iThisThreadId;

--- a/src/RageUtil/Sound/RageSound.cpp
+++ b/src/RageUtil/Sound/RageSound.cpp
@@ -378,26 +378,45 @@ RageSound::ExecutePlayBackCallback(Lua* L)
 {
 	if (soundPlayCallback == nullptr || !pendingPlayBackCall)
 		return;
-	std::lock_guard<std::mutex> guard(recentSamplesMutex);
-	std::string error;
-	soundPlayCallback->PushSelf(L);
-	lua_newtable(L);
-	for (size_t i = 0; i < fftBuffer.size(); ++i) {
-		auto r = fftBuffer[i].real;
-		auto im = fftBuffer[i].imag;
-		lua_pushnumber(L,
-					   (r * r + im * im) / (0.01f + RageSoundReader_PostBuffering::GetMasterVolume()) /
-						 (0.01f + RageSoundReader_PostBuffering::GetMasterVolume()) / 15.f);
-		lua_rawseti(L, -2, i + 1);
+	{
+		// Make sure we're not holding this mutex when we run the lua callback/script
+		// Otherwise it can deadlock if it calls ClearPlayBackCallback which locks g_mutex
+		// and GameSoundManager tries to delete the RageSound which will lock this one after
+		// g_mutex (In the opposite order)
+		// This *should* be fine since even if soundPlayCallback is set to nil by another thread while
+		// we are running it, since the `soundPlayCallback->PushSelf` call which we do while holding
+		// the mutex does a lua_rawgeti which pushes a reference to the callback to the lua stack
+		// which is owned by the lua VM and garbage collected, so it should *not* get freed.
+		std::lock_guard<std::mutex> guard(recentSamplesMutex);
+		// Recheck in case it changed inbetween the earlier check and the mutex lock
+		if (soundPlayCallback == nullptr)
+			return;
+		soundPlayCallback->PushSelf(L);
+		lua_newtable(L);
+		for (size_t i = 0; i < fftBuffer.size(); ++i) {
+			auto r = fftBuffer[i].real;
+			auto im = fftBuffer[i].imag;
+			lua_pushnumber(
+			  L,
+			  (r * r + im * im) /
+				(0.01f + RageSoundReader_PostBuffering::GetMasterVolume()) /
+				(0.01f + RageSoundReader_PostBuffering::GetMasterVolume()) /
+				15.f);
+			lua_rawseti(L, -2, i + 1);
+		}
+		pendingPlayBackCall = false;
 	}
+	// TODO: Change this parameter from RageSound to the sampling rate
+	//       by removing this PushSelf.
+	//       We're not holding the g_Mutex from GameSoundManager when we call
+	//       the callback for it's global g_playing, which I think might cause
+	//       issues depending on what the lua callback does with it.
 	PushSelf(L);
-	inPlayCallback = true;
-	LuaHelpers::RunScriptOnStack(L, error, 2, 0, false); // 1 arg, 0 returns
-	inPlayCallback = false;
+	std::string error;
+	LuaHelpers::RunScriptOnStack(L, error, 2, 0, false); // 2 args, 0 returns
 	if (error != "") // hack for now because we're bad and didn't deal with
 					 // clearing this -mina
 		soundPlayCallback->Unset();
-	pendingPlayBackCall = false;
 }
 
 /* Indicate that a block of audio data has been written to the device. */
@@ -859,33 +878,22 @@ RageSound::SetStopModeFromString(const std::string& sStopMode)
 }
 
 void
-RageSound::ActuallySetPlayBackCallback(const std::shared_ptr<LuaReference>& f,
-									   unsigned int bufSize)
+RageSound::SetPlayBackCallback(const std::shared_ptr<LuaReference>& f,
+							   unsigned int bufSize)
 {
+	std::lock_guard<std::mutex> guard(recentSamplesMutex);
+
 	soundPlayCallback = f;
 	recentPCMSamplesBufferSize = std::max(bufSize, 1024u);
 	recentPCMSamples.reserve(recentPCMSamplesBufferSize + 2);
 	fftBuffer.resize(recentPCMSamplesBufferSize / 2 + 1, {});
-	if (fftPlan) mufft_free_plan_1d(fftPlan);
-	fftPlan = mufft_create_plan_1d_r2c(recentPCMSamplesBufferSize, MUFFT_FLAG_CPU_ANY);
+	if (fftPlan)
+		mufft_free_plan_1d(fftPlan);
+	fftPlan =
+	  mufft_create_plan_1d_r2c(recentPCMSamplesBufferSize, MUFFT_FLAG_CPU_ANY);
 	if (!fftPlan)
 		Locator::getLogger()->warn(
 		  "Failed to set playback callback in mufft...");
-}
-
-void
-RageSound::SetPlayBackCallback(const std::shared_ptr<LuaReference>& f,
-							   unsigned int bufSize)
-{
-	// If we're in play callback it's safe to call this from lua, since we've
-	// locked LUA->Get() But not from C++ in another thread Invariant: The only
-	// calls to SetPlayBackCallback in C++ should be in the music thread
-	if (!inPlayCallback) {
-		std::lock_guard<std::mutex> guard(recentSamplesMutex);
-		ActuallySetPlayBackCallback(f, bufSize);
-		return;
-	}
-	ActuallySetPlayBackCallback(f, bufSize);
 }
 
 // lua start

--- a/src/RageUtil/Sound/RageSound.h
+++ b/src/RageUtil/Sound/RageSound.h
@@ -227,11 +227,8 @@ class RageSound : public RageSoundBase
 	 * play until it becomes positive. */
 	int64_t m_iStreamFrame;
 
-	void ActuallySetPlayBackCallback(const std::shared_ptr<LuaReference>& f,
-									 unsigned int bufSize);
-	std::atomic<bool> inPlayCallback{ false };
-	std::mutex
-	  recentSamplesMutex; // For all operations related to sound play callbacks
+	// For all operations related to sound play callbacks
+	std::mutex recentSamplesMutex; 
 	unsigned int recentPCMSamplesBufferSize{ 1024 };
 	std::shared_ptr<LuaReference> soundPlayCallback;
 	std::vector<float, MufftAllocator<float>> recentPCMSamples;


### PR DESCRIPTION
Example of the bug: https://crash.etterna.dev/crash-reports/aa1d672c-2eb7-459a-8e05-cc4685b3c6cd

The music thread can lock `g_Mutex` and then `recentSamplesMutex`:
![imagen](https://user-images.githubusercontent.com/24706838/167290306-16e64c15-0408-4dea-b25f-5200273f8a6c.png)

And the main thread can lock those 2 mutexes in the opposite order: 
![imagen](https://user-images.githubusercontent.com/24706838/167290355-e8d90c1d-781b-484f-88c1-c248379ba5d7.png)

The reason for the weird error message is that our mutex impl on windows tries to detect deadlocks with a 15 second waiting time:
https://github.com/etternagame/etterna/blob/201115635bb3635ca5f3e65c395e55ba7c1b5300/src/arch/Threads/Threads_Win32.cpp#L231-L250

And this return value of false is checked here: https://github.com/etternagame/etterna/blob/201115635bb3635ca5f3e65c395e55ba7c1b5300/src/RageUtil/Misc/RageThreads.cpp#L471

but the crash was commented when we moved to crashpad in https://github.com/etternagame/etterna/commit/1d8deb8dfad4681e281dde2e315623f0c8ebbc1a

This commit adds back the deadlock detection crash using `sm_crash`, which Hidden confirmed is the correct way to trigger a crashpad crash.

It also fixes the deadlock. This is done by *not* holding the recentSamples mutex while we execute the callback. This may look unsafe at first, but I believe it correct: We do not use any of the fft/samples memory while executing the callback, it is all copied to a lua table (And thus, is in memory controlled by the lua vm and GC'd by it) while we hold the mutex before executing it.

There are 2 things that do worry me:
 - One is that the RageSound that the `ExecutePlayBackCallback` method is executing for could get deleted by another thread. This is only a problem because (1) we're executing a method for it and that might be UB even if we don't use the `this` pointer (I'm not sure) and (2) mina added a "hack" that unsets the callback on an error, which would be a use after free if the sound got deleted. I'm not particularly worried about the lua function itself, since a copy is made while we hold the mutex as explained in the comment.
 - As I mention in the comment I added, we are giving lua a handle to the g_playing RageSound from the sound manager. I think this can cause all kinds of trouble if lua uses it freely, but from what I've seen in _fallback and rebirth, it's only used to call `sound:GetSampleRate()`, so we should be able to remove it and change it to an integer paremeter that's just the sample rate, if the lua API breakage is acceptable.

So this PR should (I think) leave us in a better situation, although a more definitive fix would be to move the `RunScriptOnStack` call outside the method (Because the RageSound can be deleted by another thread), change the 2nd callback parameter to the sample rate (And make the small change on the lua side for rebirth and _fallback), and decide what to do about the `if error { soundPlayCallback->Unsset() }` hack (Probably remove it? But probably ask mina if he remembers what it was about first).

I have done a quick test on both til death and rebirth with the visualizer on and this change didn't obviously break anything.