### PR TITLE
Modify Core::Platform::getLanguage to work with older macOS versions

### DIFF
--- a/src/Core/Platform/PlatformMac.mm
+++ b/src/Core/Platform/PlatformMac.mm
@@ -112,7 +112,7 @@ namespace Core::Platform {
     }
 
     std::string getLanguage(){
-        return NSLocale.currentLocale.languageCode.UTF8String;
+		return [[NSLocale.currentLocale objectForKey:NSLocaleLanguageCode] UTF8String];
     }
 
     bool openWebsite(const std::string& url){


### PR DESCRIPTION
Locale.NSLocale.languageCode was only added in macOS 10.12. However, the same information can be obtained a slightly different way that is non-deprecated and works all the way back to macOS 10.4.

This small change makes Etterna compatible with (at least) El Capitan again excepting the known issue with OpenSSL on High Sierra and earlier users.