### PR TITLE
Fix ForceOffAfterUse not disabling debug menu input

### DIFF
--- a/src/Etterna/Screen/Others/ScreenDebugOverlay.cpp
+++ b/src/Etterna/Screen/Others/ScreenDebugOverlay.cpp
@@ -548,8 +548,10 @@ ScreenDebugOverlay::Input(const InputEventPlus& input)
 			(*p)->DoAndLog(sMessage);
 			if (!sMessage.empty())
 				Locator::getLogger()->info("DEBUG: {}", sMessage.c_str());
-			if ((*p)->ForceOffAfterUse())
+			if ((*p)->ForceOffAfterUse()){
+				g_bIsDisplayed = false;
 				m_bForcedHidden = true;
+			}
 
 			// update text to show the effect of what changed above
 			UpdateText();
@@ -1587,6 +1589,7 @@ class DebugLineChartFolder: public IDebugLine
 			auto d = s->GetSongDir();
 			auto b = SONGMAN->WasLoadedFromAdditionalSongs(s);
 			auto p = FILEMAN->ResolveSongFolder(d, b);
+			g_bIsDisplayed = false;
 
 			return Core::Platform::openFolder(p);
 		}

--- a/src/Etterna/Screen/Others/ScreenDebugOverlay.cpp
+++ b/src/Etterna/Screen/Others/ScreenDebugOverlay.cpp
@@ -1589,7 +1589,6 @@ class DebugLineChartFolder: public IDebugLine
 			auto d = s->GetSongDir();
 			auto b = SONGMAN->WasLoadedFromAdditionalSongs(s);
 			auto p = FILEMAN->ResolveSongFolder(d, b);
-			g_bIsDisplayed = false;
 
 			return Core::Platform::openFolder(p);
 		}


### PR DESCRIPTION
ForceOffAfterUse used to keep the debug menu listening to input while visually closing it. Now it doesn't do that.

However, there's still a problem where after exiting out of the debug menu with it the next F3 input gets eaten, requiring two F3 inputs to open the menu again.  I tried fixing this tonight but wasn't able to. Up to you whether it's fine to merge it like this or if that should be figured out first