### PR TITLE
Configurable virtual fs mounts based on environment variables

### DIFF
--- a/CMake/Helpers/CPackSetup.cmake
+++ b/CMake/Helpers/CPackSetup.cmake
@@ -6,7 +6,8 @@ set(CPACK_RESOURCE_FILE_LICENSE ${PROJECT_SOURCE_DIR}/CMake/CPack/license_instal
 set(CPACK_COMPONENT_ETTERNA_REQUIRED TRUE)  # Require Etterna component to be installed
 
 # Custom Variables
-set(INSTALL_DIR "Etterna")
+set(INSTALL_DIR "Etterna" CACHE STRING "Output directory for built game")
+set(ASSET_DIR "${INSTALL_DIR}" CACHE STRING "Output directory for game assets")
 
 if(UNIX)
     set(CPACK_GENERATOR TGZ)
@@ -14,12 +15,14 @@ if(UNIX)
     set(CPACK_PACKAGE_CONTACT https://github.com/etternagame/etterna)
 
     install(TARGETS Etterna COMPONENT Etterna DESTINATION ${INSTALL_DIR})
-    install(FILES ${PROJECT_BINARY_DIR}/gn_crashpad/crashpad_handler
-            COMPONENT Etterna
-            DESTINATION ${INSTALL_DIR}
-            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
-                        GROUP_READ GROUP_EXECUTE
-                        WORLD_READ WORLD_EXECUTE)
+    if(WITH_CRASHPAD AND TARGET crashpad)
+        install(FILES ${PROJECT_BINARY_DIR}/gn_crashpad/crashpad_handler
+                COMPONENT Etterna
+                DESTINATION ${INSTALL_DIR}
+                PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                            GROUP_READ GROUP_EXECUTE
+                            WORLD_READ WORLD_EXECUTE)
+    endif()
 endif()
 
 # Windows Specific CPack
@@ -47,8 +50,10 @@ if(WIN32)
 
     # List every DLL etterna needs.
     list(APPEND WIN_DLLS "${PROJECT_SOURCE_DIR}/Program/avcodec-55.dll" "${PROJECT_SOURCE_DIR}/Program/avformat-55.dll"
-                         "${PROJECT_SOURCE_DIR}/Program/avutil-52.dll" "${PROJECT_SOURCE_DIR}/Program/swscale-2.dll"
-                         ${PROJECT_BINARY_DIR}/gn_crashpad/crashpad_handler.exe)
+                         "${PROJECT_SOURCE_DIR}/Program/avutil-52.dll" "${PROJECT_SOURCE_DIR}/Program/swscale-2.dll")
+    if(WITH_CRASHPAD AND TARGET crashpad)
+        list(APPEND WIN_DLLS ${PROJECT_BINARY_DIR}/gn_crashpad/crashpad_handler.exe)
+    endif()
     install(FILES ${WIN_DLLS}   COMPONENT Etterna DESTINATION Program)
     install(TARGETS Etterna     COMPONENT Etterna DESTINATION Program)
     install(FILES CMake/CPack/license_install.txt COMPONENT Etterna DESTINATION Docs)
@@ -60,24 +65,26 @@ elseif(APPLE)
     set(CPACK_DMG_VOLUME_NAME Etterna)
 
     install(TARGETS Etterna COMPONENT Etterna DESTINATION Etterna)
-    install(FILES ${PROJECT_BINARY_DIR}/gn_crashpad/crashpad_handler
-            COMPONENT Etterna DESTINATION ${INSTALL_DIR}
-            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
-                        GROUP_READ GROUP_EXECUTE
-                        WORLD_READ WORLD_EXECUTE)
+    if(WITH_CRASHPAD AND TARGET crashpad)
+        install(FILES ${PROJECT_BINARY_DIR}/gn_crashpad/crashpad_handler
+                COMPONENT Etterna DESTINATION ${INSTALL_DIR}
+                PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                            GROUP_READ GROUP_EXECUTE
+                            WORLD_READ WORLD_EXECUTE)
+    endif()
 endif()
 
 # Universal Install Directories
 ## Files Only
-install(FILES Songs/instructions.txt        COMPONENT Etterna DESTINATION "${INSTALL_DIR}/Songs")
-install(FILES Announcers/instructions.txt   COMPONENT Etterna DESTINATION "${INSTALL_DIR}/Announcers")
+install(FILES Songs/instructions.txt        COMPONENT Etterna DESTINATION "${ASSET_DIR}/Songs")
+install(FILES Announcers/instructions.txt   COMPONENT Etterna DESTINATION "${ASSET_DIR}/Announcers")
 
 ## Essential Game Files
-install(DIRECTORY Assets                    COMPONENT Etterna DESTINATION "${INSTALL_DIR}")
-install(DIRECTORY BackgroundEffects         COMPONENT Etterna DESTINATION "${INSTALL_DIR}")
-install(DIRECTORY BackgroundTransitions     COMPONENT Etterna DESTINATION "${INSTALL_DIR}")
-install(DIRECTORY BGAnimations              COMPONENT Etterna DESTINATION "${INSTALL_DIR}")
-install(DIRECTORY Data                      COMPONENT Etterna DESTINATION "${INSTALL_DIR}")
-install(DIRECTORY NoteSkins                 COMPONENT Etterna DESTINATION "${INSTALL_DIR}")
-install(DIRECTORY Scripts                   COMPONENT Etterna DESTINATION "${INSTALL_DIR}")
-install(DIRECTORY Themes                    COMPONENT Etterna DESTINATION "${INSTALL_DIR}")
+install(DIRECTORY Assets                    COMPONENT Etterna DESTINATION "${ASSET_DIR}")
+install(DIRECTORY BackgroundEffects         COMPONENT Etterna DESTINATION "${ASSET_DIR}")
+install(DIRECTORY BackgroundTransitions     COMPONENT Etterna DESTINATION "${ASSET_DIR}")
+install(DIRECTORY BGAnimations              COMPONENT Etterna DESTINATION "${ASSET_DIR}")
+install(DIRECTORY Data                      COMPONENT Etterna DESTINATION "${ASSET_DIR}")
+install(DIRECTORY NoteSkins                 COMPONENT Etterna DESTINATION "${ASSET_DIR}")
+install(DIRECTORY Scripts                   COMPONENT Etterna DESTINATION "${ASSET_DIR}")
+install(DIRECTORY Themes                    COMPONENT Etterna DESTINATION "${ASSET_DIR}")

--- a/src/Etterna/Globals/StepMania.cpp
+++ b/src/Etterna/Globals/StepMania.cpp
@@ -63,6 +63,9 @@
 #ifdef _WIN32
 #include <windows.h>
 int(WINAPIV* __vsnprintf)(char*, size_t, const char*, va_list) = _vsnprintf;
+#define PATH_SEPARATOR ";"
+#else
+#define PATH_SEPARATOR ":"
 #endif
 
 bool noWindow;
@@ -950,6 +953,17 @@ static LocalizedString COULDNT_OPEN_LOADING_WINDOW(
   "LoadingWindow",
   "Couldn't open any loading windows.");
 
+static void
+MountAdditionalDirs(const std::string& sDirList,
+		const std::string& sDelimiter,
+		const std::string& sMountPoint)
+{
+	std::vector<std::string> dirs;
+	split(sDirList, sDelimiter, dirs, true);
+	for (unsigned i = 0; i < dirs.size(); i++)
+		FILEMAN->Mount("dir", dirs[i], sMountPoint);
+}
+
 int
 sm_main(int argc, char* argv[])
 {
@@ -992,7 +1006,13 @@ sm_main(int argc, char* argv[])
 
 	// Almost everything uses this to read and write files.  Load this early.
 	FILEMAN = new RageFileManager(argv[0]);
-	FILEMAN->Mount("dir", Core::Platform::getAppDirectory(), "/");
+	const char* envRootDir = std::getenv("ETTERNA_ROOT_DIR");
+	std::string rootDir = (envRootDir && std::strlen(envRootDir) > 0)
+			? envRootDir : Core::Platform::getAppDirectory();
+	if (!FILEMAN->Mount("dir", rootDir, "/")) {
+		Locator::getLogger()->error("Failed to mount root directory: {}", rootDir);
+		return 1;
+	}
 
 	// load preferences and mount any alternative trees.
 	PREFSMAN = new PrefsManager;
@@ -1012,18 +1032,17 @@ sm_main(int argc, char* argv[])
 	WriteLogHeader();
 
 	// Set up alternative filesystem trees.
-	if (!PREFSMAN->m_sAdditionalFolders.Get().empty()) {
-		std::vector<std::string> dirs;
-		split(PREFSMAN->m_sAdditionalFolders, ",", dirs, true);
-		for (unsigned i = 0; i < dirs.size(); i++)
-			FILEMAN->Mount("dir", dirs[i], "/");
-	}
-	if (!PREFSMAN->m_sAdditionalSongFolders.Get().empty()) {
-		std::vector<std::string> dirs;
-		split(PREFSMAN->m_sAdditionalSongFolders, ",", dirs, true);
-		for (unsigned i = 0; i < dirs.size(); i++)
-			FILEMAN->Mount("dir", dirs[i], "/AdditionalSongs");
-	}
+	if (!PREFSMAN->m_sAdditionalFolders.Get().empty())
+		MountAdditionalDirs(PREFSMAN->m_sAdditionalFolders, ",", "/");
+	const char* envAdditionalFolders = std::getenv("ETTERNA_ADDITIONAL_ROOT_DIRS");
+	if (envAdditionalFolders && std::strlen(envAdditionalFolders) > 0)
+		MountAdditionalDirs(envAdditionalFolders, PATH_SEPARATOR, "/");
+
+	if (!PREFSMAN->m_sAdditionalSongFolders.Get().empty())
+		MountAdditionalDirs(PREFSMAN->m_sAdditionalSongFolders, ",", "/AdditionalSongs");
+	const char* envAdditionalSongFolders = std::getenv("ETTERNA_ADDITIONAL_SONG_DIRS");
+	if (envAdditionalSongFolders && std::strlen(envAdditionalSongFolders) > 0)
+		MountAdditionalDirs(envAdditionalSongFolders, PATH_SEPARATOR, "/AdditionalSongs");
 
 	/* One of the above filesystems might contain files that affect preferences
 	 * (e.g. Data/Static.ini). Re-read preferences. */


### PR DESCRIPTION
This PR is a first step towards addressing #651. It allows users (or package maintainers) to customize the Etterna virtual filesystem mounts using environment variables so that the game installation itself can remain immutable while any variable data is stored elsewhere. This is especially necessary for a NixOS release, as the Nix store is read-only.

More specifically, this PR does the following:
* Causes Etterna to check the env var `ETTERNA_ROOT_DIR` on startup. If present, its value is used for the path of the main mount; otherwise, the current behaviour is used, namely mounting the installation directory.
* Causes Etterna to check the env var `ETTERNA_ADDITIONAL_ROOT_DIRS` on startup. If present, it's parsed as a list of paths that are treated identically to the paths listed in the "AdditionalFolders" setting. The list delimiter is the OS-dependent path separator, namely `;` on Windows and `:` everywhere else.
* Causes Etterna to check the env var `ETTERNA_ADDITIONAL_SONG_DIRS` on startup. If present, it's parsed as a list of paths that are treated identically to the paths listed in the "AdditionalSongFolders" setting. As above, the separator is OS-dependent.
* Adds an `ASSET_DIR` CMake variable that can be configured to define where game assets should be installed. If absent, defaults to the current behaviour, namely to `INSTALL_DIR`. The purpose of this change is to allow assets to be separated from the rest of the game data so that they're easier to subsequently copy elsewhere. Could be useful for distribution on some Linux flavours.
* Makes `INSTALL_DIR` similarly configurable.
* Disables the CMake installation commands for crashpad binaries if Etterna is built without crashpad.

This last change comes up because the crashpad build task attempts to run built-in build tools (e.g. `extern/crashpad/buildtools/linux64/gn`) that fail to run on NixOS because of linking issues. Potentially, a more drastic refactoring of the build tools could fall back to the system installs of the build tools, but that wasn't a priority for me in this PR.

If these changes make it into release, the plan is to then PR [nixpkgs](https://github.com/NixOS/nixpkgs/) with an expression for Etterna. The idea is to wrap the Etterna binary so that the game's root mount is bound to `~/.local/share/etterna` in the user's home directory by environment variables, and then to add the game's immutable installation/asset directory as an additional mount.