### PR TITLE
Build docs: openssl-static -> openssl-devel on Fedora

### DIFF
--- a/Docs/Building.md
+++ b/Docs/Building.md
@@ -60,7 +60,7 @@ While most dependencies for macOS and Windows are included in the repo, there ar
 For Pop_OS!, install the `Debian` dependencies, then refer to the [Pop_OS! Notes](#pop_os-notes) section below.
 
 - Debian: `apt install build-essential libssl-dev libx11-dev libxrandr-dev libcurl4-openssl-dev libglu1-mesa-dev libpulse-dev libogg-dev libasound-dev libjack-dev`
-- Fedora: `dnf install openssl-static libX11-devel libcurl-devel mesa-libGLU-devel libXrandr-devel libogg-devel pulseaudio-libs-devel alsa-lib-devel jack-audio-connection-kit-devel`
+- Fedora: `dnf install openssl-devel libX11-devel libcurl-devel mesa-libGLU-devel libXrandr-devel libogg-devel pulseaudio-libs-devel alsa-lib-devel jack-audio-connection-kit-devel`
 - Arch: `pacman -S openssl libx11 libxrandr curl mesa glu libogg pulseaudio jack`
 - Alpine: `apk add build-base openssl-dev libx11-dev libxrandr-dev curl-dev mesa-dev glu-dev pulseaudio-dev libogg-dev alsa-lib-dev jack-dev`
 


### PR DESCRIPTION
`openssl-static` doesn't exist anymore. The new name is `openssl-devel` now https://packages.fedoraproject.org/pkgs/openssl/openssl-devel/