### PR TITLE
Remove template keyword for Clang 21

### DIFF
--- a/extern/boost/nowide/include/nowide/detail/convert.hpp
+++ b/extern/boost/nowide/include/nowide/detail/convert.hpp
@@ -36,7 +36,7 @@ namespace nowide {
             while(source_begin != source_end)
             {
                 using namespace detail::utf;
-                code_point c = utf_traits<CharIn>::template decode(source_begin, source_end);
+                code_point c = utf_traits<CharIn>::decode(source_begin, source_end);
                 if(c == illegal || c == incomplete)
                 {
                     c = NOWIDE_REPLACEMENT_CHARACTER;
@@ -47,7 +47,7 @@ namespace nowide {
                     rv = NULL;
                     break;
                 }
-                buffer = utf_traits<CharOut>::template encode(c, buffer);
+                buffer = utf_traits<CharOut>::encode(c, buffer);
                 buffer_size -= width;
             }
             *buffer++ = 0;
@@ -71,12 +71,12 @@ namespace nowide {
             code_point c;
             while(begin != end)
             {
-                c = utf_traits<CharIn>::template decode(begin, end);
+                c = utf_traits<CharIn>::decode(begin, end);
                 if(c == illegal || c == incomplete)
                 {
                     c = NOWIDE_REPLACEMENT_CHARACTER;
                 }
-                utf_traits<CharOut>::template encode(c, inserter);
+                utf_traits<CharOut>::encode(c, inserter);
             }
             return result;
         }


### PR DESCRIPTION
Fix build error
```
In file included from extern/boost/nowide/include/nowide/convert.hpp:11:
extern/boost/nowide/include/nowide/detail/convert.hpp:39:61: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
39 |                 code_point c = utf_traits<CharIn>::template decode(source_begin, source_end);
   |                                                             ^
extern/boost/nowide/include/nowide/detail/convert.hpp:50:56: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
50 |                 buffer = utf_traits<CharOut>::template encode(c, buffer);
   |                                                        ^
extern/boost/nowide/include/nowide/detail/convert.hpp:74:50: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
74 |                 c = utf_traits<CharIn>::template decode(begin, end);
   |                                                  ^
extern/boost/nowide/include/nowide/detail/convert.hpp:79:47: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
79 |                 utf_traits<CharOut>::template encode(c, inserter);
   |                                               ^
4 errors generated.
```