### PR TITLE
Fix Crashpad Building for CI Linux Target

### DIFF
--- a/extern/crashpad/crashpad/third_party/mini_chromium/mini_chromium/base/logging.h
+++ b/extern/crashpad/crashpad/third_party/mini_chromium/mini_chromium/base/logging.h
@@ -5,6 +5,7 @@
 #ifndef MINI_CHROMIUM_BASE_LOGGING_H_
 #define MINI_CHROMIUM_BASE_LOGGING_H_
 
+#include <stdint.h>
 #include <assert.h>
 #include <errno.h>
 

--- a/extern/crashpad/crashpad/third_party/mini_chromium/mini_chromium/base/strings/utf_string_conversion_utils.h
+++ b/extern/crashpad/crashpad/third_party/mini_chromium/mini_chromium/base/strings/utf_string_conversion_utils.h
@@ -6,6 +6,7 @@
 #define MINI_CHROMIUM_BASE_STRINGS_UTF_STRING_CONVERSION_UTILS_H_
 
 #include <string>
+#include <stdint.h>
 
 namespace base {
 


### PR DESCRIPTION
For some reason, a dependency of crashpad seems to be just ...
 missing a <stdint.h> include in an obvious way.
I don't know how it ever worked before, but this fixes it now :)