### PR TITLE
Prevent FFMPEG build warning from causing compilation error

### DIFF
--- a/CMake/Helpers/SetupFFMPEG.cmake
+++ b/CMake/Helpers/SetupFFMPEG.cmake
@@ -44,7 +44,7 @@ if(APPLE)
   endif()
 endif()
 list(APPEND FFMPEG_CONFIGURE "--enable-gpl")
-list(APPEND FFMPEG_CONFIGURE "--extra-cflags=-mmacosx-version-min=10.8 -w")
+list(APPEND FFMPEG_CONFIGURE "--extra-cflags=-mmacosx-version-min=10.8 -w -Wno-error=incompatible-function-pointer-types")
 
 list(APPEND FFMPEG_BUILD_LIBS
 "${FFMPEG_BIN}/libavformat/libavformat.a"


### PR DESCRIPTION
The specific error was
```
/Users/runner/work/etterna/etterna/main/build/ffmpeg_dl/ffmpeg-2.1.3-src/libavcodec/flvenc.c:96:23: error: incompatible function pointer types initializing 'int (*)(AVCodecContext *, AVPacket *, const AVFrame *, int *)' (aka 'int (*)(struct AVCodecContext *, struct AVPacket *, const struct AVFrame *, int *)') with an expression of type 'int (AVCodecContext *, AVPacket *, AVFrame *, int *)' (aka 'int (struct AVCodecContext *, struct AVPacket *, struct AVFrame *, int *)') [-Wincompatible-function-pointer-types]
    .encode2        = ff_MPV_encode_picture,
                      ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
make: *** [libavcodec/flvenc.o] Error 1
```

when trying to build for aarch64 on the Sonoma Github M1 runner

I believe this ffmpeg warning was likely fixed a long, long time
 ago; we're running an ancient version right now.