### PR TITLE
Hide cursor dynamically in X11

### DIFF
--- a/src/Core/Platform/PlatformUnix.cpp
+++ b/src/Core/Platform/PlatformUnix.cpp
@@ -278,7 +278,6 @@ namespace Core::Platform {
 
 			XDefineCursor(X11Helper::Dpy, X11Helper::Win, pBlankCursor.value());
     	}
-        //Locator::getLogger()->warn("Core::Platform::setCursorVisible not implemented");
     }
 
     ghc::filesystem::path getExecutableDirectory(){

--- a/src/Core/Platform/PlatformUnix.cpp
+++ b/src/Core/Platform/PlatformUnix.cpp
@@ -2,9 +2,11 @@
 #include "Core/Services/Locator.hpp"
 #include "Etterna/Singletons/PrefsManager.h"
 #include "Etterna/Globals/global.h"
+#include "archutils/Unix/X11Helper.h"
 
 #include <fmt/format.h>
 
+#include <optional>
 #include <string>
 #include <fstream>
 
@@ -259,7 +261,24 @@ namespace Core::Platform {
     }
 
     void setCursorVisible(bool value){
-        Locator::getLogger()->warn("Core::Platform::setCursorVisible not implemented");
+		static std::optional<Cursor> pBlankCursor{};
+
+    	if(value) {
+			XUndefineCursor(X11Helper::Dpy, X11Helper::Win);
+    	} else {
+    		if(!pBlankCursor.has_value()) {
+				const char pBlank[] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+				Pixmap BlankBitmap = XCreateBitmapFromData(X11Helper::Dpy, X11Helper::Win, pBlank, 8, 8);
+
+				XColor black = { 0, 0, 0, 0, 0, 0 };
+				pBlankCursor = XCreatePixmapCursor(
+			  		X11Helper::Dpy, BlankBitmap, BlankBitmap, &black, &black, 0, 0);
+				XFreePixmap(X11Helper::Dpy, BlankBitmap);
+    		}
+
+			XDefineCursor(X11Helper::Dpy, X11Helper::Win, pBlankCursor.value());
+    	}
+        //Locator::getLogger()->warn("Core::Platform::setCursorVisible not implemented");
     }
 
     ghc::filesystem::path getExecutableDirectory(){

--- a/src/archutils/Unix/X11Helper.cpp
+++ b/src/archutils/Unix/X11Helper.cpp
@@ -151,21 +151,6 @@ X11Helper::MakeWindow(Window& win,
 		XFree(hint);
 	}
 
-	// Hide the mouse cursor in certain situations.
-	/*
-	if (!PREFSMAN->m_bShowMouseCursor) {
-		const char pBlank[] = { 0, 0, 0, 0, 0, 0, 0, 0 };
-		Pixmap BlankBitmap = XCreateBitmapFromData(Dpy, win, pBlank, 8, 8);
-
-		XColor black = { 0, 0, 0, 0, 0, 0 };
-		Cursor pBlankPointer = XCreatePixmapCursor(
-		  Dpy, BlankBitmap, BlankBitmap, &black, &black, 0, 0);
-		XFreePixmap(Dpy, BlankBitmap);
-
-		XDefineCursor(Dpy, win, pBlankPointer);
-		XFreeCursor(Dpy, pBlankPointer);
-	}
-	*/
 	return true;
 }
 

--- a/src/archutils/Unix/X11Helper.cpp
+++ b/src/archutils/Unix/X11Helper.cpp
@@ -152,6 +152,7 @@ X11Helper::MakeWindow(Window& win,
 	}
 
 	// Hide the mouse cursor in certain situations.
+	/*
 	if (!PREFSMAN->m_bShowMouseCursor) {
 		const char pBlank[] = { 0, 0, 0, 0, 0, 0, 0, 0 };
 		Pixmap BlankBitmap = XCreateBitmapFromData(Dpy, win, pBlank, 8, 8);
@@ -164,7 +165,7 @@ X11Helper::MakeWindow(Window& win,
 		XDefineCursor(Dpy, win, pBlankPointer);
 		XFreeCursor(Dpy, pBlankPointer);
 	}
-
+	*/
 	return true;
 }
 


### PR DESCRIPTION
Implements setCursorVisible in PlatformUnix and removes the X11Helper cursor hiding logic. Allows for dynamic cursor visibility on X11.