### PR TITLE
Default WITH_CRASHPAD to OFF instead of ON in CMake

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -39,7 +39,7 @@ jobs:
         run: sudo apt update && sudo apt install ${{ matrix.cfg.cpp-version }} nasm ninja-build libglew-dev libxrandr-dev libxtst-dev libpulse-dev libasound-dev libogg-dev libvorbis-dev xorg-dev libcurl4-openssl-dev
 
       - name: Generate CMake
-        run: mkdir main/build && cd main/build && cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+        run: mkdir main/build && cd main/build && cmake -G Ninja -DWITH_CRASHPAD=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
         env:
           CXX: ${{matrix.cfg.cpp-version}}
 
@@ -228,7 +228,7 @@ jobs:
           python-version: '3.8'
 
       - name: Generate CMake
-        run: mkdir main/build && cd main/build && cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCMAKE_BUILD_TYPE=RelWithDebInfo -G Ninja ..
+        run: mkdir main/build && cd main/build && cmake -DWITH_CRASHPAD=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCMAKE_BUILD_TYPE=RelWithDebInfo -G Ninja ..
 
       - name: Build Project
         run: cd main/build && ninja
@@ -438,7 +438,7 @@ jobs:
           arch: ${{ matrix.cfg.arch }}
 
       - name: Generate CMake
-        run: mkdir main/build && cd main/build && cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
+        run: mkdir main/build && cd main/build && cmake -G Ninja -DWITH_CRASHPAD=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo ..
         env:
           DXSDK_DIR: "${{github.workspace}}/dxsdk/"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)                    # Enable folders
 add_executable(Etterna)
 
 # Project Compile Options
-set(WITH_CRASHPAD TRUE CACHE BOOL "Compile with Crash Handler (Requires depot_tools installed)")
+set(WITH_CRASHPAD OFF CACHE BOOL "Compile with Crash Handler (Requires depot_tools installed) ((Most likely only useful if you're building for distribution))")
 
 ## Setting Target Properties
 ### Set a different name for each output binary depending on what build configuration is.

--- a/Docs/Building.md
+++ b/Docs/Building.md
@@ -119,7 +119,9 @@ mkdir build && cd build
 
 Etterna has game resources in the root of the project, so the output binary is either placed in the root of the project *(Unix)* or in the `Program` folder in the project root *(Windows)*.
 
-To generate project files, you will only need to specify the `GENERATOR`. The `ARCHITECTURE` will assume 64bit if left undefined. If any trouble occurs with OpenSSL, the most likely answer will be to define where you have it installed through the `SSL_DIRECTORY` variable. If depot_tools is left uninstalled or misconfigured, you may be able to run `cmake` but the game will not compile. To get around this, build without Crashpad: Specify `-DWITH_CRASHPAD=OFF` in the `cmake` command.
+To generate project files, you will only need to specify the `GENERATOR`. The `ARCHITECTURE` will assume 64bit if left undefined. If any trouble occurs with OpenSSL, the most likely answer will be to define where you have it installed through the `SSL_DIRECTORY` variable.
+
+If you wish to build with Crashpad enabled (extremely unlikely to be useful unless you are planning on distributing your build to multiple people), specify `-DWITH_CRASHPAD=ON` in the `cmake` command. Note that this will cause compilation to fail unless you have a correct installation of Google's depot_tools in your path.
 
 - `SSL_DIRECTORY`: The root directory of your OpenSSL install. It may be required on macOS depending on the OpenSSL version which comes with your system _(thought we recommend getting the latest version from homebrew)_.
 - `GENERATOR`: The generator you are choosing to use. Supported generators are listed below.
@@ -129,10 +131,10 @@ To generate project files, you will only need to specify the `GENERATOR`. The `A
 cmake -DOPENSSL_ROOT_DIR="SSL_DIRECTORY" -G "GENERATOR" -A "ARCHITECTURE"  ..
 ```
 
-Or to build without Crashpad:
+Or to build with Crashpad:
 
 ```bash
-cmake -DOPENSSL_ROOT_DIR="SSL_DIRECTORY" -DWITH_CRASHPAD=OFF -G "GENERATOR" -A "ARCHITECTURE"  ..
+cmake -DOPENSSL_ROOT_DIR="SSL_DIRECTORY" -DWITH_CRASHPAD=ON -G "GENERATOR" -A "ARCHITECTURE"  ..
 ```
 
 We actively support the following CMake generators
@@ -147,7 +149,7 @@ For the `OPENSSL_ROOT_DIR` parameter, set the directory for where ever the opens
 - Linux: This parameter is not necessary on linux. (CMake can find it on it's own)
 - Windows: CMake writes files to find the version of OpenSSL linked above. If that version is installed, it should not be necessary to specify this variable (unless you have OpenSSL installed in a non-standard location, in which case, you should set OPENSSL_ROOT_DIR to that location)
 
-Users building without Crashpad may choose to add the `-DWITH_CRASHPAD=OFF` option at the beginning of the command.
+Users wanting to build with Crashpad may choose to add the `-DWITH_CRASHPAD=ON` option at the beginning of the command.
 
 Users of Linux be aware that the game builds on the `Debug` target by default. Here are better alternatives:
 


### PR DESCRIPTION
Crashpad is only really useful in the context where multiple
 people are using the same build and remote debugging is
 desirable, i.e. distribution builds.

For people building locally on their own machine, Crashpad is
 extremely unlikely to be helpful, and creating the environment
 where crashpad can actually be used involves the horror of
 Google's depot_tools and such...

It seems more reasonable to make users explicitly opt *into*
 crashpad, rather than having to opt out, especially when the
 error message produced when trying to build with the past
 default settings was more likely to get users to try to
 install Crashpad to fix the problem rather than simply
 disabling it.