### PR TITLE
Diet Unlock System

### DIFF
--- a/Themes/Rebirth/Scripts/10 WheelDataManager.lua
+++ b/Themes/Rebirth/Scripts/10 WheelDataManager.lua
@@ -1882,8 +1882,16 @@ function WHEELDATA.SetAllSongs(self)
     self.AllSongs = {}
     self.AllSongsByGroup = {}
     self.AllGroups = {}
+
+    local selectable = function(song)
+        if not song:IsSelectable() then
+            return song:GetHighestGrade() ~= "Grade_Invalid"
+        end
+
+        return true
+    end
     for _, song in ipairs(SONGMAN:GetAllSongs()) do
-        if #song:GetChartsOfCurrentGameMode() > 0 and song:IsSelectable() then
+        if #song:GetChartsOfCurrentGameMode() > 0 and selectable(song) then
             self.AllSongs[#self.AllSongs+1] = song
             local group = song:GetGroupName()
             if self.AllSongsByGroup[group] == nil then

--- a/Themes/Rebirth/Scripts/10 WheelDataManager.lua
+++ b/Themes/Rebirth/Scripts/10 WheelDataManager.lua
@@ -1883,7 +1883,7 @@ function WHEELDATA.SetAllSongs(self)
     self.AllSongsByGroup = {}
     self.AllGroups = {}
     for _, song in ipairs(SONGMAN:GetAllSongs()) do
-        if #song:GetChartsOfCurrentGameMode() > 0 then
+        if #song:GetChartsOfCurrentGameMode() > 0 and song:IsSelectable() then
             self.AllSongs[#self.AllSongs+1] = song
             local group = song:GetGroupName()
             if self.AllSongsByGroup[group] == nil then

--- a/src/Etterna/Actor/Base/ActorFrame.cpp
+++ b/src/Etterna/Actor/Base/ActorFrame.cpp
@@ -818,6 +818,19 @@ class LunaActorFrame : public Luna<ActorFrame>
 		p->SetLightDirection(vTmp);
 		COMMON_RETURN_SELF;
 	}
+	static int AddChild(T* p, lua_State* L)
+	{
+		auto* pActor = Luna<Actor>::check(L, 1);
+		if (pActor == nullptr)
+		{
+			lua_pushnil(L);
+			return 1;
+		}
+		p->AddChild(pActor);
+		pActor->SetParent(p);
+		pActor->PushSelf(L);
+		return 1;
+	}
 	static int AddChildFromPath(T* p, lua_State* L)
 	{
 		// this one is tricky, we need to get an Actor from Lua.
@@ -872,6 +885,7 @@ class LunaActorFrame : public Luna<ActorFrame>
 		ADD_METHOD(SetDiffuseLightColor);
 		ADD_METHOD(SetSpecularLightColor);
 		ADD_METHOD(SetLightDirection);
+		ADD_METHOD(AddChild);
 		ADD_METHOD(AddChildFromPath);
 		ADD_METHOD(RemoveChild);
 		ADD_METHOD(RemoveAllChildren);

--- a/src/Etterna/Models/Misc/GameConstantsAndTypes.cpp
+++ b/src/Etterna/Models/Misc/GameConstantsAndTypes.cpp
@@ -433,7 +433,6 @@ LuaXType(FailType);
 static const char* SelectionDisplayNames[] = {
 	"Never",
 	"Always",
-	"Overwritten"
 };
 XToString(SelectionDisplay);
 StringToX(SelectionDisplay);

--- a/src/Etterna/Models/Misc/GameConstantsAndTypes.cpp
+++ b/src/Etterna/Models/Misc/GameConstantsAndTypes.cpp
@@ -429,3 +429,12 @@ XToString(FailType);
 XToLocalizedString(FailType);
 StringToX(FailType);
 LuaXType(FailType);
+
+static const char* SelectionDisplayNames[] = {
+	"Never",
+	"Always",
+	"Overwritten"
+};
+XToString(SelectionDisplay);
+StringToX(SelectionDisplay);
+LuaXType(SelectionDisplay);

--- a/src/Etterna/Models/Misc/GameConstantsAndTypes.h
+++ b/src/Etterna/Models/Misc/GameConstantsAndTypes.h
@@ -565,6 +565,8 @@ enum SelectionDisplay
 
 auto
 SelectionDisplayToString(SelectionDisplay sd) -> const std::string&;
+auto
+StringToSelectionDisplay(const std::string&) -> SelectionDisplay;
 LuaDeclareType(SelectionDisplay);
 
 #endif

--- a/src/Etterna/Models/Misc/GameConstantsAndTypes.h
+++ b/src/Etterna/Models/Misc/GameConstantsAndTypes.h
@@ -553,4 +553,17 @@ auto
 FailTypeToLocalizedString(FailType cat) -> const std::string&;
 LuaDeclareType(FailType);
 
+// SelectionDisplay is essentially what determines whether a file is visible or not.
+enum SelectionDisplay
+{
+	SelectionDisplay_Never, // SelectionDisplay_Never just means that the file will not be shown ever unless certain circumstances happen.
+	SelectionDisplay_Always, // SelectionDisplay_Always means that the file will be shown on the menu.
+	SelectionDisplay_Overwritten, // SelectionDisplay_Overwritten represents if a file is forcefully shown, used as a value to know that's happening.
+	NUM_SelectionDisplay
+};
+
+auto
+SelectionDisplayToString(SelectionDisplay sd) -> const std::string&;
+LuaDeclareType(SelectionDisplay);
+
 #endif

--- a/src/Etterna/Models/Misc/GameConstantsAndTypes.h
+++ b/src/Etterna/Models/Misc/GameConstantsAndTypes.h
@@ -558,8 +558,9 @@ enum SelectionDisplay
 {
 	SelectionDisplay_Never, // SelectionDisplay_Never just means that the file will not be shown ever unless certain circumstances happen.
 	SelectionDisplay_Always, // SelectionDisplay_Always means that the file will be shown on the menu.
-	SelectionDisplay_Overwritten, // SelectionDisplay_Overwritten represents if a file is forcefully shown, used as a value to know that's happening.
-	NUM_SelectionDisplay
+
+	NUM_SelectionDisplay,
+	SelectionDisplay_Invalid
 };
 
 auto

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderSM.cpp
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderSM.cpp
@@ -176,23 +176,23 @@ void
 SMSetSelectable(SMSongTagInfo& info)
 {
 	if (EqualsNoCase((*info.params)[1], "YES")) {
-		info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS;
+		info.song->m_SelectionDisplay = info.song->SelectionDisplay_Always;
 	} else if (EqualsNoCase((*info.params)[1], "NO")) {
-		info.song->m_SelectionDisplay = info.song->SHOW_NEVER;
+		info.song->m_SelectionDisplay = info.song->SelectionDisplay_Never;
 	}
 	// ROULETTE from 3.9. It was removed since UnlockManager can serve
 	// the same purpose somehow. This, of course, assumes you're using
 	// unlocks. -aj
 	else if (EqualsNoCase((*info.params)[1], "ROULETTE")) {
-		info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS;
+		info.song->m_SelectionDisplay = info.song->SelectionDisplay_Always;
 	}
 	/* The following two cases are just fixes to make sure simfiles that
 	 * used 3.9+ features are not excluded here */
 	else if (EqualsNoCase((*info.params)[1], "ES") ||
 			 EqualsNoCase((*info.params)[1], "OMES")) {
-		info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS;
+		info.song->m_SelectionDisplay = info.song->SelectionDisplay_Always;
 	} else if (StringToInt((*info.params)[1]) > 0) {
-		info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS;
+		info.song->m_SelectionDisplay = info.song->SelectionDisplay_Always;
 	} else {
 //		LOG->UserLog("Song file",
 //					 info.path,

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderSM.cpp
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderSM.cpp
@@ -176,23 +176,23 @@ void
 SMSetSelectable(SMSongTagInfo& info)
 {
 	if (EqualsNoCase((*info.params)[1], "YES")) {
-		info.song->m_SelectionDisplay = info.song->SelectionDisplay_Always;
+		info.song->m_SelectionDisplay = SelectionDisplay_Always;
 	} else if (EqualsNoCase((*info.params)[1], "NO")) {
-		info.song->m_SelectionDisplay = info.song->SelectionDisplay_Never;
+		info.song->m_SelectionDisplay = SelectionDisplay_Never;
 	}
 	// ROULETTE from 3.9. It was removed since UnlockManager can serve
 	// the same purpose somehow. This, of course, assumes you're using
 	// unlocks. -aj
 	else if (EqualsNoCase((*info.params)[1], "ROULETTE")) {
-		info.song->m_SelectionDisplay = info.song->SelectionDisplay_Always;
+		info.song->m_SelectionDisplay = SelectionDisplay_Always;
 	}
 	/* The following two cases are just fixes to make sure simfiles that
 	 * used 3.9+ features are not excluded here */
 	else if (EqualsNoCase((*info.params)[1], "ES") ||
 			 EqualsNoCase((*info.params)[1], "OMES")) {
-		info.song->m_SelectionDisplay = info.song->SelectionDisplay_Always;
+		info.song->m_SelectionDisplay = SelectionDisplay_Always;
 	} else if (StringToInt((*info.params)[1]) > 0) {
-		info.song->m_SelectionDisplay = info.song->SelectionDisplay_Always;
+		info.song->m_SelectionDisplay = SelectionDisplay_Always;
 	} else {
 //		LOG->UserLog("Song file",
 //					 info.path,

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderSMA.cpp
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderSMA.cpp
@@ -303,21 +303,21 @@ SMALoader::LoadFromSimfile(const std::string& sPath, Song& out, bool bFromCache)
 
 		else if (sValueName == "SELECTABLE") {
 			if (EqualsNoCase(sParams[1], "YES"))
-				out.m_SelectionDisplay = out.SelectionDisplay_Always;
+				out.m_SelectionDisplay = SelectionDisplay_Always;
 			else if (EqualsNoCase(sParams[1], "NO"))
-				out.m_SelectionDisplay = out.SelectionDisplay_Never;
+				out.m_SelectionDisplay = SelectionDisplay_Never;
 			// ROULETTE from 3.9. It was removed since UnlockManager can serve
 			// the same purpose somehow. This, of course, assumes you're using
 			// unlocks. -aj
 			else if (EqualsNoCase(sParams[1], "ROULETTE"))
-				out.m_SelectionDisplay = out.SelectionDisplay_Always;
+				out.m_SelectionDisplay = SelectionDisplay_Always;
 			/* The following two cases are just fixes to make sure simfiles that
 			 * used 3.9+ features are not excluded here */
 			else if (EqualsNoCase(sParams[1], "ES") ||
 					 EqualsNoCase(sParams[1], "OMES"))
-				out.m_SelectionDisplay = out.SelectionDisplay_Always;
+				out.m_SelectionDisplay = SelectionDisplay_Always;
 			else if (StringToInt(sParams[1]) > 0)
-				out.m_SelectionDisplay = out.SelectionDisplay_Always;
+				out.m_SelectionDisplay = SelectionDisplay_Always;
 			else {
                 //				LOG->UserLog(
 //				  "Song file",

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderSMA.cpp
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderSMA.cpp
@@ -303,21 +303,21 @@ SMALoader::LoadFromSimfile(const std::string& sPath, Song& out, bool bFromCache)
 
 		else if (sValueName == "SELECTABLE") {
 			if (EqualsNoCase(sParams[1], "YES"))
-				out.m_SelectionDisplay = out.SHOW_ALWAYS;
+				out.m_SelectionDisplay = out.SelectionDisplay_Always;
 			else if (EqualsNoCase(sParams[1], "NO"))
-				out.m_SelectionDisplay = out.SHOW_NEVER;
+				out.m_SelectionDisplay = out.SelectionDisplay_Never;
 			// ROULETTE from 3.9. It was removed since UnlockManager can serve
 			// the same purpose somehow. This, of course, assumes you're using
 			// unlocks. -aj
 			else if (EqualsNoCase(sParams[1], "ROULETTE"))
-				out.m_SelectionDisplay = out.SHOW_ALWAYS;
+				out.m_SelectionDisplay = out.SelectionDisplay_Always;
 			/* The following two cases are just fixes to make sure simfiles that
 			 * used 3.9+ features are not excluded here */
 			else if (EqualsNoCase(sParams[1], "ES") ||
 					 EqualsNoCase(sParams[1], "OMES"))
-				out.m_SelectionDisplay = out.SHOW_ALWAYS;
+				out.m_SelectionDisplay = out.SelectionDisplay_Always;
 			else if (StringToInt(sParams[1]) > 0)
-				out.m_SelectionDisplay = out.SHOW_ALWAYS;
+				out.m_SelectionDisplay = out.SelectionDisplay_Always;
 			else {
                 //				LOG->UserLog(
 //				  "Song file",

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderSSC.cpp
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderSSC.cpp
@@ -170,21 +170,21 @@ void
 SetSelectable(SSC::SongTagInfo& info)
 {
 	if (EqualsNoCase((*info.params)[1], "YES")) {
-		info.song->m_SelectionDisplay = info.song->SelectionDisplay_Always;
+		info.song->m_SelectionDisplay = SelectionDisplay_Always;
 	} else if (EqualsNoCase((*info.params)[1], "NO")) {
-		info.song->m_SelectionDisplay = info.song->SelectionDisplay_Never;
+		info.song->m_SelectionDisplay = SelectionDisplay_Never;
 	}
 	// ROULETTE from 3.9 is no longer in use.
 	else if (EqualsNoCase((*info.params)[1], "ROULETTE")) {
-		info.song->m_SelectionDisplay = info.song->SelectionDisplay_Always;
+		info.song->m_SelectionDisplay = SelectionDisplay_Always;
 	}
 	/* The following two cases are just fixes to make sure simfiles that
 	 * used 3.9+ features are not excluded here */
 	else if (EqualsNoCase((*info.params)[1], "ES") ||
 			 EqualsNoCase((*info.params)[1], "OMES")) {
-		info.song->m_SelectionDisplay = info.song->SelectionDisplay_Always;
+		info.song->m_SelectionDisplay = SelectionDisplay_Always;
 	} else if (StringToInt((*info.params)[1]) > 0) {
-		info.song->m_SelectionDisplay = info.song->SelectionDisplay_Always;
+		info.song->m_SelectionDisplay = SelectionDisplay_Always;
 	} else {
 //		LOG->UserLog("Song file",
 //					 info.path,

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderSSC.cpp
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderSSC.cpp
@@ -170,21 +170,21 @@ void
 SetSelectable(SSC::SongTagInfo& info)
 {
 	if (EqualsNoCase((*info.params)[1], "YES")) {
-		info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS;
+		info.song->m_SelectionDisplay = info.song->SelectionDisplay_Always;
 	} else if (EqualsNoCase((*info.params)[1], "NO")) {
-		info.song->m_SelectionDisplay = info.song->SHOW_NEVER;
+		info.song->m_SelectionDisplay = info.song->SelectionDisplay_Never;
 	}
 	// ROULETTE from 3.9 is no longer in use.
 	else if (EqualsNoCase((*info.params)[1], "ROULETTE")) {
-		info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS;
+		info.song->m_SelectionDisplay = info.song->SelectionDisplay_Always;
 	}
 	/* The following two cases are just fixes to make sure simfiles that
 	 * used 3.9+ features are not excluded here */
 	else if (EqualsNoCase((*info.params)[1], "ES") ||
 			 EqualsNoCase((*info.params)[1], "OMES")) {
-		info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS;
+		info.song->m_SelectionDisplay = info.song->SelectionDisplay_Always;
 	} else if (StringToInt((*info.params)[1]) > 0) {
-		info.song->m_SelectionDisplay = info.song->SHOW_ALWAYS;
+		info.song->m_SelectionDisplay = info.song->SelectionDisplay_Always;
 	} else {
 //		LOG->UserLog("Song file",
 //					 info.path,

--- a/src/Etterna/Models/NoteWriters/NotesWriterETT.cpp
+++ b/src/Etterna/Models/NoteWriters/NotesWriterETT.cpp
@@ -274,10 +274,10 @@ WriteGlobalTags(RageFile& f, const Song& out)
 			  0,
 			  "An invalid selectable value was found for this song!"); // fall
 																	   // through
-		case Song::SHOW_ALWAYS:
+		case SelectionDisplay::SelectionDisplay_Always:
 			f.Write("YES");
 			break;
-		case Song::SHOW_NEVER:
+		case SelectionDisplay::SelectionDisplay_Never:
 			f.Write("NO");
 			break;
 	}

--- a/src/Etterna/Models/NoteWriters/NotesWriterSM.cpp
+++ b/src/Etterna/Models/NoteWriters/NotesWriterSM.cpp
@@ -55,10 +55,10 @@ WriteGlobalTags(RageFile& f, Song& out)
 		default:
 			FAIL_M(ssprintf("Invalid selection display: %i",
 							out.m_SelectionDisplay));
-		case Song::SHOW_ALWAYS:
+		case SelectionDisplay::SelectionDisplay_Always:
 			f.Write("YES");
 			break;
-		case Song::SHOW_NEVER:
+		case SelectionDisplay::SelectionDisplay_Never:
 			f.Write("NO");
 			break;
 	}

--- a/src/Etterna/Models/NoteWriters/NotesWriterSSC.cpp
+++ b/src/Etterna/Models/NoteWriters/NotesWriterSSC.cpp
@@ -284,10 +284,10 @@ WriteGlobalTags(RageFile& f, const Song& out)
 			  0,
 			  "An invalid selectable value was found for this song!"); // fall
 																	   // through
-		case Song::SHOW_ALWAYS:
+		case SelectionDisplay::SelectionDisplay_Always:
 			f.Write("YES");
 			break;
-		case Song::SHOW_NEVER:
+		case SelectionDisplay::SelectionDisplay_Never:
 			f.Write("NO");
 			break;
 	}

--- a/src/Etterna/Models/Songs/Song.cpp
+++ b/src/Etterna/Models/Songs/Song.cpp
@@ -2528,6 +2528,18 @@ class LunaSong : public Luna<Song>
 		lua_pushboolean(L, SONGMAN->OpenSongFolder(p));
 		return 1;
 	}
+	static int IsSelectable(T* p, lua_State* L)
+	{
+		lua_pushboolean(L, p->GetSelectionDisplay() == SelectionDisplay_Always);
+		return 1;
+	}
+	static int SetSelectable(T* p, lua_State* L)
+	{
+		auto arg1 = BArg(1);
+		p->SetSelectionDisplay(arg1? SelectionDisplay_Always : SelectionDisplay_Never);
+		return 1;
+	}
+
 	LunaSong()
 	{
 		ADD_METHOD(GetDisplayFullTitle);
@@ -2600,6 +2612,8 @@ class LunaSong : public Luna<Song>
 		ADD_METHOD(GetDateTimeAdded);
 		ADD_METHOD(GetDateAdded);
 		ADD_METHOD(OpenSongFolder);
+		ADD_METHOD(IsSelectable);
+		ADD_METHOD(SetSelectable);
 	}
 };
 

--- a/src/Etterna/Models/Songs/Song.cpp
+++ b/src/Etterna/Models/Songs/Song.cpp
@@ -75,7 +75,7 @@ Song::Song()
 	firstSecond = -1;
 	lastSecond = -1;
 	specifiedLastSecond = -1;
-	m_SelectionDisplay = SHOW_ALWAYS;
+	m_SelectionDisplay = SelectionDisplay_Always;
 	m_bEnabled = true;
 	m_DisplayBPMType = DISPLAY_BPM_ACTUAL;
 	m_fSpecifiedBPMMin = 0;
@@ -104,6 +104,12 @@ Song::~Song()
 
 	// It's the responsibility of the owner of this Song to make sure
 	// that all pointers to this Song and its Steps are invalidated.
+}
+
+void
+Song::SetSelectionDisplay(SelectionDisplay sd)
+{
+	this->m_SelectionDisplay = sd;
 }
 
 void

--- a/src/Etterna/Models/Songs/Song.h
+++ b/src/Etterna/Models/Songs/Song.h
@@ -7,6 +7,7 @@
 #include "Etterna/Models/StepsAndStyles/Steps.h"
 #include "Etterna/Models/Misc/TimingData.h"
 #include "Etterna/Models/Misc/DateTime.h"
+#include "Etterna/Models/Misc/GameConstantsAndTypes.h"
 
 #include <set>
 
@@ -70,12 +71,13 @@ class Song
 	auto GetSongDir() -> const std::string& { return m_sSongDir; }
 
 	/** @brief When should this song be displayed in the music wheel? */
-	enum SelectionDisplay
+	SelectionDisplay m_SelectionDisplay;
+
+	void SetSelectionDisplay(SelectionDisplay sd);
+	[[nodiscard]] auto GetSelectionDisplay()
 	{
-		SHOW_ALWAYS, /**< always show on the wheel. */
-		SHOW_NEVER	 /**< never show on the wheel (unless song hiding is turned
-						off). */
-	} m_SelectionDisplay;
+		return m_SelectionDisplay;
+	}
 
 	Song();
 	~Song();

--- a/src/Etterna/Models/Songs/Song.h
+++ b/src/Etterna/Models/Songs/Song.h
@@ -74,7 +74,7 @@ class Song
 	SelectionDisplay m_SelectionDisplay;
 
 	void SetSelectionDisplay(SelectionDisplay sd);
-	[[nodiscard]] auto GetSelectionDisplay()
+	[[nodiscard]] auto GetSelectionDisplay() const -> SelectionDisplay
 	{
 		return m_SelectionDisplay;
 	}

--- a/src/Etterna/Models/Songs/SongCacheIndex.cpp
+++ b/src/Etterna/Models/Songs/SongCacheIndex.cpp
@@ -411,10 +411,10 @@ SongCacheIndex::CacheSong(Song& song, const std::string& dir) const
 				ASSERT_M(0,
 						 "An invalid selectable value was found for this "
 						 "song!"); // fall through
-			case Song::SHOW_ALWAYS:
+			case SelectionDisplay::SelectionDisplay_Always:
 				insertSong.bind(index++, 0);
 				break;
-			case Song::SHOW_NEVER:
+			case SelectionDisplay::SelectionDisplay_Never:
 				insertSong.bind(index++, 1);
 				break;
 		}
@@ -1050,9 +1050,9 @@ SongCacheIndex::SongFromStatement(Song* song, SQLite::Statement& query) const
 
 		auto selection = static_cast<int>(query.getColumn(index++));
 		if (selection == 0)
-			song->m_SelectionDisplay = song->SHOW_ALWAYS;
+			song->m_SelectionDisplay = song->SelectionDisplay_Always;
 		else
-			song->m_SelectionDisplay = song->SHOW_NEVER;
+			song->m_SelectionDisplay = song->SelectionDisplay_Never;
 
 		auto bpmminIndex = index++;
 		auto bpmmaxIndex = index++;

--- a/src/Etterna/Models/Songs/SongCacheIndex.cpp
+++ b/src/Etterna/Models/Songs/SongCacheIndex.cpp
@@ -1050,9 +1050,9 @@ SongCacheIndex::SongFromStatement(Song* song, SQLite::Statement& query) const
 
 		auto selection = static_cast<int>(query.getColumn(index++));
 		if (selection == 0)
-			song->m_SelectionDisplay = song->SelectionDisplay_Always;
+			song->m_SelectionDisplay = SelectionDisplay_Always;
 		else
-			song->m_SelectionDisplay = song->SelectionDisplay_Never;
+			song->m_SelectionDisplay = SelectionDisplay_Never;
 
 		auto bpmminIndex = index++;
 		auto bpmmaxIndex = index++;

--- a/src/Etterna/Models/Songs/SongUtil.cpp
+++ b/src/Etterna/Models/Songs/SongUtil.cpp
@@ -64,6 +64,14 @@ SongUtil::GetSteps(const Song* pSong,
 		if (uHash != 0 && uHash != pSteps->GetHash())
 			continue;
 
+		if (PROFILEMAN != nullptr && pSong->GetSelectionDisplay() == SelectionDisplay_Never)
+		{
+			auto* p = PROFILEMAN->GetProfile(PLAYER_1);
+
+			if (p->GetBestGrade(pSong, st) == Grade_Invalid)
+				continue;
+		}
+
 		if (filteringSteps && FILTERMAN != nullptr && FILTERMAN->AnyActiveFilter()) {
 			// iterating over all rates until it just works
 			// explanation in MusicWheel::FilterBySkillsets

--- a/src/Etterna/Singletons/SongManager.cpp
+++ b/src/Etterna/Singletons/SongManager.cpp
@@ -1292,22 +1292,16 @@ auto
 SongManager::GetSongs(const std::string& sGroupName) const
   -> const std::vector<Song*>&
 {
-	std::vector<Song*> vtmp;
+	static const std::vector<Song*> vEmpty;
+
 	if (sGroupName == GROUP_ALL) {
 		return m_pSongs;
 	}
 	auto iter = m_mapSongGroupIndex.find(sGroupName);
 	if (iter != m_mapSongGroupIndex.end()) {
-		vtmp = iter->second;
+		return iter->second;
 	}
-
-	vtmp.erase(
-		std::remove_if(vtmp.begin(), vtmp.end(), [](Song* s) { return s->GetSelectionDisplay() != SelectionDisplay_Always; }),
-		vtmp.end()
-	);
-
-	static const std::vector<Song*> vret = vtmp;
-	return vret;
+	return vEmpty;
 }
 void
 SongManager::ForceReloadSongGroup(const std::string& sGroupName) const

--- a/src/Etterna/Singletons/SongManager.cpp
+++ b/src/Etterna/Singletons/SongManager.cpp
@@ -1292,16 +1292,22 @@ auto
 SongManager::GetSongs(const std::string& sGroupName) const
   -> const std::vector<Song*>&
 {
-	static const std::vector<Song*> vEmpty;
-
+	std::vector<Song*> vtmp;
 	if (sGroupName == GROUP_ALL) {
 		return m_pSongs;
 	}
 	auto iter = m_mapSongGroupIndex.find(sGroupName);
 	if (iter != m_mapSongGroupIndex.end()) {
-		return iter->second;
+		vtmp = iter->second;
 	}
-	return vEmpty;
+
+	vtmp.erase(
+		std::remove_if(vtmp.begin(), vtmp.end(), [](Song* s) { return s->GetSelectionDisplay() != SelectionDisplay_Always; }),
+		vtmp.end()
+	);
+
+	static const std::vector<Song*> vret = vtmp;
+	return vret;
 }
 void
 SongManager::ForceReloadSongGroup(const std::string& sGroupName) const


### PR DESCRIPTION
This PR is intended to bring ``#SELECTABLE`` back to use by turning it into a visibility toggle instead, or an unlock system in other words.

With this pull request, it modifies:
* Function `GetSteps()` to filter out unselectable songs that have not been cleared - `SongUtil.cpp`
* Adds getters and setters for `m_SelectionDisplay` - `Song.cpp` and `Song.h`
* Turns `SelectionDisplay` into a global enum - `Song.h`, `NotesLoaderSM.cpp`, `NotesLoaderSMA.cpp`, `NotesLoaderSSC.cpp`, `NotesWriterSM.cpp`, `NotesWriterSSC.cpp`, `NotesWriterETT.cpp`, `SongCacheIndex.cpp`,  `GameConstantsAndTypes.h`, and `GameConstantsAndTypes.cpp` (yes it's that big)
* Adds Lua hooks such as `IsSelectable()` and `SetSelectable()` - `Song.cpp`
* Function `WHEELDATA.SetAllSongs()` to do the same thing as `GetSteps()` in `SongUtil.cpp`, but specifically for Rebirth - `10 WheelDataManager.lua`

**BONUS:**
* Adding `AddChild` Lua function, why not? - `ActorFrame.cpp`

~~This PR isn't exactly done yet, as it needs a form of saving state at some point, with maybe fancier features.~~

This PR is ready to be reviewed and pulled, this honestly is anticlimactic after literally posting yesterday.  