### PR TITLE
Replay Offset Display and .osu Sample Preview fixes

### DIFF
--- a/src/Etterna/Actor/Gameplay/NoteDisplay.cpp
+++ b/src/Etterna/Actor/Gameplay/NoteDisplay.cpp
@@ -789,7 +789,8 @@ NoteDisplay::DrawReplayActors(const TapNote& tn,
 							  const int& row) const
 {
 	if (!PREFSMAN->m_bReplaysShowOffsets ||
-		!REPLAYS->GetActiveReplay()->HasColumnData()) {
+		!REPLAYS->GetActiveReplay()->HasColumnData() ||
+		GAMESTATE->GetGameplayMode() != GameplayMode_Replay) {
 		return;
 	}
 

--- a/src/Etterna/Models/NoteLoaders/NotesLoaderOSU.cpp
+++ b/src/Etterna/Models/NoteLoaders/NotesLoaderOSU.cpp
@@ -9,6 +9,7 @@
 #include "Etterna/Singletons/PrefsManager.h"
 
 #include <cmath>
+#include <limits>
 #include <string>
 #include <map>
 #include <algorithm>
@@ -207,9 +208,9 @@ OsuLoader::SetTimingData(
 	out.m_DisplayBPMType = DISPLAY_BPM_ACTUAL;
 
 	auto general = parsedData["General"];
-	out.m_fMusicSampleStartSeconds = stof(general["AudioLeadIn"]) / 1000.0f;
-	out.m_fMusicSampleLengthSeconds =
-	  stof(general["PreviewTime"]) / 1000.0f; // these probably aren't right
+	out.m_fMusicSampleStartSeconds = stof(general["PreviewTime"]) / 1000.0f;
+	out.m_fMusicSampleLengthSeconds = std::numeric_limits<float>::max();
+	// let Song::TidyUpData() does its job
 }
 
 bool


### PR DESCRIPTION
Replay Offset Display: with `== GameplayMode_Replay`

.osu sample preview: by making use of `Song::TidyUpData()`'s `> this->m_fMusicLengthSeconds` if condition to let it just use the whole song after the preview point