### PR TITLE
Delete d3d render targets before Reset()ing Device

### DIFF
--- a/src/RageUtil/Graphics/RageDisplay_D3D.cpp
+++ b/src/RageUtil/Graphics/RageDisplay_D3D.cpp
@@ -380,6 +380,12 @@ FindBackBufferType(bool bWindowed, int iBPP) -> D3DFORMAT
 auto
 SetD3DParams(bool& bNewDeviceOut) -> std::string
 {
+	// wipe old render targets
+	for (auto& rt : g_mapRenderTargets) {
+		delete rt.second;
+	}
+	g_mapRenderTargets.clear();
+
 	if (g_pd3dDevice == nullptr)
 	// device is not yet created. We need to create it
 	{
@@ -410,13 +416,6 @@ SetD3DParams(bool& bNewDeviceOut) -> std::string
 	}
 
 	g_pd3dDevice->SetRenderState(D3DRS_NORMALIZENORMALS, TRUE);
-
-	// wipe old render targets
-	for (auto& rt : g_mapRenderTargets) {
-		delete rt.second;
-	}
-
-	g_mapRenderTargets.clear();
 
 	// Palettes were lost by Reset(), so mark them unloaded.
 	g_TexResourceToPaletteIndex.clear();


### PR DESCRIPTION
Fixes #953

Like I mentioned in https://github.com/etternagame/etterna/issues/1166

The ::Reset documentation https://docs.microsoft.com/en-us/windows/win32/api/d3d9helper/nf-d3d9helper-idirect3ddevice9-reset says:

> Before calling the IDirect3DDevice9::Reset method for a device, an application should release any explicit render targets, depth stencil surfaces, additional swap chains, state blocks, and D3DPOOL_DEFAULT resources associated with the device.

Looking around the only place where we call `->Reset`, it seems we are deleting render targets *after* calling Reset, instead of before:

https://github.com/etternagame/etterna/blob/201115635bb3635ca5f3e65c395e55ba7c1b5300/src/RageUtil/Graphics/RageDisplay_D3D.cpp#L403-L417