### PR TITLE
Dejank D3D

### DIFF
--- a/src/RageUtil/Graphics/RageBitmapTexture.cpp
+++ b/src/RageUtil/Graphics/RageBitmapTexture.cpp
@@ -255,6 +255,8 @@ RageBitmapTexture::Create()
 			pixfmt = RagePixelFormat_RGBA4;
 	}
 
+	auto pfd = DISPLAY->GetPixelFormatDesc(pixfmt);
+
 	/* Dither if appropriate.
 	 * XXX: This is a special case: don't bother dithering to RGBA8888.
 	 * We actually want to dither only if the destination has greater color
@@ -264,7 +266,6 @@ RageBitmapTexture::Create()
 	if (actualID.bDither &&
 		(pixfmt == RagePixelFormat_RGBA4 || pixfmt == RagePixelFormat_RGB5A1)) {
 		// Dither down to the destination format.
-		auto pfd = DISPLAY->GetPixelFormatDesc(pixfmt);
 		auto dst = CreateSurface(pImg->w,
 								 pImg->h,
 								 pfd->bpp,
@@ -283,15 +284,16 @@ RageBitmapTexture::Create()
 	 * done *before* we set up the palette, since it might change it. */
 	RageSurfaceUtils::FixHiddenAlpha(pImg);
 
-	/* Scale up to the texture size, if needed. */
+	/* Convert the surface to the format the display wants, so we don't have
+	 * to do this every time on reupload. */
 	RageSurfaceUtils::ConvertSurface(pImg,
 									 m_iTextureWidth,
 									 m_iTextureHeight,
-									 pImg->fmt.BitsPerPixel,
-									 pImg->fmt.Mask[0],
-									 pImg->fmt.Mask[1],
-									 pImg->fmt.Mask[2],
-									 pImg->fmt.Mask[3]);
+									 pfd->bpp,
+									 pfd->masks[0],
+									 pfd->masks[1],
+									 pfd->masks[2],
+									 pfd->masks[3]);
 
 	m_uTexHandle = DISPLAY->CreateTexture(pixfmt, pImg, actualID.bMipMaps);
 


### PR DESCRIPTION
I don't use D3D so I don't know if this actually improves things any but it probably does. I think on OpenGL it'll prevent some unnecessary block copies on the music wheel. The main thing is just getting rid of the `blit_rgba_to_rgba` multithreading nonsense. It was basically only ever faster when converting 2048x2048 textures into a format for uploading to the GPU, anything smaller than that and it just sucked up more time than it saved. 

But that conversion itself was all wrong, anyway. Firstly f017d788857baf65f75632085da1c31c4835a0e6, its basically only ever used for converting images from RGBA to BGRA. RGBA is what OpenGL and everything after D3D10 uses, but D3D9 is from back when everything on Windows wanted to blit directly into GDI handles, so all textures have to be converted to that format when using RageDisplay_D3D. But the code doing that conversion was made for things like RGBA8 to RGBA4--not a byte swap. So just do the byte swap.

Second 8bbb8d82a024548c457ba2c5f37d94246fcb5254, that conversion was happening on every texture reupload, and the game is pretty aggressive about unloading textures, making the texture cache irrelevant. Although I think it's still kind of irrelevant but w/e (and also this matters way less than doing the right kind of blit)