### PR TITLE
Initialize depot_tools before using it to avoid CI error, upgrade GHA Windows runner for same reason

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -397,7 +397,7 @@ jobs:
         - { name: x64,  arch: x64,  ssl-dir: 'C:\Program Files\OpenSSL-Win64'}
 
     name: "Windows ${{matrix.cfg.name}}"
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Checkout Etterna
         uses: actions/checkout@v3

--- a/extern/crashpad/CMakeLists.txt
+++ b/extern/crashpad/CMakeLists.txt
@@ -55,6 +55,7 @@ FetchContent_GetProperties(depot_tools SOURCE_DIR DEPOT_TOOLS_DIR)
 list(APPEND CMAKE_PROGRAM_PATH ${DEPOT_TOOLS_DIR})
 find_program(EXE_DEPOT_GN gn)
 find_program(EXE_DEPOT_NINJA ninja)
+find_program(EXE_DEPOT_UPDATE_DEPOT_TOOLS update_depot_tools)
 
 # Crashpad source and build folders
 set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/crashpad)
@@ -129,6 +130,7 @@ ExternalProject_Add_Step(crashpad_init gn_configure
 	ALWAYS 1
 	USES_TERMINAL 1
 	WORKING_DIRECTORY ${SOURCE_DIR}
+	COMMAND ${EXE_DEPOT_UPDATE_DEPOT_TOOLS}
 	COMMAND ${EXE_DEPOT_GN} gen ${BINARY_DIR} "--args=target_cpu=\"${GN_TARGET_CPU}\" is_debug=${GN_IS_DEBUG} extra_cflags=\"${GN_WIN_LINK_FLAG}\"" && ${EXE_DEPOT_NINJA} -C ${BINARY_DIR} crashpad_handler
 	BYPRODUCTS ${OUTPUT_LIBS})
 

--- a/extern/crashpad/CMakeLists.txt
+++ b/extern/crashpad/CMakeLists.txt
@@ -56,6 +56,7 @@ list(APPEND CMAKE_PROGRAM_PATH ${DEPOT_TOOLS_DIR})
 find_program(EXE_DEPOT_GN gn)
 find_program(EXE_DEPOT_NINJA ninja)
 find_program(EXE_DEPOT_UPDATE_DEPOT_TOOLS update_depot_tools)
+find_program(EXE_DEPOT_GIT git) # TODO: I'm not sure this grabs the "right" version of git; investigate here if shennanigans arise.
 
 # Crashpad source and build folders
 set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/crashpad)
@@ -130,6 +131,7 @@ ExternalProject_Add_Step(crashpad_init gn_configure
 	ALWAYS 1
 	USES_TERMINAL 1
 	WORKING_DIRECTORY ${SOURCE_DIR}
+	COMMAND ${EXE_DEPOT_GIT} config --global depot-tools.allowGlobalGitConfig true
 	COMMAND ${EXE_DEPOT_UPDATE_DEPOT_TOOLS}
 	COMMAND ${EXE_DEPOT_GN} gen ${BINARY_DIR} "--args=target_cpu=\"${GN_TARGET_CPU}\" is_debug=${GN_IS_DEBUG} extra_cflags=\"${GN_WIN_LINK_FLAG}\"" && ${EXE_DEPOT_NINJA} -C ${BINARY_DIR} crashpad_handler
 	BYPRODUCTS ${OUTPUT_LIBS})


### PR DESCRIPTION
Before this change, the CI was failing with the message
```
python3_bin_reldir.txt not found. need to initialize depot_tools by
running gclient, update_depot_tools or ensure_bootstrap.
```
in the crashpad_init gn_configure phase.

This commit simply runs `update_depot_tools` before running gn,
also including the necessary CMAKE change to locate the binary

It also upgrades the Windows GHA runner from Windows-2019 to Windows-2022, as without this change update_depot_tools fails in a strange way in the midst of running a Visual Studio 2019 command.