### PR TITLE
Modernize ARRAYLEN

### DIFF
--- a/src/RageUtil/Utils/RageUtil.h
+++ b/src/RageUtil/Utils/RageUtil.h
@@ -29,7 +29,7 @@ class RageFileDriver;
 #define ZERO(x) memset(&(x), 0, sizeof(x))
 
 /** @brief Get the length of the array. */
-#define ARRAYLEN(a) (sizeof(a) / sizeof((a)[0]))
+#define ARRAYLEN(a) std::size(a)
 
 /**
  * @brief Scales x so that l1 corresponds to l2 and h1 corresponds to h2.


### PR DESCRIPTION
Replaces the c-style `sizeof(a) / sizeof(a[0])` with `std::size(a)` [C++17]. The benefit of this is that pointers fail to compile and standard types (ex. `std::vector`) will behave more correctly. This does not fix any bugs that I am aware of.
