### PR TITLE
Replace unweildy COMPILE_ASSERT macro with static_assert

### DIFF
--- a/src/Etterna/Globals/global.h
+++ b/src/Etterna/Globals/global.h
@@ -130,32 +130,6 @@ ShowWarningOrTrace(const char* file,
 #define SM_UNIQUE_NAME2(x, line) SM_UNIQUE_NAME3(x, line)
 #define SM_UNIQUE_NAME(x) SM_UNIQUE_NAME2(x, __LINE__)
 
-template<bool>
-struct CompileAssert;
-template<>
-struct CompileAssert<true>
-{
-};
-template<int>
-struct CompileAssertDecl
-{
-};
-
-// Ignore "unused-local-typedef" warnings for COMPILE_ASSERT
-#if defined(__clang__)
-#define COMPILE_ASSERT_PRE                                                     \
-	_Pragma("clang diagnostic push")                                           \
-	  _Pragma("clang diagnostic ignored \"-Wunused-local-typedef\"")
-#define COMPILE_ASSERT_POST _Pragma("clang diagnostic pop")
-#else
-#define COMPILE_ASSERT_PRE
-#define COMPILE_ASSERT_POST
-#endif
-#define COMPILE_ASSERT(COND)                                                   \
-	COMPILE_ASSERT_PRE                                                         \
-	typedef CompileAssertDecl<sizeof(CompileAssert<!!(COND)>)>                 \
-	  CompileAssertInst COMPILE_ASSERT_POST
-
 #include "RageUtil/Misc/RageException.h"
 /* Don't include our own headers here, since they tend to change often. */
 

--- a/src/Etterna/Models/Misc/EnumHelper.h
+++ b/src/Etterna/Models/Misc/EnumHelper.h
@@ -47,7 +47,7 @@ EnumToString(int iVal,
                                                                                \
 	const std::string& X##ToString(X x);                                       \
                                                                                \
-	COMPILE_ASSERT(NUM_##X == ARRAYLEN(X##Names));                             \
+static_assert(NUM_##X == ARRAYLEN(X##Names), "Size mismatch between "#X" enum and "#X"Names (Did you forget to add a string for a new enum entry?)");                              \
                                                                                \
 	const std::string& X##ToString(X x)                                        \
                                                                                \

--- a/src/Etterna/Models/Misc/Game.cpp
+++ b/src/Etterna/Models/Misc/Game.cpp
@@ -1,4 +1,4 @@
-﻿#include "Etterna/Globals/global.h"
+#include "Etterna/Globals/global.h"
 #include "Game.h"
 
 TapNoteScore
@@ -38,7 +38,7 @@ static const Game::PerButtonInfo g_CommonButtonInfo[] = {
 const Game::PerButtonInfo*
 Game::GetPerButtonInfo(GameButton gb) const
 {
-	COMPILE_ASSERT(GAME_BUTTON_NEXT == ARRAYLEN(g_CommonButtonInfo));
+	static_assert(GAME_BUTTON_NEXT == ARRAYLEN(g_CommonButtonInfo));
 	if (gb < GAME_BUTTON_NEXT)
 		return &g_CommonButtonInfo[gb];
 

--- a/src/Etterna/Singletons/InputMapper.cpp
+++ b/src/Etterna/Singletons/InputMapper.cpp
@@ -1270,7 +1270,7 @@ static const InputScheme::GameButtonInfo g_CommonGameButtonInfo[] = {
 const InputScheme::GameButtonInfo*
 InputScheme::GetGameButtonInfo(GameButton gb) const
 {
-	COMPILE_ASSERT(GAME_BUTTON_NEXT == ARRAYLEN(g_CommonGameButtonInfo));
+	static_assert(GAME_BUTTON_NEXT == ARRAYLEN(g_CommonGameButtonInfo));
 	if (gb < GAME_BUTTON_NEXT)
 		return &g_CommonGameButtonInfo[gb];
 

--- a/src/arch/MovieTexture/MovieTexture_Generic.cpp
+++ b/src/arch/MovieTexture/MovieTexture_Generic.cpp
@@ -498,7 +498,7 @@ MovieTexture_Generic::UpdateFrame()
 static EffectMode EffectModes[] = {
 	EffectMode_YUYV422,
 };
-COMPILE_ASSERT(ARRAYLEN(EffectModes) == NUM_PixelFormatYCbCr);
+static_assert(ARRAYLEN(EffectModes) == NUM_PixelFormatYCbCr);
 
 EffectMode
 MovieTexture_Generic::GetEffectMode(MovieDecoderPixelFormatYCbCr fmt)


### PR DESCRIPTION
When this codebase was originally written, there wasn't a built-in
 cross-compiler way to add compile-time asserts, so the original
 authors did something clever by forcing the compile-time
 instantiation of a undefined template class if a precondition was
 not met.

However, this produces a wall of insane template errors all wrapped
 within macro expansions that is completely unintelligible if you
 haven't seen it before.

Since C++11 we have static_assert for the same purpose, and can
 produce nice diagnostic strings as an added bonus :)