### PR TITLE
Fix CI build for 32-bit Windows and add debug logging for Chocolatey

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -437,7 +437,7 @@ jobs:
       
       - name: Install openSSL (i386)
         if: ${{ matrix.cfg.arch == 'x86' }}
-        run: choco install openssl --version=3.5.0 -y --x86 
+        run: msiexec /i https://slproweb.com/download/Win32OpenSSL-3_5_0.msi /quiet
 
       - name: Install chocolatey packages (x64)
         if: ${{ matrix.cfg.arch == 'x64' }}

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -437,7 +437,7 @@ jobs:
       
       - name: Install openSSL (i386)
         if: ${{ matrix.cfg.arch == 'x86' }}
-        run: choco install openssl --version=3.5.0 -y --x86
+        run: choco install openssl --version=3.5.0 -y --x86 
 
       - name: Install chocolatey packages (x64)
         if: ${{ matrix.cfg.arch == 'x64' }}
@@ -446,6 +446,10 @@ jobs:
       - name: Install openSSL (x64)
         if: ${{ matrix.cfg.arch == 'x64' }}
         run: choco install openssl --version=3.5.0 -y
+      
+      - name: Print Install Failures (if present)
+        if: ${{ failure() }}
+        run: type C:\ProgramData\chocolatey\logs\chocolatey.log && exit 1 #TODO: Also print Python install logs, more?
 
       - name: Configure MSBuild
         uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
Chocolatey's 32-bit openssl 3.5 package seems to be straight-up broken, so this commit replaces the chocolatey command with simply running the openssl installer provided by [Shining Light Productions](https://slproweb.com/products/Win32OpenSSL.html), who is officially endorsed by the main OpenSSL project.

This PR additionally adds in a build step to the GHA script that prints out Chocolatey's build log _if_ the install step fails to aid debugging, as I found trying to troubleshoot Chocolatey's failures on the runner without this information nearly impossible.