### PR TITLE
Make OpenSSL static link on all operating systems preferentially

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,10 +63,16 @@ target_include_directories(Etterna PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)      
 ## Package Includes
 ### OpenSSL is not used directly by our program, but we have to use OpenSSL first
 ### in order to statically link. Once find_package is run once, it's results are cached
-set(OPENSSL_USE_STATIC_LIBS ON CACHE BOOL "" FORCE)
+set(OPENSSL_USE_STATIC_LIBS ON CACHE BOOL "")
 set(OPENSSL_MSVC_STATIC_RT ON CACHE BOOL "" FORCE)
 
-find_package(OpenSSL REQUIRED)
+find_package(OpenSSL)
+# If a static version of OpenSSL cannot be found then try a dynamic link, if that fails then error (REQUIRED)
+if(NOT OPENSSL_FOUND)
+    set(OPENSSL_USE_STATIC_LIBS OFF CACHE BOOL "" FORCE)
+    find_package(OpenSSL REQUIRED)
+endif()
+
 find_package(Threads REQUIRED)
 target_link_libraries(Etterna PRIVATE Threads::Threads)
 target_link_libraries(Etterna PRIVATE OpenSSL::SSL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,9 +63,7 @@ target_include_directories(Etterna PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)      
 ## Package Includes
 ### OpenSSL is not used directly by our program, but we have to use OpenSSL first
 ### in order to statically link. Once find_package is run once, it's results are cached
-if (WIN32 OR APPLE)
-    set(OPENSSL_USE_STATIC_LIBS ON CACHE BOOL "" FORCE)
-endif()
+set(OPENSSL_USE_STATIC_LIBS ON CACHE BOOL "" FORCE)
 set(OPENSSL_MSVC_STATIC_RT ON CACHE BOOL "" FORCE)
 
 find_package(OpenSSL REQUIRED)


### PR DESCRIPTION
This should resolve issue #1215 as it will make the binaries generated for Linux static link OpenSSL so ubuntu 22.04 should not need to have OpenSSL 1.1 to function.

The reason this was chosen over switching to OpenSSL 3.0 with maintaining dynamic linking on Linux is because doing this would create the same problem for Ubuntu 20.04 LTS as they are stuck with OpenSSL 1.1. The CI for Etterna also uses Ubuntu 20.04 which means trying to switch to OpenSSL 3.0 would make that build fail without manually grabbing the package from the Ubuntu 22.04 repositories.

The reason dynamic linking is still allowed in the build process is for operating systems (Arch Linux) that lack static versions of packages and must dynamically link if they want to compile the game (see #952)