### PR TITLE
Fix duplicate log suppression pr :)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .vscode
 .vs
 .idea
+.kdev4
+*.kdev4
 /[Bb]uild
 
 # Ignore executables (Linux, macOS, Windows)

--- a/src/Core/Misc/PlogLogger.cpp
+++ b/src/Core/Misc/PlogLogger.cpp
@@ -87,7 +87,7 @@ PlogLogger::PlogLogger() {
 
 void PlogLogger::log(Core::ILogger::Severity logLevel, const std::string_view message) {
     const std::lock_guard<std::mutex> lock(this->mutex);
-    if (this->last_msg.empty()) {
+    if (!this->last_msg.empty()) {
         if (message == this->last_msg) {
             this->count++;
         } else {

--- a/src/Core/Misc/PlogLogger.cpp
+++ b/src/Core/Misc/PlogLogger.cpp
@@ -7,7 +7,6 @@
 
 #ifdef _WIN32
 #include <cstdio>
-#include <cstring>
 
 namespace plog {
 

--- a/src/Core/Misc/PlogLogger.cpp
+++ b/src/Core/Misc/PlogLogger.cpp
@@ -7,6 +7,8 @@
 
 #ifdef _WIN32
 #include <cstdio>
+#include <cstring>
+
 namespace plog {
 
     /**
@@ -84,7 +86,19 @@ PlogLogger::PlogLogger() {
 }
 
 void PlogLogger::log(Core::ILogger::Severity logLevel, const std::string_view message) {
-    PLOG(PlogLogger::convertSeverity(logLevel)) << message;
+    if (this->last_msg != NULL) {
+        if (message == *this->last_msg) {
+            this->count++;
+        } else {
+            PLOG(PlogLogger::convertSeverity(logLevel)) << *this->last_msg << (this->count > 0? fmt::format(FMT_STRING(" (x{})"), std::to_string(this->count + 1)) : "");
+            
+            delete this->last_msg;
+            this->last_msg = new std::string{message};
+            this->count = 0;
+        }
+    } else {
+        this->last_msg = new std::string{message};
+    }
 }
 
 void PlogLogger::setLogLevel(Core::ILogger::Severity logLevel) {

--- a/src/Core/Misc/PlogLogger.cpp
+++ b/src/Core/Misc/PlogLogger.cpp
@@ -85,6 +85,10 @@ PlogLogger::PlogLogger() {
 }
 
 void PlogLogger::log(Core::ILogger::Severity logLevel, const std::string_view message) {
+	/* Note: If multiple PlogLogger objects exist in the same thread, this last-message log suppression
+	 * will persist across calls to log between different instances. This may or may not be desired,
+	 * if this hypothetical scenario ever happens, consider :)
+	 */
 	static thread_local std::string last_message = "";
 	static thread_local Core::ILogger::Severity last_log_level;
 	static thread_local unsigned num_occurrences = 0;

--- a/src/Core/Misc/PlogLogger.cpp
+++ b/src/Core/Misc/PlogLogger.cpp
@@ -86,20 +86,19 @@ PlogLogger::PlogLogger() {
 }
 
 void PlogLogger::log(Core::ILogger::Severity logLevel, const std::string_view message) {
-    this->mutex.lock();
-    if (this->last_msg != "") {
+    const std::lock_guard<std::mutex> lock(this->mutex);
+    if (this->last_msg.empty()) {
         if (message == this->last_msg) {
             this->count++;
         } else {
             PLOG(PlogLogger::convertSeverity(logLevel)) << this->last_msg << (this->count > 0? fmt::format(FMT_STRING(" (x{})"), std::to_string(this->count + 1)) : "");
-            
+
             this->last_msg = std::string{message};
             this->count = 0;
         }
     } else {
         this->last_msg = std::string{message};
     }
-    this->mutex.unlock();
 }
 
 void PlogLogger::setLogLevel(Core::ILogger::Severity logLevel) {

--- a/src/Core/Misc/PlogLogger.cpp
+++ b/src/Core/Misc/PlogLogger.cpp
@@ -86,19 +86,20 @@ PlogLogger::PlogLogger() {
 }
 
 void PlogLogger::log(Core::ILogger::Severity logLevel, const std::string_view message) {
-    if (this->last_msg != NULL) {
-        if (message == *this->last_msg) {
+    this->mutex.lock();
+    if (this->last_msg != "") {
+        if (message == this->last_msg) {
             this->count++;
         } else {
-            PLOG(PlogLogger::convertSeverity(logLevel)) << *this->last_msg << (this->count > 0? fmt::format(FMT_STRING(" (x{})"), std::to_string(this->count + 1)) : "");
+            PLOG(PlogLogger::convertSeverity(logLevel)) << this->last_msg << (this->count > 0? fmt::format(FMT_STRING(" (x{})"), std::to_string(this->count + 1)) : "");
             
-            delete this->last_msg;
-            this->last_msg = new std::string{message};
+            this->last_msg = std::string{message};
             this->count = 0;
         }
     } else {
-        this->last_msg = new std::string{message};
+        this->last_msg = std::string{message};
     }
+    this->mutex.unlock();
 }
 
 void PlogLogger::setLogLevel(Core::ILogger::Severity logLevel) {

--- a/src/Core/Misc/PlogLogger.hpp
+++ b/src/Core/Misc/PlogLogger.hpp
@@ -4,6 +4,8 @@
 #include "Core/Services/ILogger.hpp"
 #include <plog/Log.h>
 
+#include <mutex>
+
 class PlogLogger : public Core::ILogger {
 public:
     int count = 0;
@@ -12,7 +14,7 @@ public:
 
     PlogLogger();
     void setLogLevel(ILogger::Severity logLevel) override;
-	std::string getLogFile() override;    
+	std::string getLogFile() override;
 protected:
     void log(ILogger::Severity logLevel, const std::string_view message) override;
 private:

--- a/src/Core/Misc/PlogLogger.hpp
+++ b/src/Core/Misc/PlogLogger.hpp
@@ -6,8 +6,9 @@
 
 class PlogLogger : public Core::ILogger {
 public:
-    std::string* last_msg = NULL;
     int count = 0;
+    std::string last_msg;
+    std::mutex mutex;
 
     PlogLogger();
     void setLogLevel(ILogger::Severity logLevel) override;

--- a/src/Core/Misc/PlogLogger.hpp
+++ b/src/Core/Misc/PlogLogger.hpp
@@ -4,15 +4,8 @@
 #include "Core/Services/ILogger.hpp"
 #include <plog/Log.h>
 
-#include <mutex>
-
 class PlogLogger : public Core::ILogger {
 public:
-    int count = 0;
-    Core::ILogger::Severity last_severity;
-    std::string last_msg;
-    std::mutex mutex;
-
     PlogLogger();
     void setLogLevel(ILogger::Severity logLevel) override;
 	std::string getLogFile() override;

--- a/src/Core/Misc/PlogLogger.hpp
+++ b/src/Core/Misc/PlogLogger.hpp
@@ -6,9 +6,12 @@
 
 class PlogLogger : public Core::ILogger {
 public:
+    std::string* last_msg = NULL;
+    int count = 0;
+
     PlogLogger();
     void setLogLevel(ILogger::Severity logLevel) override;
-	std::string getLogFile() override;
+	std::string getLogFile() override;    
 protected:
     void log(ILogger::Severity logLevel, const std::string_view message) override;
 private:

--- a/src/Core/Misc/PlogLogger.hpp
+++ b/src/Core/Misc/PlogLogger.hpp
@@ -9,6 +9,7 @@
 class PlogLogger : public Core::ILogger {
 public:
     int count = 0;
+    Core::ILogger::Severity last_severity;
     std::string last_msg;
     std::mutex mutex;
 

--- a/src/RageUtil/File/RageFile.h
+++ b/src/RageUtil/File/RageFile.h
@@ -3,6 +3,8 @@
 #ifndef RAGE_FILE_H
 #define RAGE_FILE_H
 
+#include <cstdint>
+
 #include "RageFileBasic.h"
 
 struct lua_State;


### PR DESCRIPTION
Should fix problems of #1304 

Note -- in order to prevent acquiring a global mutex between multiple threads, I exploit the fact that a spammed log message would happen on the same thread, letting us use thread_local variables instead.