### PR TITLE
Slightly cleanup DLMAN

### DIFF
--- a/src/Etterna/Singletons/DownloadManager.cpp
+++ b/src/Etterna/Singletons/DownloadManager.cpp
@@ -2786,6 +2786,10 @@ class LunaDownloadManager : public Luna<DownloadManager>
 		ADD_METHOD(RequestChartLeaderBoardFromOnline);
 		ADD_METHOD(RequestOnlineScoreReplayData);
 		ADD_METHOD(GetChartLeaderBoard);
+		// This does not actually request the leaderboard from online.
+		// It gets the already retrieved data from DLMAN
+		// Why does this alias exist? - Note: lowercase `b`oard
+		AddMethod("GetChartLeaderboard", GetChartLeaderBoard);
 		ADD_METHOD(ToggleRateFilter);
 		ADD_METHOD(GetCurrentRateFilter);
 		ADD_METHOD(ToggleTopScoresOnlyFilter);

--- a/src/Etterna/Singletons/DownloadManager.cpp
+++ b/src/Etterna/Singletons/DownloadManager.cpp
@@ -5,6 +5,7 @@
 #include "Core/Services/Locator.hpp"
 #include "Core/Platform/Platform.hpp"
 #include "RageUtil/File/RageFile.h"
+#include "RageUtil/Utils/RageUtil.h"
 #include "DownloadManager.h"
 #include "GameState.h"
 #include "ScoreManager.h"
@@ -156,15 +157,6 @@ DownloadManager::InstallSmzip(const string& sZipFile)
 
 	SCREENMAN->SystemMessage(sResult);
 	return true;
-}
-
-// A couple utility inline string functions
-inline bool
-ends_with(std::string const& value, std::string const& ending)
-{
-	if (ending.size() > value.size())
-		return false;
-	return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
 }
 
 inline CURL*

--- a/src/Etterna/Singletons/DownloadManager.cpp
+++ b/src/Etterna/Singletons/DownloadManager.cpp
@@ -187,32 +187,6 @@ initCURLHandle(bool withBearer)
 	curl_easy_setopt(curlHandle, CURLOPT_TIMEOUT, 120); // Seconds
 	return curlHandle;
 }
-inline bool
-addFileToForm(curl_httppost*& form,
-			  curl_httppost*& lastPtr,
-			  string field,
-			  string fileName,
-			  string filePath,
-			  std::string& contents)
-{
-	RageFile rFile;
-	if (!rFile.Open(filePath))
-		return false;
-	rFile.Read(contents, rFile.GetFileSize());
-	rFile.Close();
-	curl_formadd(&form,
-				 &lastPtr,
-				 CURLFORM_COPYNAME,
-				 field.c_str(),
-				 CURLFORM_BUFFER,
-				 fileName.c_str(),
-				 CURLFORM_BUFFERPTR,
-				 contents.c_str(),
-				 CURLFORM_BUFFERLENGTH,
-				 0,
-				 CURLFORM_END);
-	return true;
-}
 inline void
 SetCURLResultsString(CURL* curlHandle, string* str)
 {

--- a/src/Etterna/Singletons/DownloadManager.cpp
+++ b/src/Etterna/Singletons/DownloadManager.cpp
@@ -638,10 +638,7 @@ DownloadManager::RemoveFavorite(const string& chartkey)
 	if (it != DLMAN->favorites.end())
 		DLMAN->favorites.erase(it);
 	string req = "user/" + UrlEncode(DLMAN->sessionUser) + "/favorites/" + UrlEncode(chartkey);
-	auto done = [](HTTPRequest& req, CURLMsg*) {
-
-	};
-	auto r = SendRequest(req, {}, done);
+	auto r = SendRequest(req, {}, {});
 	if (r)
 		curl_easy_setopt(r->handle, CURLOPT_CUSTOMREQUEST, "DELETE");
 }
@@ -652,10 +649,7 @@ DownloadManager::RemoveGoal(const string& chartkey, float wife, float rate)
 {
 	string req = "user/" + UrlEncode(DLMAN->sessionUser) + "/goals/" + UrlEncode(chartkey )+ "/" +
 				 to_string(wife) + "/" + to_string(rate);
-	auto done = [](HTTPRequest& req, CURLMsg*) {
-
-	};
-	auto r = SendRequest(req, {}, done);
+	auto r = SendRequest(req, {}, {});
 	if (r)
 		curl_easy_setopt(r->handle, CURLOPT_CUSTOMREQUEST, "DELETE");
 }
@@ -667,16 +661,13 @@ DownloadManager::AddGoal(const string& chartkey,
 						 DateTime& timeAssigned)
 {
 	string req = "user/" + UrlEncode(DLMAN->sessionUser) + "/goals";
-	auto done = [](HTTPRequest& req, CURLMsg*) {
-
-	};
 	std::vector<pair<string, string>> postParams = {
 		make_pair("chartkey", UrlEncode(chartkey)),
 		make_pair("rate", to_string(rate)),
 		make_pair("wife", to_string(wife)),
 		make_pair("timeAssigned", timeAssigned.GetString())
 	};
-	SendRequest(req, postParams, done, true, true);
+	SendRequest(req, postParams, {}, true, true);
 }
 
 void
@@ -692,9 +683,6 @@ DownloadManager::UpdateGoal(const string& chartkey,
 		timeAchievedString = timeAchieved.GetString();
 
 	string req = "user/" + UrlEncode(DLMAN->sessionUser) + "/goals/update";
-	auto done = [](HTTPRequest& req, CURLMsg*) {
-
-	};
 	std::vector<pair<string, string>> postParams = {
 		make_pair("chartkey", UrlEncode(chartkey)),
 		make_pair("rate", to_string(rate)),
@@ -703,7 +691,7 @@ DownloadManager::UpdateGoal(const string& chartkey,
 		make_pair("timeAssigned", timeAssigned.GetString()),
 		make_pair("timeAchieved", timeAchievedString)
 	};
-	SendRequest(req, postParams, done, true, true);
+	SendRequest(req, postParams, {}, true, true);
 }
 
 void
@@ -1196,17 +1184,6 @@ DownloadManager::EndSession()
 		MESSAGEMAN->Broadcast("LogOut");
 }
 
-std::vector<std::string>
-split(const std::string& s, char delimiter)
-{
-	std::vector<std::string> tokens;
-	std::string token;
-	std::istringstream tokenStream(s);
-	while (std::getline(tokenStream, token, delimiter)) {
-		tokens.push_back(token);
-	}
-	return tokens;
-}
 // User rank
 void
 DownloadManager::RefreshUserRank()
@@ -2330,18 +2307,6 @@ Download::Failed()
 	msg.SetParam("pack", LuaReference::CreateFromPush(*p_Pack));
 	MESSAGEMAN->Broadcast(msg);
 }
-/// Try to find in the Haystack the Needle - ignore case
-bool
-findStringIC(const std::string& strHaystack, const std::string& strNeedle)
-{
-	auto it = std::search(
-	  strHaystack.begin(),
-	  strHaystack.end(),
-	  strNeedle.begin(),
-	  strNeedle.end(),
-	  [](char ch1, char ch2) { return toupper(ch1) == toupper(ch2); });
-	return (it != strHaystack.end());
-}
 
 // lua start
 #include "Etterna/Models/Lua/LuaBinding.h"
@@ -2823,10 +2788,6 @@ class LunaDownloadManager : public Luna<DownloadManager>
 		ADD_METHOD(RequestChartLeaderBoardFromOnline);
 		ADD_METHOD(RequestOnlineScoreReplayData);
 		ADD_METHOD(GetChartLeaderBoard);
-		// This does not actually request the leaderboard from online.
-		// It gets the already retrieved data from DLMAN
-		// Why does this alias exist?
-		AddMethod("GetChartLeaderboard", GetChartLeaderBoard);
 		ADD_METHOD(ToggleRateFilter);
 		ADD_METHOD(GetCurrentRateFilter);
 		ADD_METHOD(ToggleTopScoresOnlyFilter);

--- a/src/Etterna/Singletons/DownloadManager.h
+++ b/src/Etterna/Singletons/DownloadManager.h
@@ -33,11 +33,9 @@ class RageFileWrapper
 class Download
 {
   public:
-	std::function<void(Download*)> Done;
 	Download(
 	  std::string url,
-	  std::string filename = "",
-	  std::function<void(Download*)> done = [](Download*) {});
+	  std::string filename = "");
 	~Download();
 	void Install();
 	void Update(float fDeltaSeconds);
@@ -171,12 +169,12 @@ class DownloadManager
 	static LuaReference EMPTY_REFERENCE;
 	DownloadManager();
 	~DownloadManager();
-	std::map<std::string, Download*> downloads; // Active downloads
+	std::map<std::string, std::shared_ptr<Download>> downloads; // Active downloads
 	std::vector<HTTPRequest*>
 	  HTTPRequests; // Active HTTP requests (async, curlMulti)
 
-	std::map<std::string, Download*> finishedDownloads;
-	std::map<std::string, Download*> pendingInstallDownloads;
+	std::map<std::string, std::shared_ptr<Download>> finishedDownloads;
+	std::map<std::string, std::shared_ptr<Download>> pendingInstallDownloads;
 	CURLM* mPackHandle{ nullptr }; // Curl multi handle for packs downloads
 	CURLM* mHTTPHandle{ nullptr }; // Curl multi handle for httpRequests
 	CURLMcode ret = CURLM_CALL_MULTI_PERFORM;
@@ -242,9 +240,9 @@ class DownloadManager
 	void RefreshPackList(const std::string& url);
 
 	void init();
-	Download* DownloadAndInstallPack(const std::string& url,
+	std::shared_ptr<Download> DownloadAndInstallPack(const std::string& url,
 									 std::string filename = "");
-	Download* DownloadAndInstallPack(DownloadablePack* pack,
+	std::shared_ptr<Download> DownloadAndInstallPack(DownloadablePack* pack,
 									 bool mirror = false);
 	void Update(float fDeltaSeconds);
 	void UpdatePacks(float fDeltaSeconds);

--- a/src/Etterna/Singletons/DownloadManager.h
+++ b/src/Etterna/Singletons/DownloadManager.h
@@ -256,7 +256,6 @@ class DownloadManager
 
 	std::string GetError() { return error; }
 	bool Error() { return error.empty(); }
-	bool EncodeSpaces(std::string& str);
 
 	void UploadScore(HighScore* hs,
 					 std::function<void()> callback,

--- a/src/Etterna/Singletons/DownloadManager.h
+++ b/src/Etterna/Singletons/DownloadManager.h
@@ -94,11 +94,9 @@ class HTTPRequest
   public:
 	HTTPRequest(
 	  CURL* h,
-	  std::function<void(HTTPRequest&, CURLMsg*)> done = [](HTTPRequest& req,
-															CURLMsg*) {},
+	  std::function<void(HTTPRequest&)> done = [](HTTPRequest& req) {},
 	  curl_httppost* postform = nullptr,
-	  std::function<void(HTTPRequest&, CURLMsg*)> fail = [](HTTPRequest& req,
-															CURLMsg*) {})
+	  std::function<void(HTTPRequest&)> fail = [](HTTPRequest& req) {})
 	  : handle(h)
 	  , form(postform)
 	  , Done(done)
@@ -106,8 +104,8 @@ class HTTPRequest
 	CURL* handle{ nullptr };
 	curl_httppost* form{ nullptr };
 	std::string result;
-	std::function<void(HTTPRequest&, CURLMsg*)> Done;
-	std::function<void(HTTPRequest&, CURLMsg*)> Failed;
+	std::function<void(HTTPRequest&)> Done;
+	std::function<void(HTTPRequest&)> Failed;
 };
 class OnlineTopScore
 {
@@ -272,7 +270,7 @@ class DownloadManager
 	HTTPRequest* SendRequest(
 	  std::string requestName,
 	  std::vector<std::pair<std::string, std::string>> params,
-	  std::function<void(HTTPRequest&, CURLMsg*)> done,
+	  std::function<void(HTTPRequest&)> done,
 	  bool requireLogin = true,
 	  bool post = false,
 	  bool async = true,
@@ -280,7 +278,7 @@ class DownloadManager
 	HTTPRequest* SendRequestToURL(
 	  std::string url,
 	  std::vector<std::pair<std::string, std::string>> params,
-	  std::function<void(HTTPRequest&, CURLMsg*)> done,
+	  std::function<void(HTTPRequest&)> done,
 	  bool requireLogin,
 	  bool post,
 	  bool async,


### PR DESCRIPTION
commit messages have the description of the stuff I did. Aggregated:

 - Removed unused ReadThis class and functions
 - removed unused cpuid in ComputerIdentity()
 - Inlined progressfunc and write_data definitions to the only place
   they're used as capture-less lambas
 - Inlined checkProtocol function which had a confusing name and was
   only used once (Also changed default to https)
 - Removed the hacky EncodeSpaces function, replaced it with curl's url
   encoding function (curl_easy_escape) in the places where I think it
   was needed (tested score leaderboard requests and pack downloading
   and they seem to work alright)
 - [Remove ends_with function from DLMAN (Already in RageUtil.h)](https://github.com/etternagame/etterna/commit/5b91178ce31e88647ccdde8320e24007d8fb9371)
 - [Remove unused addFileToForm function from DLMAN](https://github.com/etternagame/etterna/commit/d044791f67b71f535629fece23cd5086fd462f69) (unused)
 - Remove SetCURLPostToURL which was only called in 2 places and only
added one line over SetCURLURL
 - Remove an unused CURL handle fromDownloadManager::RefreshTop25 which I think we were leaking.
 - Move CURL handle deletion of the Download struct from ~DownloadManager to it's destructor ~Download
 - Removed the unused Done() callback from Download
 - Remove split (unused, probably replaced with splitPath at some point
   and not removed)
 - Renive findStringIC (unused)
 - Remove duplicated GetChartLeaderboard AddMethod call
 - Replace a couple 3-line empty lambda definitions which just add noise
   with {} literals which are equivalent
 - [Remove unused CURLMsg* param from DLMAN callbacks](https://github.com/etternagame/etterna/pull/1199/commits/82ad755650a374aaf6b80e5621583d9c1c3e60d9)