### PR TITLE
Add and implement Core::setClipboardText

### DIFF
--- a/src/Core/Platform/Platform.cpp
+++ b/src/Core/Platform/Platform.cpp
@@ -63,6 +63,11 @@ int getClipboard(lua_State* L) {
     return 1;
 }
 
+int setClipboardText(lua_State* L) {
+	lua_pushboolean(L, Core::Platform::setClipboardText(SArg(1)));
+	return 1;
+}
+
 int setCursorVisible(lua_State* L){
     Core::Platform::setCursorVisible(BArg(1));
     return 0;
@@ -78,6 +83,7 @@ const luaL_Reg ArchTable[] = {
         LIST_METHOD(isGameFocused),
         LIST_METHOD(getSystem),
         LIST_METHOD(getClipboard),
+		LIST_METHOD(setClipboardText),
         LIST_METHOD(setCursorVisible),
 		LIST_METHOD(requestUserAttention),
         { nullptr, nullptr }

--- a/src/Core/Platform/Platform.hpp
+++ b/src/Core/Platform/Platform.hpp
@@ -101,7 +101,15 @@ namespace Core::Platform {
      * @brief Get contents of the system clipboard.
      * @return UTF-8 clipboard contents, or an empty string if the the clipboard is a non-text type.
      */
+
     std::string getClipboard();
+
+	/**
+	 * @brief Set contents of sytem clipboard to provided text
+	 * @param text Text to set clipboard to
+	 * @return Whether the operation was performed succesfully
+	 */
+	bool setClipboardText(std::string text);
 
     /**
      * Set if the mouse is visible or invisible

--- a/src/Core/Platform/PlatformMac.mm
+++ b/src/Core/Platform/PlatformMac.mm
@@ -152,6 +152,12 @@ namespace Core::Platform {
         return [item stringForType:(NSPasteboardTypeString)].UTF8String;
     }
 
+	bool setClipboardText(std::string text){
+		[[NSPasteboard generalPasteboard] clearContents];
+		[[NSPasteboard generalPasteboard] setString:[NSString stringWithUTF8String:text.c_str()] forType:NSPasteboardTypeString];
+		return true;
+	}
+
     void setCursorVisible(bool value){
 		static bool cursor_visible = true;
 		/*NSCursor hide/unhide keeps a reference count; each hide

--- a/src/Core/Platform/PlatformUnix.cpp
+++ b/src/Core/Platform/PlatformUnix.cpp
@@ -244,6 +244,11 @@ namespace Core::Platform {
         return res;
     }
 
+    bool setClipboardText(std::string text){
+        Locator::getLogger()->warn("Core::Platform::setClipboardText not implemented");
+        return false;
+    }
+
     void setCursorVisible(bool value){
         Locator::getLogger()->warn("Core::Platform::setCursorVisible not implemented");
     }

--- a/src/Core/Platform/PlatformWin.cpp
+++ b/src/Core/Platform/PlatformWin.cpp
@@ -292,6 +292,11 @@ namespace Core::Platform {
 		return res;
 	}
 
+	bool setClipboardText(std::string text){
+		Locator::getLogger()->warn("Core::Platform::setClipboardText not implemented");
+		return false;
+	}
+
 	void setCursorVisible(bool value){
  		if (value){
 		    while (ShowCursor(true) < 0);


### PR DESCRIPTION
Currently implemented for macOS
Implementations are stubbed out for Unix and Windows Core platform