### PR TITLE
clang-cl CI

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -188,6 +188,7 @@ jobs:
         cfg:
         - { name: i386, arch: x86,  ssl-dir: 'C:\Program Files (x86)\OpenSSL-Win32' }
         - { name: x64,  arch: x64,  ssl-dir: 'C:\Program Files\OpenSSL-Win64'}
+        - { name: x64_clang_cl,  arch: x64,  ssl-dir: 'C:\Program Files\OpenSSL-Win64'}
 
     name: "Windows ${{matrix.cfg.name}}"
     runs-on: windows-2019
@@ -226,6 +227,14 @@ jobs:
       - name: Install chocolatey packages (x64)
         if: ${{ matrix.cfg.arch == 'x64' }}
         run: choco install ninja nsis openssl curl -y
+
+      - name: Set clang-cl as compiler
+        if: ${{ matrix.cfg.name == 'x64_clang_cl' }}
+        run: |
+          echo "CC=clang-cl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "CXX=clang-cl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "CFLAGS=-m64" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "CXXFLAGS=-m64" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Configure MSBuild
         uses: ilammy/msvc-dev-cmd@v1

--- a/extern/crashpad/CMakeLists.txt
+++ b/extern/crashpad/CMakeLists.txt
@@ -102,7 +102,7 @@ endif()
 
 set(GN_WIN_LINK_FLAG "")	# Dynamically link to C runtime library
 if(WIN32)
-	set(GN_WIN_LINK_FLAG /MT)	# Dynamically link to C runtime library
+	set(GN_WIN_LINK_FLAG "/GL- /MT")	# Dynamically link to C runtime library
 	if(CMAKE_BUILD_TYPE STREQUAL Debug) #TODO: Fix for multi-config generators
 		string(APPEND GN_WIN_LINK_FLAG d)
 	endif()

--- a/extern/curl/CMakeLists.txt
+++ b/extern/curl/CMakeLists.txt
@@ -1143,7 +1143,8 @@ endif()
 
 if(MSVC)
   # Disable default manifest added by CMake
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /MANIFEST:NO")
+  # Commented: This breaks clang-cl
+  #set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /MANIFEST:NO")
 
   add_definitions(-D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE)
 #  if(CMAKE_C_FLAGS MATCHES "/W[0-4]")


### PR DESCRIPTION
This adds a new windows CI configuration for clang-cl

`clang-cl.exe` is a driver/frontend for clang that ships with the windows clang binaries that LLVM distributes that accepts the same command line arguments as `cl.exe`(the MSVC compiler).

I had to comment a "MANIFEST:NO" linker flag that seems to be unsupported by clang, and disable /GL (LTO) for crashpad.

I'm not sure if this is worth adding but it might be nice to track support so we don't break it, since some people might want to develop on windows using clang, and we could also consider using clang-cl as the compiler for releases after testing how the resulting binaries compare (performance, size, etc)