### PR TITLE
Minor Etterna Documentation Fixups (pause_menu.html exclusion & fixing images)

### DIFF
--- a/.ci/generate_doc_configs.sh
+++ b/.ci/generate_doc_configs.sh
@@ -4,7 +4,7 @@
 sudo apt-get install build-essential libssl-dev libx11-dev libxrandr-dev libcurl4-openssl-dev libglu1-mesa-dev libpulse-dev libogg-dev libasound-dev libjack-dev
 
 #Install doxygen
-sudo apt-get install doxygen 
+sudo apt-get install doxygen graphviz
 
 eval "$(luarocks path --bin)"
 

--- a/Docs/legacy/Themerdocs/pause_menu.md
+++ b/Docs/legacy/Themerdocs/pause_menu.md
@@ -1,3 +1,8 @@
+---
+# Exclude this from sidebar of Etterna documentation site
+nav_exclude: true
+---
+
 # Purpose
 
 The pause menu controller actor encapsulates the logic for when to activate

--- a/Docs/legacy/Userdocs/Keymaps_ini_format.md
+++ b/Docs/legacy/Userdocs/Keymaps_ini_format.md
@@ -1,3 +1,7 @@
+---
+# Exclude this from sidebar of Etterna documentation site
+nav_exclude: true
+---
 # Overview
 
 The Keymaps.ini file tells StepMania how the keys on the keyboard or other


### PR DESCRIPTION
Exclude pause_menu and keymaps_ini_format from Etterna documentation sidebar

Amusingly enough the pause menu was probably the worst SM5 legacy documentation that could have shown up, since pausing is *definitely* not an Etterna feature :)

With this change, both are still *built* by Jekyll, and can be navigated to if you know the link, but won't be prominently displayed on the homepage.


Also


Install graphviz in Etterna Doc CI to properly build DOT files