### PR TITLE
til death & bare frames - don't send you to the top of the pack when cancelling/exiting song search

### DIFF
--- a/src/Etterna/Actor/Menus/MusicWheel.cpp
+++ b/src/Etterna/Actor/Menus/MusicWheel.cpp
@@ -203,7 +203,7 @@ MusicWheel::ReloadSongList(bool searching, const std::string& findme)
 		RebuildWheelItems();
 		SelectSection(m_sExpandedSectionName);
 		SetOpenSection(m_sExpandedSectionName);
-		ChangeMusic(1);
+		SelectSongOrCourse();
 		SCREENMAN->PostMessageToTopScreen(SM_SongChanged, 0.35F);
 		return;
 	}


### PR DESCRIPTION
this was driving me up the wall. exactly as the title implies, this makes cancelling song search keep you on the song you were on and not send you back up to the first song in the pack

intended for til death, but bare-frames seems to also use this function, as it's also affected by the change
rebirth already had this feature, the change doesn't appear to cause any conflicts with it