### PR TITLE
(Again) disable use of libssh2 when building cURL

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -13,7 +13,7 @@ set(BUILD_SHARED_LIBS OFF) # Tell CMake to prefer static libs
 
 # External Libraries
 ## Curl Specific Options
-set(CMAKE_USE_LIBSSH2 OFF CACHE BOOL "" FORCE) # Disable curl libssh2
+set(CURL_USE_LIBSSH2 OFF CACHE BOOL "" FORCE) # Disable curl libssh2
 set(BUILD_CURL_EXE OFF CACHE BOOL "" FORCE)    # Tell curl not to build standalone binary
 set(BUILD_TESTING OFF CACHE BOOL "" FORCE)     # Disable curl testing
 set(CURL_USE_OPENSSL ON CACHE BOOL "" FORCE)  # Require OpenSSL


### PR DESCRIPTION
Without this change, we run into the problem where our GHA builder has the libssh2 library installed (and so the built cURL dynamically links to it) but the average mac user does not, leading to the application immediately crashing on start.

This was already fixed once before, but with the recent(ish) upgrade to a newer version of cURL than what we'd been using in f1dd6fe, the option CMAKE_USE_LIBSSH2 was renamed to CURL_USE_LIBSSH2, which silently made our forcing of that setting to OFF no longer work.