### PR TITLE
Fix uninit read Defect in SoundPosMap

### DIFF
--- a/src/RageUtil/Sound/RageSoundPosMap.cpp
+++ b/src/RageUtil/Sound/RageSoundPosMap.cpp
@@ -45,7 +45,6 @@ pos_map_queue::~pos_map_queue()
 
 pos_map_queue::pos_map_queue(const pos_map_queue& cpy)
 {
-	*this = cpy;
 	m_pImpl = new pos_map_impl(*cpy.m_pImpl);
 }
 


### PR DESCRIPTION
The `*this = cpy` statement calls the copy constructor, which does `delete m_pImpl` while the field is uninitialized. Just removing it should be fine, we allocate a copy of the m_pImpl anyways and that is the only field in the type.