### PR TITLE
Some calc floating point stability fixes 

### DIFF
--- a/src/Etterna/MinaCalc/CalcWindow.h
+++ b/src/Etterna/MinaCalc/CalcWindow.h
@@ -182,7 +182,7 @@ struct CalcMovingWindow
 		// we can basically just branch to ccacc or acca checks depending on
 		// which value is higher
 		bool o;
-		if (_itv_vals[4] > _itv_vals[5]) {
+		if (any_ms_is_greater(_itv_vals[4], _itv_vals[5])) {
 			// if middle is higher, run the ccacc check that will divide it
 			o = ccacc_timing_check(factor, threshold);
 		} else {

--- a/src/Etterna/MinaCalc/Dependent/HD_PatternMods/Chaos.h
+++ b/src/Etterna/MinaCalc/Dependent/HD_PatternMods/Chaos.h
@@ -49,7 +49,7 @@ struct ChaosMod
 		// previous value
 		const float b = ms_any.get_last();
 
-		if (a == 0.F || b == 0.F || a == b) {
+		if (any_ms_is_zero(a) || any_ms_is_zero(b) || any_ms_is_close(a, b)) {
 			_u(1.F);
 			_wot(_u.get_mean_of_window(window));
 			return;

--- a/src/Etterna/MinaCalc/Dependent/HD_PatternMods/WideRangeRoll.h
+++ b/src/Etterna/MinaCalc/Dependent/HD_PatternMods/WideRangeRoll.h
@@ -155,7 +155,7 @@ struct WideRangeRollMod
 
 	void handle_roll_timing_check()
 	{
-		if (seq_ms[1] > seq_ms[0]) {
+		if (any_ms_is_greater(seq_ms[1], seq_ms[0])) {
 			zoop_the_woop(1, 2.5F);
 		} else {
 			seq_ms[0] /= 2.5F;

--- a/src/Etterna/MinaCalc/MinaCalc.cpp
+++ b/src/Etterna/MinaCalc/MinaCalc.cpp
@@ -1013,7 +1013,7 @@ MinaSDCalcDebug(
 	}
 }
 
-int mina_calc_version = 495;
+int mina_calc_version = 496;
 auto
 GetCalcVersion() -> int
 {

--- a/src/Etterna/MinaCalc/SequencingHelpers.h
+++ b/src/Etterna/MinaCalc/SequencingHelpers.h
@@ -83,3 +83,45 @@ max_index(const std::vector<float>& v) -> int
 	return static_cast<int>(
 	  std::distance(v.begin(), std::max_element(v.begin(), v.end())));
 }
+
+/// functions for comparing row deltas (see "any_ms" comment in
+/// GenerecSequencing.h)
+
+// it's expected that successive row deltas will often be equal,
+// but this is not reliable in floating point. so any time you
+// want to branch on a comparison you need to assume that very
+// close values are supposed to be equal
+
+// floats are good to around 1e-5, milliseconds scale that up by 1e3,
+// if we stick to small-brain base 10 then 0.1f is all we have left
+
+/// tolerance for comparisons of row time deltas
+constexpr float any_ms_epsilon = 0.1F;
+
+/// a > b
+inline auto
+any_ms_is_greater(float a, float b) -> bool
+{
+	return (a - b) > any_ms_epsilon;
+}
+
+/// a < b
+inline auto
+any_ms_is_lesser(float a, float b) -> bool
+{
+	return (b - a) > any_ms_epsilon;
+}
+
+/// a == b
+inline auto
+any_ms_is_close(float a, float b) -> bool
+{
+	return fabsf(a - b) <= any_ms_epsilon;
+}
+
+/// a == 0
+inline auto
+any_ms_is_zero(float a) -> bool
+{
+	return any_ms_is_close(a, 0.F);
+}

--- a/src/Etterna/MinaCalc/UlbuAcolytes.h
+++ b/src/Etterna/MinaCalc/UlbuAcolytes.h
@@ -116,7 +116,14 @@ struct PatternMods
 inline auto
 time_to_itv_idx(const float& time) -> int
 {
-	return static_cast<int>(time / interval_span);
+	// Offset time by half a millisecond to consistently break ties when a row
+	// lies on an interval boundary. This is worst on files at bpms like 180
+	// where the milliseconds between 16ths cannot be represented exactly by a
+	// float but in exact arithemetic regularly align with the interval
+	// boundaries. Offsetting here makes the calc more robust to bpm
+	// fluctuations, mines at the start of the file, etc, which could move notes
+	// into different intervals
+	return static_cast<int>((time + 0.0005f) / interval_span);
 }
 
 inline auto


### PR DESCRIPTION
The calc is unusually sensitive to tiny changes in row times. For example depending on whether they are computed [here](https://github.com/etternagame/etterna/blob/877d46ae88f9d7d6c887a7e954192bd757399cc1/src/Etterna/Models/Misc/TimingData.cpp#L1400) or [here](https://github.com/etternagame/etterna/blob/877d46ae88f9d7d6c887a7e954192bd757399cc1/src/Etterna/Models/Misc/TimingData.cpp#L1418) can cause a large change in the result, even when they are equivalent (i.e., bpm change after the last non-empty row)

This is kinda academic but it seemed like an interesting thing to track down and fix so here we are. This PR moves most files around randomly in a range of around 0.5 MSD. It is apparently a bit better on average but that may just be chance

It turns out there were 2 sources of instability:
 - Comparisons of row time deltas. This one is where most the instability was coming from. Basically for row times `t0`, `t1`, `t2`, `t3`, all a 16th apart, you don't necessarily have `(t1 - t0) == (t3 - t2)` due to rounding error. This matters for the couple places where the calc branches on one being greater than the other. For equal deltas, sometimes you get lucky and it's less or equal, sometimes you get unlucky and it's greater.
 - Inconsistent interval binning on certain BPMs. Since the first non-empty row is set to time 0 and intervals are half a second, any bpm which lines up rows onto half seconds has many rows that lie exactly on interval boundaries. Those are representable in floating point but may be missed due to rounding error. If it comes under, rows get binned into the previous interval. So e.g. the calc may see oscillating NPS density where it should be constant. Smoothing and sequencing makes this less bad but it's still weird

Aside from the changes in this PR, another thing that would help is rounding the row times (after rate scaling) to a power of two, like `1/1024`. That'll fix interval binning and it'll make row time deltas exact. But it will only fix comparisons of the form `(t1 - t0) == (t3 - t2)`, if you do anything more complicated you end up in the same situation. So I didn't bother

