### PR TITLE
Add grade counter and nothing as new tip types for Rebirth's footer

### DIFF
--- a/Themes/Rebirth/BGAnimations/footer.lua
+++ b/Themes/Rebirth/BGAnimations/footer.lua
@@ -63,7 +63,7 @@ t[#t+1] = LoadFont("Common Normal") .. {
     end
 }
 
-t[#t+1] = LoadFont("Common Normal") .. {
+quoteortip = LoadFont("Common Normal") .. {
     Name = "QuoteOrTip",
     InitCommand = function(self)
         self:halign(0)
@@ -74,5 +74,45 @@ t[#t+1] = LoadFont("Common Normal") .. {
         registerActorToColorConfigElement(self, "main", "PrimaryText")
     end
 }
+
+gradecounter = LoadFont("Common Normal") .. {
+    Name = "GradeCounter",
+    InitCommand = function(self)
+        local aaaaa = WHEELDATA:GetTotalClearsByGrade("Grade_Tier01")
+        local aaaa = WHEELDATA:GetTotalClearsByGrade("Grade_Tier02") + WHEELDATA:GetTotalClearsByGrade("Grade_Tier03") + WHEELDATA:GetTotalClearsByGrade("Grade_Tier04")
+        local aaa = WHEELDATA:GetTotalClearsByGrade("Grade_Tier05") + WHEELDATA:GetTotalClearsByGrade("Grade_Tier06") + WHEELDATA:GetTotalClearsByGrade("Grade_Tier07")
+        local aa = WHEELDATA:GetTotalClearsByGrade("Grade_Tier08") + WHEELDATA:GetTotalClearsByGrade("Grade_Tier09") + WHEELDATA:GetTotalClearsByGrade("Grade_Tier10")
+        local a = WHEELDATA:GetTotalClearsByGrade("Grade_Tier11") + WHEELDATA:GetTotalClearsByGrade("Grade_Tier12") + WHEELDATA:GetTotalClearsByGrade("Grade_Tier13")
+        self:xy(actuals.Width * allowedPercentageForQuote / 2, -actuals.Height / 2)
+        self:zoom(textSize)
+        self:maxwidth(actuals.Width * allowedPercentageForQuote / textSize - textZoomFudge)
+        self:settextf("%d %s   %d %s   %d %s   %d %s   %d %s",
+        aaaaa, getGradeStrings("Grade_Tier01"),
+        aaaa, getGradeStrings("Grade_Tier04"),
+        aaa, getGradeStrings("Grade_Tier07"),
+        aa, getGradeStrings("Grade_Tier10"),
+        a, getGradeStrings("Grade_Tier13"))
+        registerActorToColorConfigElement(self, "main", "PrimaryText")
+        -- uh
+        local yea = 0
+        function attributive(when, gren) --
+            yea = yea + when
+            self:AddAttribute(yea, {Length = #getGradeStrings(gren), Diffuse = colorByGrade(gren)})
+        end
+        attributive(#tostring(aaaaa) + 1, "Grade_Tier01")
+        attributive(3 + #getGradeStrings("Grade_Tier01") + #tostring(aaaa) + 1, "Grade_Tier04")
+        attributive(3 + #getGradeStrings("Grade_Tier04") + #tostring(aaa) + 1, "Grade_Tier07")
+        attributive(3 + #getGradeStrings("Grade_Tier07") + #tostring(aa) + 1, "Grade_Tier10")
+        attributive(3 + #getGradeStrings("Grade_Tier10") + #tostring(a) + 1, "Grade_Tier13")
+    end,
+}
+
+tiptype = themeConfig:get_data().global.TipType
+
+if tiptype == 3 then
+    t[#t+1] = gradecounter
+elseif tiptype == 1 or tiptype == 2 then
+    t[#t+1] = quoteortip
+end
 
 return t

--- a/Themes/Rebirth/BGAnimations/playerInfoFrame/settings.lua
+++ b/Themes/Rebirth/BGAnimations/playerInfoFrame/settings.lua
@@ -6197,9 +6197,48 @@ local function rightFrame()
                 DisplayName = translations["TipType"],
                 Type = "SingleChoice",
                 Explanation = translations["TipTypeExplanation"],
-                Choices = choiceSkeleton("Tips", "Quotes"),
-                Directions = optionDataToggleDirectionsFUNC("tipType", 1, 2),
-                ChoiceIndexGetter = optionDataToggleIndexGetterFUNC("tipType", 1),
+                Choices = {
+                    {
+                        Name = "Tips",
+                        DisplayName = "Tips",
+                        ChosenFunction = function()
+                            optionData["tipType"].set(1)
+                        end
+                    },
+                    {
+                        Name = "Quotes",
+                        DisplayName = "Quotes",
+                        ChosenFunction = function()
+                            optionData["tipType"].set(2)
+                        end
+                    },
+                    {
+                        Name = "GradeCounter",
+                        DisplayName = "Grade Counter",
+                        ChosenFunction = function()
+                            optionData["tipType"].set(3)
+                        end
+                    },
+                    {
+                        Name = "Nothing",
+                        DisplayName = "Nothing",
+                        ChosenFunction = function()
+                            optionData["tipType"].set(4)
+                        end
+                    }
+                },
+                ChoiceIndexGetter = function(self)
+                    v = optionData["tipType"].get()
+                    if v == 1 then
+                        return 1
+                    elseif v == 2 then
+                        return 2
+                    elseif v == 3 then
+                        return 3
+                    else
+                        return 4
+                    end
+                end,
             },
             {
                 Name = "Set BG Fit Mode",

--- a/Themes/Rebirth/Scripts/01 theme_config.lua
+++ b/Themes/Rebirth/Scripts/01 theme_config.lua
@@ -1,6 +1,6 @@
 local defaultConfig = {
     global = {
-        TipType = 1, -- 1 = tips, 2 = quotes ...
+        TipType = 1, -- 1 = tips, 2 = quotes, 3 = grade counter, 4 = nothing ...
         ShowVisualizer = true,
         FallbackToAverageColorBG = true, -- wheel bg only
         StaticBackgrounds = false,

--- a/Themes/Rebirth/Scripts/02 ThemePrefs.lua
+++ b/Themes/Rebirth/Scripts/02 ThemePrefs.lua
@@ -782,7 +782,8 @@ function TipType()
         Choices = {
             THEME:GetString("OptionNames", "Off"),
             THEME:GetString("OptionNames", "Tips"),
-            THEME:GetString("OptionNames", "RandomPhrases")
+            THEME:GetString("OptionNames", "RandomPhrases"),
+            THEME:GetString("OptionNames", "GradeCounter")
         },
         LoadSelections = function(self, list, pn)
             local pref = themeConfig:get_data().global.TipType
@@ -790,8 +791,10 @@ function TipType()
                 list[1] = true
             elseif pref == 2 then
                 list[2] = true
-            else
+            elseif pref == 3 then
                 list[3] = true
+            else -- default to nothing
+                list[4] = true
             end
         end,
         SaveSelections = function(self, list, pn)
@@ -800,8 +803,10 @@ function TipType()
                 value = 1
             elseif list[2] == true then
                 value = 2
-            else
+            elseif list[3] == true then
                 value = 3
+            else -- default to nothing
+                value = 4
             end
             themeConfig:get_data().global.TipType = value
             themeConfig:set_dirty()


### PR DESCRIPTION
I'm unsure about the colorbygrade function possibly not working as intended and setting a default color instead of one defined in another color config preset, as I've noticed other places use ColorConfigChangedMessageCommand to redraw elements that are registered as color config actors.
Also, about ThemePrefs.lua -- it seems like that's for the main menu options, which aren't shown on Rebirth at all... And the strings that it pulled on lines 783 to 785 only seemed to be defined on Til' Death's en.ini, so I opted not to mess with that without a double-check first.

Both new options should work as intended through the cog menu, but it should be noted that all 5 grades show up regardless if a score with those grades was set or not.