### PR TITLE
Fix GBracketing NaN issue.

### DIFF
--- a/src/Etterna/MinaCalc/Dependent/HD_PatternMods/GenericBracketing.h
+++ b/src/Etterna/MinaCalc/Dependent/HD_PatternMods/GenericBracketing.h
@@ -86,9 +86,11 @@ struct GBracketingMod
 		t_taps = static_cast<float>(mitvghi.total_taps);
 		bracket_taps = static_cast<float>(mitvghi.taps_bracketing);
 
-		total_prop =
-		  total_prop_base + ((bracket_taps + prop_buffer) /
-							 (t_taps - prop_buffer) * total_prop_scaler);
+		// don't bother to deal with total_prop if it's zero because nan apparently happens here.
+		if (t_taps - prop_buffer != 0)
+			total_prop =
+			total_prop_base + ((bracket_taps + prop_buffer) /
+								(t_taps - prop_buffer) * total_prop_scaler);
 		total_prop =
 		  std::clamp(fastsqrt(total_prop), total_prop_min, total_prop_max);
 

--- a/src/Etterna/MinaCalc/Dependent/HD_PatternMods/GenericBracketing.h
+++ b/src/Etterna/MinaCalc/Dependent/HD_PatternMods/GenericBracketing.h
@@ -78,7 +78,7 @@ struct GBracketingMod
 		}
 
 		// definitely no brackets, decay
-		if (mitvghi.taps_bracketing == 0) {
+		if (mitvghi.taps_bracketing == 0 || mitvghi.total_taps == static_cast<int>(prop_buffer)) {
 			decay_mod();
 			return pmod;
 		}
@@ -86,11 +86,10 @@ struct GBracketingMod
 		t_taps = static_cast<float>(mitvghi.total_taps);
 		bracket_taps = static_cast<float>(mitvghi.taps_bracketing);
 
-		// don't bother to deal with total_prop if it's zero because nan apparently happens here.
-		if (t_taps - prop_buffer != 0)
-			total_prop =
-			total_prop_base + ((bracket_taps + prop_buffer) /
-								(t_taps - prop_buffer) * total_prop_scaler);
+		total_prop =
+		total_prop_base + ((bracket_taps + prop_buffer) /
+							(t_taps - prop_buffer) * total_prop_scaler);
+
 		total_prop =
 		  std::clamp(fastsqrt(total_prop), total_prop_min, total_prop_max);
 

--- a/src/Etterna/MinaCalc/MinaCalc.cpp
+++ b/src/Etterna/MinaCalc/MinaCalc.cpp
@@ -957,7 +957,7 @@ MinaSDCalcDebug(
 #endif
 }
 
-int mina_calc_version = 521;
+int mina_calc_version = 522;
 auto
 GetCalcVersion() -> int
 {


### PR DESCRIPTION
Yeah, apparently NaNs can make a major difference to calculations.

Added an extra check to prevent NaN from occuring due to the amount in `total_taps`. - `GenericBracketing.h`