### PR TITLE
Set any 0 bpm segments to the previous segment's bpm

### DIFF
--- a/src/Etterna/Models/NoteLoaders/NotesLoaderSM.cpp
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderSM.cpp
@@ -117,7 +117,7 @@ void
 SMSetBPMs(SMSongTagInfo& info)
 {
 	info.BPMChanges.clear();
-	info.loader->ParseBPMs(info.BPMChanges, (*info.params)[1], info.song->m_sSongFileName);
+	info.loader->ParseBPMs(info.BPMChanges, (*info.params)[1]);
 }
 void
 SMSetStops(SMSongTagInfo& info)
@@ -432,7 +432,6 @@ SMLoader::ProcessInstrumentTracks(Song& out, const std::string& sParam)
 void
 SMLoader::ParseBPMs(std::vector<pair<float, float>>& out,
 					const std::string& line,
-					const std::string& sPath,
 					const int rowsPerBeat)
 {
 	std::vector<std::string> arrayBPMChangeExpressions;
@@ -453,8 +452,8 @@ SMLoader::ParseBPMs(std::vector<pair<float, float>>& out,
 		const auto fBeat = RowToBeat(arrayBPMChangeValues[0], rowsPerBeat);
 		const auto fNewBPM = StringToFloat(arrayBPMChangeValues[1]);
 		if (fNewBPM == 0) {
-			Locator::getLogger()->error("Song file \"{}\" has a zero BPM. Ignored",
-										sPath);
+			Locator::getLogger()->error("Song file {} has a zero BPM. Ignored",
+										GetSongTitle());
 			continue;
 		}
 

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderSM.cpp
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderSM.cpp
@@ -452,8 +452,8 @@ SMLoader::ParseBPMs(std::vector<pair<float, float>>& out,
 		const auto fBeat = RowToBeat(arrayBPMChangeValues[0], rowsPerBeat);
 		const auto fNewBPM = StringToFloat(arrayBPMChangeValues[1]);
 		if (fNewBPM == 0) {
-//			LOG->UserLog(
-//			  "Song file", this->GetSongTitle(), "has a zero BPM; ignored.");
+			Locator::getLogger()->error("Song file {} has a zero BPM. Ignored",
+										GetSongTitle());
 			continue;
 		}
 

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderSM.cpp
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderSM.cpp
@@ -117,7 +117,7 @@ void
 SMSetBPMs(SMSongTagInfo& info)
 {
 	info.BPMChanges.clear();
-	info.loader->ParseBPMs(info.BPMChanges, (*info.params)[1]);
+	info.loader->ParseBPMs(info.BPMChanges, (*info.params)[1], info.song->m_sSongFileName);
 }
 void
 SMSetStops(SMSongTagInfo& info)
@@ -432,6 +432,7 @@ SMLoader::ProcessInstrumentTracks(Song& out, const std::string& sParam)
 void
 SMLoader::ParseBPMs(std::vector<pair<float, float>>& out,
 					const std::string& line,
+					const std::string& sPath,
 					const int rowsPerBeat)
 {
 	std::vector<std::string> arrayBPMChangeExpressions;
@@ -452,8 +453,8 @@ SMLoader::ParseBPMs(std::vector<pair<float, float>>& out,
 		const auto fBeat = RowToBeat(arrayBPMChangeValues[0], rowsPerBeat);
 		const auto fNewBPM = StringToFloat(arrayBPMChangeValues[1]);
 		if (fNewBPM == 0) {
-			Locator::getLogger()->error("Song file {} has a zero BPM. Ignored",
-										GetSongTitle());
+			Locator::getLogger()->error("Song file \"{}\" has a zero BPM. Ignored",
+										sPath);
 			continue;
 		}
 

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderSM.cpp
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderSM.cpp
@@ -452,8 +452,8 @@ SMLoader::ParseBPMs(std::vector<pair<float, float>>& out,
 		const auto fBeat = RowToBeat(arrayBPMChangeValues[0], rowsPerBeat);
 		const auto fNewBPM = StringToFloat(arrayBPMChangeValues[1]);
 		if (fNewBPM == 0) {
-			Locator::getLogger()->error("Song file {} has a zero BPM. Ignored",
-										GetSongTitle());
+			Locator::getLogger()->error("Song file \"{}\" has a zero BPM. Ignored",
+										this->GetChartPath());
 			continue;
 		}
 
@@ -1163,6 +1163,7 @@ SMLoader::LoadFromSimfile(const std::string& sPath, Song& out, bool bFromCache)
 
 	out.m_SongTiming.m_sFile = sPath;
 	out.m_sSongFileName = sPath;
+	this->chartPath = sPath;
 
 	SMSongTagInfo reused_song_info(&*this, &out, sPath);
 

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderSM.h
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderSM.h
@@ -83,9 +83,11 @@ struct SMLoader
 	 * @brief Parse BPM Changes data from a string.
 	 * @param out the vector to put the data in.
 	 * @param line the string in question.
+	 * @param sPath a const reference to the path of the song.
 	 * @param rowsPerBeat the number of rows per beat for this purpose. */
 	void ParseBPMs(std::vector<std::pair<float, float>>& out,
 				   const std::string& line,
+				   const std::string& sPath,
 				   const int rowsPerBeat = -1);
 	/**
 	 * @brief Process the BPM Segments from the string.

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderSM.h
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderSM.h
@@ -83,11 +83,9 @@ struct SMLoader
 	 * @brief Parse BPM Changes data from a string.
 	 * @param out the vector to put the data in.
 	 * @param line the string in question.
-	 * @param sPath a const reference to the path of the song.
 	 * @param rowsPerBeat the number of rows per beat for this purpose. */
 	void ParseBPMs(std::vector<std::pair<float, float>>& out,
 				   const std::string& line,
-				   const std::string& sPath,
 				   const int rowsPerBeat = -1);
 	/**
 	 * @brief Process the BPM Segments from the string.

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderSM.h
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderSM.h
@@ -223,6 +223,11 @@ struct SMLoader
 	 * @return the file extension. */
 	std::string GetFileExtension() const { return fileExt; }
 
+	/**
+	* @brief Get the chart path.
+	* @return the chart path. */
+	std::string GetChartPath() const { return chartPath; }
+
   public:
 	// SetSongTitle and GetSongTitle changed to public to allow the functions
 	// used by the parser helper to access them. -Kyz
@@ -241,6 +246,8 @@ struct SMLoader
 	const std::string fileExt;
 	/** @brief The song title that is being processed. */
 	std::string songTitle;
+	/** @brief The path of the chart that is being processed. */
+	std::string chartPath;
 };
 
 #endif

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderSMA.cpp
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderSMA.cpp
@@ -350,7 +350,7 @@ SMALoader::LoadFromSimfile(const std::string& sPath, Song& out, bool bFromCache)
 
 		else if (sValueName == "BPMS") {
 			vBPMChanges.clear();
-			ParseBPMs(vBPMChanges, sParams[1], sPath, iRowsPerBeat);
+			ParseBPMs(vBPMChanges, sParams[1], iRowsPerBeat);
 		}
 
 		else if (sValueName == "STOPS" || sValueName == "FREEZES") {

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderSMA.cpp
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderSMA.cpp
@@ -350,7 +350,7 @@ SMALoader::LoadFromSimfile(const std::string& sPath, Song& out, bool bFromCache)
 
 		else if (sValueName == "BPMS") {
 			vBPMChanges.clear();
-			ParseBPMs(vBPMChanges, sParams[1], iRowsPerBeat);
+			ParseBPMs(vBPMChanges, sParams[1], sPath, iRowsPerBeat);
 		}
 
 		else if (sValueName == "STOPS" || sValueName == "FREEZES") {


### PR DESCRIPTION
When I loaded a chart with bpms 170 -> 0 -> 170 in 0.70, the chart was treated as having a constant 170 bpm. To avoid timestamps going to infinity, we can treat 0 bpm segments as having the same bpm as the previous segment. Charts with `bpms.size > 1` will always have a previous segment to draw from.

Closes #946 