### PR TITLE
Fix incorrect bpm display for ssc songs with varying bpms per-chart

### DIFF
--- a/Themes/Rebirth/BGAnimations/ScreenSelectMusic decorations/curSongBox.lua
+++ b/Themes/Rebirth/BGAnimations/ScreenSelectMusic decorations/curSongBox.lua
@@ -418,12 +418,9 @@ t[#t+1] = Def.ActorFrame {
             self:maxwidth(actuals.BPMWidth / textsize - textzoomFudge)
         end,
         SetCommand = function(self, params)
-            -- it appears that SetFromSteps is broken...
-            -- note to self.
-            -- wow i forgot about this. time to forget about it again -11 months later
             if params.steps then
                 self:visible(true)
-                self:SetFromSong(params.song)
+                self:SetFromSteps(params.steps)
             else
                 self:visible(false)
             end

--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/wifeTwirl.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/wifeTwirl.lua
@@ -650,10 +650,10 @@ t[#t + 1] = Def.ActorFrame {
 		InitCommand = function(self)
 			self:xy(capWideScale(get43size(384), 400) + 62, SCREEN_BOTTOM - 110.5):halign(1):zoom(0.50):maxwidth(50)
 		end,
-		MortyFartsCommand = function(self)
+		MintyFreshCommand = function(self)
 			if song then
 				self:visible(true)
-				self:SetFromSong(song)
+				self:SetFromSteps(steps)
 			else
 				self:visible(false)
 			end

--- a/Themes/bare-frames/BGAnimations/ScreenSelectMusic decorations/songinfo.lua
+++ b/Themes/bare-frames/BGAnimations/ScreenSelectMusic decorations/songinfo.lua
@@ -82,7 +82,7 @@ t[#t+1] = Def.ActorFrame {
         SetStuffCommand = function(self)
             if song then
                 self:visible(true)
-                self:SetFromSong(song)
+                self:SetFromSteps(steps)
             else
                 self:visible(false)
             end

--- a/src/Etterna/Actor/Menus/BPMDisplay.cpp
+++ b/src/Etterna/Actor/Menus/BPMDisplay.cpp
@@ -204,6 +204,7 @@ BPMDisplay::SetBpmFromSteps(const Steps* pSteps)
 	pSteps->GetTimingData()->GetActualBPM(fMinBPM, fMaxBPM);
 	bpms.Add(fMinBPM);
 	bpms.Add(fMaxBPM);
+	SetBPMRange(bpms);
 	m_fCycleTime = 1.0f;
 }
 


### PR DESCRIPTION
This fixes the remaining problem within #615 wherein the displayed BPM range for songs that had different BPM ranges per-chart was incorrect.

#619 fixed most of the problems, but as Poco noted in https://github.com/etternagame/etterna/pull/619#issuecomment-520270829 the Lua binding for BPMDisplay `SetFromSteps` still did not work even after that change.

That was because `BPMDisplay::SetBpmFromSteps` did all the work to determine the correct BPM range and then just ... didn't call `SetBPMRange` to actually update it.

This PR fixes that function and then makes the simple changes required to Rebirth, Til Death, and bare-frames to get them to use it.

Closes: #615 