### PR TITLE
Add Windows UTF8 Manifest

### DIFF
--- a/src/archutils/CMakeLists.txt
+++ b/src/archutils/CMakeLists.txt
@@ -43,7 +43,8 @@ if(WIN32)
 		"Win32/VideoDriverInfo.cpp"
 		"Win32/WindowIcon.cpp"
 		"Win32/WindowsDialogBox.cpp"
-		"Win32/WindowsResources.rc")
+		"Win32/WindowsResources.rc"
+		"Win32/Etterna.manifest")
 
 	list(APPEND OS_HPP
 		"Win32/AppInstance.h"

--- a/src/archutils/Win32/Etterna.manifest
+++ b/src/archutils/Win32/Etterna.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+ <assemblyIdentity type="win32" name="..." version="6.0.0.0"/>
+  <application>
+   <windowsSettings>
+    <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+  </windowsSettings>
+  </application>
+</assembly>


### PR DESCRIPTION
This fixes files with mojibake path errors on newer versions of Windows.

According to https://learn.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page on old versions prior to 2019, things will work as before.

Maybe this will uncover mysterious latent bugs but since Linux and MacOS do in fact work it seems unlikely to me!?