### PR TITLE
Rebirth login binding change to not use physical location. Issue #1118

### DIFF
--- a/Themes/Rebirth/BGAnimations/playerInfoFrame/main.lua
+++ b/Themes/Rebirth/BGAnimations/playerInfoFrame/main.lua
@@ -254,7 +254,7 @@ local function beginLoginProcess(self)
     off()
 
     username = ""
-    
+
     -- this sets up 2 text entry windows to pull your username and pass
     -- if you press escape or just enter nothing, you are forced out
     -- input redirects are controlled here because we want to be careful not to break any prior redirects
@@ -666,8 +666,9 @@ t[#t+1] = Def.ActorFrame {
             end
 
             local ctrl = INPUTFILTER:IsControlPressed()
+            local char = event.charNoModifiers:upper()
             -- login logout shortcut
-            if ctrl and event.DeviceInput.button == "DeviceButton_l" then
+            if ctrl and char == "L" then
                 if not DLMAN:IsLoggedIn() then
                     beginLoginProcess(self)
                 else


### PR DESCRIPTION
Only changed this DeviceButtom_ since I didn't find any other one which could result in similar bugs. I wasn't able to test the bug because I don't a non-conventional layout keyboard but I'm pretty certain this should do the trick.

This is my first attempt in contributing to the project. If if mess anything up please tell me.