### PR TITLE
Fix ThemeManager::GetPathInfoToRaw crash

### DIFF
--- a/src/Etterna/Singletons/ThemeManager.cpp
+++ b/src/Etterna/Singletons/ThemeManager.cpp
@@ -644,8 +644,8 @@ ThemeManager::GetPathInfoToRaw(PathInfo& out,
 	/* Ugly: the parameters to this function may be a reference into g_vThemes,
 	 * or something else that might suddenly go away when we call ReloadMetrics,
 	 * so make a copy. */
-	const std::string& sThemeName = sThemeName_;
-	const std::string& sMetricsGroup = sMetricsGroup_;
+	const std::string sThemeName = sThemeName_;
+	const std::string sMetricsGroup = sMetricsGroup_;
 	const std::string sElement = sElement_;
 
 	const std::string sThemeDir = GetThemeDirFromName(sThemeName);
@@ -844,8 +844,8 @@ ThemeManager::GetPathInfo(PathInfo& out,
 	/* Ugly: the parameters to this function may be a reference into g_vThemes,
 	 * or something else that might suddenly go away when we call ReloadMetrics.
 	 */
-	const std::string& sMetricsGroup = sMetricsGroup_;
-	const std::string& sElement = sElement_;
+	const std::string sMetricsGroup = sMetricsGroup_;
+	const std::string sElement = sElement_;
 
 	std::string sFileName =
 	  MetricsGroupAndElementToFileName(sMetricsGroup, sElement);
@@ -1049,8 +1049,8 @@ ThemeManager::GetMetricRaw(const IniFile& ini,
 	/* Ugly: the parameters to this function may be a reference into g_vThemes,
 	 * or something else that might suddenly go away when we call ReloadMetrics.
 	 */
-	const std::string& sMetricsGroup = sMetricsGroup_;
-	const std::string& sValueName = sValueName_;
+	const std::string sMetricsGroup = sMetricsGroup_;
+	const std::string sValueName = sValueName_;
 
 	for (;;) {
 		std::string ret;


### PR DESCRIPTION
Should fix
https://crash.etterna.dev/crash-reports/d48f8d83-6089-400b-b649-b426c4f058d6
In
https://github.com/etternagame/etterna/commit/74618a164f623f5e37174cd8f0927ad7ea87b07a#diff-fa2cfd199eddea90ff3e3cad44b343d951a77386b267c89d39b689c07a534e65R652
mina changed a couple string types to string&, per a resharper
suggestion
Doing that causes some crashes, the comment above the lines this commit
changes explain that ReloadMetrics can delete/reallocate the string
parameters the functions take by reference, so they make a local copy of
their string parameters. This can result in a crash if a lua script
error is encountered and we attempt to reloadmetrics and retry, for
example here
https://github.com/etternagame/etterna/blob/201115635bb3635ca5f3e65c395e55ba7c1b5300/src/Etterna/Singletons/ThemeManager.cpp#L750-L752