### PR TITLE
Automatically create a build of Etterna compatible with OSX High Sierra

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -312,7 +312,7 @@ jobs:
           path: tools
 
       - name: Install homebrew packages
-        run: brew install cmake nasm ninja && brew tap bluebandit21/etterna && brew update && HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install bluebandit21/etterna/openssl@1.1_osx_high_sierra
+        run: brew install cmake nasm ninja && brew tap etternagame/etterna && brew update && HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install etternagame/etterna/openssl@1.1_osx_high_sierra
 
       - name: Generate CMake
         run: mkdir main/build && cd main/build && cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1_osx_high_sierra -DWITH_CRASHPAD=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -G Ninja ..

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -286,7 +286,93 @@ jobs:
         if: ${{ matrix.cfg.dist && github.event_name == 'release' && github.event.action == 'published' }}
         with:
           files: ${{github.workspace}}/main/build/*.dmg
+  macos_high_sierra:
+    name: mac OSX High Sierra (Legacy) ${{matrix.cfg.name}}
+    runs-on: ${{matrix.cfg.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        cfg:
+          #- { os: macos-10.15,  name: "Catalina", dist: false} # rendered useless by GHA
+          - { os: macos-13,     name: "Ventura", dist: false}
+          - { os: macos-12,     name: "Monterey", dist: true}
+          #- { os: macos-11,     name: "Big Sur",  dist: true}
 
+    steps:
+
+      - name: Checkout Etterna
+        uses: actions/checkout@v3
+        with:
+          path: main
+
+      - name: Checkout CrashpadTools
+        uses: actions/checkout@v3
+        with:
+          repository: etternagame/CrashpadTools
+          path: tools
+
+      - name: Install homebrew packages
+        run: brew install cmake nasm ninja && brew tap bluebandit21/etterna && brew update && HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew install bluebandit21/etterna/openssl@1.1_osx_high_sierra
+
+      - name: Generate CMake
+        run: mkdir main/build && cd main/build && cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1_osx_high_sierra -DWITH_CRASHPAD=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo -G Ninja ..
+
+      - name: Build Project
+        run: cd main/build && ninja
+
+      - name: Generate binary
+        if: ${{matrix.cfg.dist}}
+        run: cd main/build && cpack
+
+      - name: Upload Binary
+        if: ${{matrix.cfg.dist}}
+        uses: actions/upload-artifact@v3
+        with:
+          name: "Etterna - OSX High Sierra (Legacy)"
+          path: '${{github.workspace}}/main/build/*.dmg'
+
+      - name: Update Environment Variables
+        if: ${{matrix.cfg.dist}}
+        run: |
+          echo "${{github.workspace}}/tools/mac" >> $GITHUB_PATH
+          echo "ETTERNA_ARCH=x64" >> $GITHUB_ENV
+
+      - name: Generate Symbols
+        if: ${{matrix.cfg.dist}}
+        run: |
+          echo "Running dsymutil..."
+          dsymutil -o ${{github.workspace}}/main/Etterna.dsym main/Etterna.app/Contents/MacOS/Etterna > /dev/null
+          echo "Dumping Symbols..."
+          dump_syms ${{github.workspace}}/main/Etterna.dsym main/Etterna.app/Contents/MacOS/Etterna > ${{github.workspace}}/main/Etterna.sym
+          echo "Stripping debug symbols from binary..."
+          strip main/Etterna.app/Contents/MacOS/Etterna
+
+      - name: Prepare symbols for upload artifacts
+        if: ${{matrix.cfg.dist}}
+        run: cd main && ${{github.workspace}}/main/.ci/prepare_symbols.py
+
+      - name: Upload Symbols to action artifacts
+        if: ${{matrix.cfg.dist}}
+        uses: actions/upload-artifact@v3
+        with:
+          name: Etterna Symbols - ${{github.sha}}
+          path: '${{github.workspace}}/main/EtternaSymbolsUploadDir'
+
+      - name: Get version for CrashServer Upload
+        id: get_version
+        if: ${{ matrix.cfg.dist && github.event_name == 'release' && github.event.action == 'published' }}
+        run: |
+          echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+
+      - name: Upload Symbols to Crash Server
+        if: ${{ matrix.cfg.dist && github.event_name == 'release' && github.event.action == 'published' }}
+        run: symupload ${{github.workspace}}/main/Etterna.sym "https://crash.etterna.dev/api/symbol/upload?api_key=${{secrets.CRASHSERVER_API_KEY}}&version=${{ steps.get_version.outputs.VERSION }}"
+
+      - name: Upload files to Release
+        uses: softprops/action-gh-release@v1
+        if: ${{ matrix.cfg.dist && github.event_name == 'release' && github.event.action == 'published' }}
+        with:
+          files: ${{github.workspace}}/main/build/*.dmg
   windows: # Windows x64 and x86 build matrix
     strategy:
       fail-fast: false # Don't cancel other matrix jobs if one fails


### PR DESCRIPTION
Hopefully,
Closes: #1186 

-- I haven't been able to find anyone willing to help verify my fix, unfortunately (I pinged like all six people that have been known to ever encounter this problem).
That said, I checked the disassembly of the generated binary and it looks good?
-- `___chkstk_darwin` is definitely not present :D