### PR TITLE
Alt+Enter Window Fix

### DIFF
--- a/src/Etterna/Globals/StepMania.cpp
+++ b/src/Etterna/Globals/StepMania.cpp
@@ -1399,6 +1399,7 @@ HandleGlobalInputs(const InputEventPlus& input)
 		 * bool it if it's been less than, say, half a second. */
 #if !defined(__APPLE__)
 		GameLoop::setToggleWindowed();
+		StepMania::ApplyGraphicOptions();
 #endif
 		return true;
 	}
@@ -1481,7 +1482,6 @@ void StepMania::HandleInputEvents(float fDeltaTime) {
 
 	if (GameLoop::GetAndClearToggleWindowed()) {
 		PREFSMAN->m_bWindowed.Set(!PREFSMAN->m_bWindowed);
-		StepMania::ApplyGraphicOptions();
 	}
 }
 

--- a/src/Etterna/Globals/StepMania.cpp
+++ b/src/Etterna/Globals/StepMania.cpp
@@ -1399,7 +1399,6 @@ HandleGlobalInputs(const InputEventPlus& input)
 		 * bool it if it's been less than, say, half a second. */
 #if !defined(__APPLE__)
 		GameLoop::setToggleWindowed();
-		StepMania::ApplyGraphicOptions();
 #endif
 		return true;
 	}

--- a/src/Etterna/Globals/StepMania.cpp
+++ b/src/Etterna/Globals/StepMania.cpp
@@ -1481,7 +1481,23 @@ void StepMania::HandleInputEvents(float fDeltaTime) {
 	}
 
 	if (GameLoop::GetAndClearToggleWindowed()) {
-		PREFSMAN->m_bWindowed.Set(!PREFSMAN->m_bWindowed);
+		int attempted = 0;
+		while (true)
+		{
+			if (attempted >= 2)
+			{
+				Locator::getLogger()->error("End my resizing suffering.");
+				ShutdownGame();
+			}
+
+			PREFSMAN->m_bWindowed.Set(!PREFSMAN->m_bWindowed);
+			StepMania::ApplyGraphicOptions();
+
+			attempted++;
+			Locator::getLogger()->info("Focused: {}", GameLoop::isGameFocused()? "yes" : "no");
+
+			if (GameLoop::isGameFocused()) break;
+		}
 	}
 }
 


### PR DESCRIPTION
~~This should fix how the window handles context resetting, because apparently we've been doing it **after** the window got resized, forcing it to never really update on exclusive fullscreen.~~

~~My fix is literally just doing it when the keybind is pressed.~~

(this is stupid, i found out after.)