### PR TITLE
Add journal feature: per-pack Obsidian markdown + hotkeys + screensho…

### DIFF
--- a/Docs/Journal.md
+++ b/Docs/Journal.md
@@ -1,0 +1,166 @@
+# Etterna Journal — 설계 문서
+
+Etterna fork (`etterna-journal`) 에 추가되는 기능 세트: 팩별 Obsidian 마크다운 자동 생성 · 날짜별 메모 hotkey · 곡 태그 라벨링 · 스크린샷 자동 첨부.
+상위 맥락: 메인 워크스페이스 `TODO.md` query 7, 환경 가이드는 `Content/Tools/etterna_fork_workflow.md`.
+
+## 1. 구현 전략
+
+**Lua-first.** Themes/Rebirth 내에서 Scripts 모듈 + BGAnimations overlay 로 구현하여 C++ 수정 최소화 → upstream merge 충돌 최소.
+프레임워크 재사용:
+- `DFRStarted` / `DFRFinished` 이벤트 (`src/Etterna/Singletons/SongManager.cpp:222, 233`) → 팩 리로드 hook
+- `create_setting(...)` 헬퍼 (`Themes/Rebirth/Scripts/02 ThemePrefs.lua`) → 저널 설정 저장
+- 기존 `TAGMAN` 확장 (`Themes/Rebirth/Scripts/01 TagManager.lua`) → 곡별 태그 관리
+- `ScreenTextEntry` → 인게임 메모 입력
+- `FILEMAN` (Lua) · `RageFileManager` → 파일 I/O
+- `SaveScreenshot` 반환 경로 (`src/Etterna/Globals/StepMania.cpp:1201`) → 스크린샷 첨부 hook
+
+## 2. 디렉토리 레이아웃 (사용자 Preference)
+
+```
+<JournalRoot>/                      # 사용자 Preference "JournalOutputDir"
+  <PackName>.md                     # 팩별 마크다운 (옵시디언 vault 에 직접 맵핑)
+  banners/                          # 모든 팩 배너 이미지 집합
+    <PackName>__<SongDir>.<ext>
+  screenshots/                      # 모든 스크린샷
+    <PackName>__<SongDir>__<UTC>.<ext>
+  tags.json                         # 사용자 정의 태그 리스트 + 곡별 할당
+  .journal-cache.json               # 내부 상태 (banner 해시, 최근 entry 위치 등)
+```
+
+**이름 충돌 방지 규칙**
+- 배너: `{pack}__{songdir}.{ext}` — 동일 팩 내 곡 디렉토리가 unique 하므로 충돌 없음. 팩 경계를 넘어도 prefix 로 분리.
+- 스크린샷: `{pack}__{songdir}__{YYYYMMDD_HHMMSS}.{ext}` — 타임스탬프까지 포함하여 유일성 보장.
+- 공백·특수문자는 `_` 로 치환.
+
+## 3. 팩 마크다운 포맷
+
+곡 섹션 단위. 한 팩 = 한 .md.
+
+```markdown
+# <Song Title>
+
+![[banners/<PackName>__<SongDir>.png|128]]
+
+#Etterna/4KEY/Jumpstream #Etterna/4KEY/Handstream
+
+* 2026-04-23 0.85 레이트 후살 연습, 거의 안정
+* 2026-04-24 0.9 시도, 최후살 실수 2회
+  [[screenshots/<PackName>__<SongDir>__20260424_213012.png]]
+```
+
+각 섹션 구성 요소:
+1. **헤딩** `# <타이틀>` — 곡 구분자. 병합 기준.
+2. **배너 라인** `![[banners/...|128]]` — 자동 관리 (팩 리로드 때 갱신).
+3. **태그 라인** `#tag1 #tag2 ...` — 자동 관리 (태그 UI 로 갱신).
+4. **메모 블록** `* YYYY-MM-DD ...` — 사용자 작성, 자동 건드리지 않음. 스크린샷은 그날 메모 아래 이어붙임.
+
+## 4. 병합 전략 (사용자 메모 보존)
+
+팩 리로드 시 .md 재생성 로직:
+
+```
+for each song in pack:
+  if section "# <title>" exists in current .md:
+    # 기존 섹션 유지. 관리 라인만 sync.
+    update banner line (2번째 content line if match pattern, else insert)
+    update tag line  (3번째 content line if match pattern, else insert)
+    leave memo bullets + screenshot attachments untouched
+  else:
+    # 신규 곡: 템플릿 섹션 append
+    append fresh section with heading + banner + empty tag line
+```
+
+섹션 파싱 규칙: `^# ` (heading) 부터 다음 `^# ` 직전까지를 "한 섹션" 으로 취급. 하위 heading (`##`, `###`) 은 섹션 내부로 귀속.
+
+**보존 보장**
+- 사용자가 추가한 heading 간 설명 블록, 링크, 추가 태그 라인, memo bullet 은 절대 삭제하지 않음.
+- 자동 관리 라인 판별은 pattern match (배너는 `![[banners/...]]`, 태그는 `^#` 으로 시작하고 `Etterna/` prefix) — user-authored 라인과 구분.
+
+## 5. In-game Hotkey
+
+곡 선택 스크린 (`ScreenSelectMusic`) 에서만 동작.
+
+| Hotkey | 동작 |
+|---|---|
+| `Ctrl+Shift+C` | 현재 곡에 오늘자 메모 추가. `ScreenTextEntry` 로 텍스트 입력 → `* YYYY-MM-DD <text>` append. |
+| `Ctrl+Shift+T` | 태그 토글 UI 팝업. `tags.json` 의 정의된 태그 리스트 표시 → 토글 → 해당 곡 섹션의 태그 라인 갱신. |
+
+Rebirth 테마 기존 단축키와 충돌 없음을 확인 (`Themes/Rebirth/**/*.lua` grep 결과 `Ctrl+Shift+*` 조합 부재).
+
+## 6. 태그 관리
+
+`tags.json` 스키마:
+```json
+{
+  "defined": [
+    "Etterna/4KEY/Jumpstream",
+    "Etterna/4KEY/Handstream",
+    "Etterna/4KEY/Chordjack",
+    "Etterna/4KEY/Stream",
+    "Etterna/4KEY/Technical"
+  ],
+  "assigned": {
+    "<PackName>/<SongDir>": ["Etterna/4KEY/Jumpstream", "Etterna/4KEY/OH_Trill"]
+  }
+}
+```
+
+`defined` 는 사용자가 직접 편집 또는 태그 UI 에서 "Add new" 로 추가. `assigned` 는 UI 토글로 관리. 마크다운의 태그 라인은 `assigned` 를 매번 재생성.
+
+## 7. 스크린샷 자동 첨부
+
+`SaveScreenshot` 호출 → 반환 경로 X → `screenshots/` 폴더로 복사 · rename (`{pack}__{song}__{ts}.ext`) → 현재 곡의 .md 섹션에서 **오늘자 entry** 찾아서 그 직후 라인에 `  [[screenshots/...]]` append (들여쓰기 2 space, embed 아닌 link 형태).
+
+오늘자 entry 부재 시: `* YYYY-MM-DD` 라인을 먼저 생성 후 아래 첨부.
+
+원본 스크린샷은 Etterna 기본 경로 (`Save/Screenshots/`) 에도 그대로 두어 기존 기능 유지.
+
+## 8. Preferences
+
+새 Preferences (Etterna `Preference<T>` 시스템, `Save/Preferences.ini`):
+
+| Key | Type | Default | 설명 |
+|---|---|---|---|
+| `JournalEnabled` | bool | `false` | 저널 기능 전체 on/off. 기본 off → 비활성 사용자에게 영향 없음. |
+| `JournalOutputDir` | string | `Save/Journal/` | 마크다운 · 배너 · 스크린샷 루트. 옵시디언 vault 경로 지정 권장. |
+
+Preference 등록 위치: `src/Etterna/Singletons/PrefsManager.cpp` (소량 C++ 변경) — 또는 Lua `ThemePrefs` 만으로도 가능하지만 Preference 시스템이 더 표준적이라 전자 권장. Upstream 충돌 risk 최소 (끝에 append).
+
+## 9. 파일 구조 (구현 산출물)
+
+Upstream 충돌 최소화를 위해 **신규 파일 위주**로 작성:
+
+```
+Themes/Rebirth/Scripts/
+  50 JournalCore.lua         # 경로 · 파일 I/O · 공통 유틸
+  50 JournalMarkdown.lua     # .md 파싱 · 병합 · 쓰기
+  50 JournalBanner.lua       # 배너 copy · rename
+  50 JournalScreenshot.lua   # 스크린샷 hook · 첨부
+  50 JournalTags.lua         # tags.json 로드 · 저장 · 갱신
+  50 JournalInput.lua        # ScreenSelectMusic hotkey binding
+Themes/Rebirth/BGAnimations/
+  ScreenSelectMusic decorations/journal.lua   # overlay (UI 팝업 · input listener)
+```
+
+기존 파일 수정 (최소):
+- `src/Etterna/Singletons/PrefsManager.cpp` — 2개 Preference 추가 (파일 끝에 append)
+- `Themes/Rebirth/BGAnimations/ScreenSelectMusic decorations.lua` — journal.lua 로드 1 줄 추가
+
+## 10. 구현 순서 (Phases)
+
+| Phase | 산출 | 검증 |
+|---|---|---|
+| A | Preferences + Lua 모듈 스캐폴드 | Linux 빌드 통과, 프리퍼런스 나타나는지 로그 |
+| B | 팩 마크다운 생성 + 배너 복사 | `DFRFinished` 후 .md · banners/ 생성 확인 |
+| C | 메모 hotkey (`Ctrl+Shift+C`) | 인게임 입력 → .md 에 날짜 entry 추가 (Windows) |
+| D | 태그 UI (`Ctrl+Shift+T`) | 토글 → tags.json 업데이트 → .md 태그 라인 갱신 (Windows) |
+| E | 스크린샷 자동 첨부 | F12 등 기본 스크린샷 키 → .md 에 링크 append (Windows) |
+
+Phase A-B 는 devcontainer Linux 빌드로 Lua syntax · 빌드 성공 확인 가능.
+Phase C-E 는 실제 인게임 동작이 필요하므로 Windows 빌드에서 사용자 검증.
+
+## 11. 비고
+
+- 모든 파일 쓰기는 원자적(쓰기 실패 시 기존 파일 손상 방지) — `tmp 파일 작성 → rename` 패턴 사용.
+- `.journal-cache.json` 은 지능적 skip 용 (배너 해시 같아도 복사 다시 안 하기, 섹션 위치 캐싱). 분실되어도 재생성 가능.
+- upstream merge 시 `Themes/Rebirth/` 는 본가가 빈번히 수정 → 충돌 가능성 존재. 최악의 경우 테마 파일은 수동 rebase.

--- a/Docs/Journal_Verification.md
+++ b/Docs/Journal_Verification.md
@@ -1,0 +1,149 @@
+---
+title: Etterna Journal — Windows 검증 체크리스트
+---
+
+# Etterna Journal — Windows 검증 체크리스트
+
+[[TODO]] query 7-2 구현 검증용. devcontainer (Linux) 에서 GUI 테스트 불가능하므로 실제 동작은 Windows 로컬 빌드로 확인해야 합니다.
+설계: [[Docs/Journal]]. 구현은 `Themes/Rebirth/Scripts/50 Journal*.lua` + overlay + StepMania.cpp (+5줄).
+
+## 0. 준비
+
+### 0.1 Windows 에 etterna-journal 빌드
+- `git pull` (또는 최초라면 `git clone https://github.com/ATTANGHUB/etterna-journal.git`).
+- `Docs/Building.md` 절차대로 Visual Studio + CMake + vcpkg 로 빌드.
+- 빌드 성공하면 `Etterna.exe` 가 생성됨.
+
+### 0.2 최초 실행 (설정 파일 생성)
+- `Etterna.exe` 실행 → 곡 선택 화면까지 진입.
+- **기대**: `Save/Rebirth/journal.lua` 파일이 생성됨 (기본값으로).
+- 게임 종료.
+
+### 0.3 설정 편집
+- `Save/Rebirth/journal.lua` 를 텍스트 에디터로 열기.
+- 다음처럼 수정:
+  ```lua
+  return {
+      enabled = true,
+      outputDir = "C:/Users/<you>/ObsidianVault/Etterna",
+      bannerDir = "banners",
+      screenshotDir = "screenshots",
+      tagsFile = "tags.json",
+      cacheFile = ".journal-cache.json",
+  }
+  ```
+  - `outputDir` 은 **절대 경로**, **forward-slash** 추천 (백슬래시도 동작하지만 이스케이프 필요).
+  - 이 폴더는 자동 생성됨 (mkdir) — 미리 만들 필요 없음.
+
+## 1. Phase B — 팩 마크다운 + 배너 복사
+
+### 1.1 기본 생성
+1. `Etterna.exe` 재실행.
+2. 곡 선택 화면 진입 후 1~2초 대기.
+3. **확인**:
+   - [ ] `<outputDir>/` 에 각 팩마다 `<팩이름>.md` 생성됨.
+   - [ ] `<outputDir>/banners/` 폴더에 배너 이미지들이 `<팩>__<곡디렉토리>.<ext>` 형태로 복사됨.
+   - [ ] `<outputDir>/tags.json` 생성됨 (defined 태그 8개 기본 포함).
+   - [ ] .md 파일 안에 각 곡마다 다음 섹션이 있음:
+     ```
+     # <곡 제목>
+     
+     ![[banners/<팩>__<곡디렉토리>.png|128]]
+     ```
+
+### 1.2 메모 보존 검증 (중요)
+1. 아무 .md 파일에서 한 곡 섹션을 찾아, 배너 라인 아래에 수동으로 추가:
+   ```
+   * 2026-04-23 테스트 메모. 삭제되지 않아야 함.
+   ```
+2. 게임에서 **Ctrl+Q** 로 차트 리로드.
+3. **확인**:
+   - [ ] 방금 추가한 `* 2026-04-23 테스트 메모...` 라인이 그대로 남아있음.
+   - [ ] 배너 라인은 정상 (바뀌지 않았거나 동일한 내용으로 유지).
+   - [ ] 새 곡이 팩에 추가된 경우에만 신규 섹션이 append 됨.
+
+### 1.3 배너 이름 충돌 방지
+- [ ] 같은 곡을 여러 번 리로드해도 `banners/` 폴더에 중복 파일이 생기지 않음 (이미 존재 시 skip).
+- [ ] 다른 팩에 같은 이름 곡이 있어도 `<팩>__<곡>` prefix 로 분리됨.
+
+## 2. Phase C — 메모 hotkey (Ctrl+Shift+C)
+
+1. 곡 선택 화면에서 아무 곡 선택.
+2. **Ctrl+Shift+C** 누름.
+3. **확인**:
+   - [ ] 텍스트 입력창 (`ScreenTextEntry`) 이 뜨고 "Memo: <곡 제목>" 프롬프트 표시.
+4. 메모 입력 (예: `0.9레이트 연습, 후살 2회 실수`) → Enter.
+5. **확인**:
+   - [ ] 화면 우상단에 "[Journal] memo saved to ..." 메시지 표시.
+   - [ ] 해당 팩의 .md 파일에서 해당 곡 섹션 끝에 다음 라인 추가:
+     ```
+     * 2026-04-23 0.9레이트 연습, 후살 2회 실수
+     ```
+6. Esc 로 입력 취소 시:
+   - [ ] .md 변경 없음, 아무 메시지 없음.
+
+## 3. Phase D v1 — 태그 순환 토글 (Ctrl+Shift+T)
+
+1. 곡 선택.
+2. **Ctrl+Shift+T** 를 여러 번 누름 (예: 3회).
+3. **확인**:
+   - [ ] 누를 때마다 화면 우상단에 `[Journal] +Etterna/4KEY/Jumpstream` 같은 메시지 표시.
+   - [ ] `tags.json` 의 `assigned` 섹션에 `"<팩>/<곡>"` 키로 태그 리스트 저장.
+   - [ ] 해당 곡 섹션의 배너 라인 아래 (또는 헤딩 바로 아래) 태그 라인이 업데이트됨:
+     ```
+     #Etterna/4KEY/Jumpstream #Etterna/4KEY/Handstream
+     ```
+4. 같은 태그가 이미 있을 때 다시 누르면 `-` 로 제거 표시.
+
+### 3.1 제한 사항
+- 현재는 `defined` 리스트를 **순차 순환** 하며 토글하는 placeholder. 특정 태그만 고르려면 여러 번 눌러야 함.
+- `defined` 리스트를 바꾸려면 `tags.json` 을 직접 편집 후 게임 재시작.
+- 제대로 된 multiselect UI 는 후속 iteration (Phase D-2).
+
+## 4. Phase E — 스크린샷 자동 첨부
+
+1. 곡 선택 화면에서 아무 곡 선택.
+2. **PrintScreen** 누름 (Shift+PrintScreen 은 압축 저장).
+3. **확인**:
+   - [ ] `Save/Screenshots/` 에 원본 스크린샷 생성 (기존 동작 유지).
+   - [ ] `<outputDir>/screenshots/<팩>__<곡>__20260423_HHMMSS.png` 로 복사본 생성.
+   - [ ] .md 파일의 해당 곡 섹션에서 **오늘자 메모 아래** 다음 라인이 추가됨:
+     ```
+       [[screenshots/<팩>__<곡>__20260423_HHMMSS.png]]
+     ```
+     (2-space 들여쓰기, `![[...]]` 가 아닌 `[[...]]` — 옵시디언에서 embed 아닌 link).
+4. 오늘자 메모가 아직 없을 때 PrintScreen 누름 → `* 2026-04-23` 라인이 먼저 생성되고 그 아래에 첨부.
+
+## 5. Obsidian 연동 확인
+
+1. `outputDir` 을 옵시디언 vault 내 경로로 지정했다면, Obsidian 에서 vault 열기.
+2. **확인**:
+   - [ ] 팩 .md 들이 노트로 나타남.
+   - [ ] `![[banners/...|128]]` 가 128px 이미지로 렌더.
+   - [ ] `#Etterna/4KEY/Jumpstream` 가 옵시디언 태그로 인식 (왼쪽 panel 태그 뷰).
+   - [ ] 스크린샷 `[[screenshots/...]]` 이 클릭 가능한 링크로.
+
+## 6. 트러블슈팅
+
+| 증상 | 원인 후보 | 대처 |
+|---|---|---|
+| `journal.lua` 가 생성되지 않음 | 테마 로딩 전 에러, 또는 Rebirth 가 아님 | Themes 설정 확인, 로그에서 `[Journal]` 검색 |
+| .md 가 생성되지 않음 | `enabled=false` 또는 `outputDir` 비어있음 | `Save/Rebirth/journal.lua` 재확인 |
+| `mkdir` 실패 | `outputDir` 에 쓰기 권한 없음 | 다른 경로로 이동 |
+| 한글 곡명 깨짐 | .md 저장 encoding (Lua `io` 는 바이트 그대로 씀) | 옵시디언에서 UTF-8 기대 — 곡명 원본이 UTF-8 이면 정상 |
+| Ctrl+Shift+C 반응 없음 | SelectMusic overlay 미로드 | 로그에서 `JournalOverlay` 검색, `default.lua` 수정 반영 확인 |
+| 스크린샷이 .md 에 붙지 않음 | `GAMESTATE:GetCurrentSong()` 이 nil (곡 선택 전) | 곡 선택 후 찍기 |
+
+## 7. 로그 확인 (게임 내 또는 log.txt)
+
+모든 Journal 메시지는 `[Journal]` prefix 로 시작. Etterna 의 로그 파일 (`Logs/log.txt` 또는 게임 내 `~` 콘솔) 에서 grep:
+- `[Journal] regenerateAll: N packs, +X new sections, Y updated (Zs)` — 정상 동작 신호.
+- `[Journal] ensureDir failed` — 경로 문제.
+- `[Journal] banner copy failed` — 원본 배너 파일 없음 (일부 곡은 배너 없을 수 있음, 정상).
+- `[Journal] screenshot source not found` — 저장 경로 해석 실패 (버그 가능성).
+
+## 8. 완료 후
+
+- 이 문서의 checkbox 를 다 확인한 후 문제 없으면 [[TODO]] 7-2 를 `[x]` 로 resolve.
+- 문제 발견 시 이슈 요약 + 재현 방법 을 TODO 새 쿼리로 등록.
+- Phase D-2 (multiselect 태그 UI) 는 별도 쿼리로 후속 iteration.

--- a/Themes/Rebirth/BGAnimations/ScreenSelectMusic decorations/default.lua
+++ b/Themes/Rebirth/BGAnimations/ScreenSelectMusic decorations/default.lua
@@ -82,5 +82,6 @@ t[#t+1] = Def.ActorFrame {
 
 t[#t+1] = LoadActor("_chartPreview.lua")
 t[#t+1] = LoadActor("calcDebug.lua")
+t[#t+1] = LoadActor("journal.lua")
 
 return t

--- a/Themes/Rebirth/BGAnimations/ScreenSelectMusic decorations/journal.lua
+++ b/Themes/Rebirth/BGAnimations/ScreenSelectMusic decorations/journal.lua
@@ -1,0 +1,164 @@
+-- Journal: ScreenSelectMusic overlay
+-- - Subscribes to DFRFinished → regenerate all pack markdowns.
+-- - Hooks Ctrl+Shift+C → memo entry for current song.
+-- - Hooks Ctrl+Shift+T → tag toggle cycle for current song.
+-- Spec: Docs/Journal.md §5 (hotkeys), §3 (markdown), §6 (tags).
+
+local t = Def.ActorFrame {
+    Name = "JournalOverlay",
+}
+
+---------------------------------------------------------------
+-- Identity helpers
+
+local function currentSong()
+    if not GAMESTATE then return nil end
+    return GAMESTATE:GetCurrentSong()
+end
+
+local function songIdentity(song)
+    if not song then return nil, nil, nil end
+    local pack = song.GetGroupName and song:GetGroupName() or "Unknown"
+    local dir = song.GetSongDir and song:GetSongDir() or ""
+    dir = dir:gsub("[/\\]$", "")
+    local seg = dir:match("([^/\\]+)$") or dir
+    local title = (song.GetDisplayMainTitle and song:GetDisplayMainTitle()) or
+                  (song.GetMainTitle and song:GetMainTitle()) or seg
+    return pack, seg, title
+end
+
+---------------------------------------------------------------
+-- Append memo to current song's .md
+
+local function appendMemoToCurrentSong(text)
+    local song = currentSong()
+    if not song then return false, "no song" end
+    local pack, dir, title = songIdentity(song)
+    local path = JOURNAL.packMarkdownPath(pack)
+    local existing = JOURNAL.readText(path) or ""
+    local doc = JOURNAL.md.parse(existing)
+    local idx = JOURNAL.md.indexByTitle(doc)[title]
+    local section
+    if idx then
+        section = doc.sections[idx]
+    else
+        local banner = JOURNAL.banner.copyFor(song, pack, dir)
+        local tags = JOURNAL.tags.get(pack, dir)
+        section = JOURNAL.md.newSection({ title = title, bannerPath = banner, tags = tags })
+        doc.sections[#doc.sections + 1] = section
+    end
+    JOURNAL.md.appendMemo(section, text)
+    return JOURNAL.writeText(path, JOURNAL.md.serialize(doc))
+end
+
+---------------------------------------------------------------
+-- Memo entry flow via ScreenTextEntry
+
+local function openMemoEntry()
+    if not JOURNAL.isEnabled() then
+        ms.ok("[Journal] disabled — set JournalOutputDir + enable")
+        return
+    end
+    local song = currentSong()
+    if not song then
+        ms.ok("[Journal] no song selected")
+        return
+    end
+    local _, _, title = songIdentity(song)
+
+    SCREENMAN:AddNewScreenToTop("ScreenTextEntry")
+    local scr = SCREENMAN:GetTopScreen()
+    if not (scr and scr.Load) then
+        ms.ok("[Journal] ScreenTextEntry unavailable")
+        return
+    end
+    scr:Load({
+        Question = "Memo: " .. title,
+        InitialAnswer = "",
+        MaxInputLength = 400,
+        OnOK = function(answer)
+            if answer and answer ~= "" then
+                local ok = appendMemoToCurrentSong(answer)
+                ms.ok(ok and ("[Journal] memo saved to " .. title) or "[Journal] write failed")
+            end
+        end,
+        OnCancel = function() end,
+    })
+end
+
+---------------------------------------------------------------
+-- Tag cycle toggle (Phase D placeholder — real UI in next iteration)
+
+local tagCycleIdx = 1
+
+local function cycleToggleTag()
+    if not JOURNAL.isEnabled() then
+        ms.ok("[Journal] disabled")
+        return
+    end
+    local song = currentSong()
+    if not song then return end
+    local pack, dir, title = songIdentity(song)
+    local defined = JOURNAL.tags.defined()
+    if #defined == 0 then
+        ms.ok("[Journal] no tags defined")
+        return
+    end
+    local tag = defined[((tagCycleIdx - 1) % #defined) + 1]
+    tagCycleIdx = tagCycleIdx + 1
+    local added = JOURNAL.tags.toggle(pack, dir, tag)
+    -- sync tag line in markdown
+    local path = JOURNAL.packMarkdownPath(pack)
+    local existing = JOURNAL.readText(path) or ""
+    local doc = JOURNAL.md.parse(existing)
+    local idx = JOURNAL.md.indexByTitle(doc)[title]
+    if idx then
+        JOURNAL.md.syncManagedLines(doc.sections[idx], nil, JOURNAL.tags.get(pack, dir))
+        JOURNAL.writeText(path, JOURNAL.md.serialize(doc))
+    end
+    ms.ok("[Journal] " .. (added and "+" or "-") .. tag)
+end
+
+---------------------------------------------------------------
+-- DFRFinished hook: regenerate all pack .md
+
+t[#t + 1] = Def.Actor {
+    Name = "JournalDFRListener",
+    OnCommand = function(self)
+        -- Trigger initial regen with slight delay
+        self:sleep(0.2):queuecommand("InitialRegen")
+    end,
+    InitialRegenCommand = function()
+        if JOURNAL.isEnabled() then
+            JOURNAL.pack.regenerateAll()
+        end
+    end,
+    DFRFinishedMessageCommand = function()
+        if JOURNAL.isEnabled() then
+            JOURNAL.pack.regenerateAll()
+        end
+    end,
+}
+
+---------------------------------------------------------------
+-- Input listener
+
+t[#t + 1] = Def.Actor {
+    Name = "JournalInputListener",
+    OnCommand = function(self)
+        local screen = SCREENMAN:GetTopScreen()
+        if not screen or not screen.AddInputCallback then return end
+        screen:AddInputCallback(function(event)
+            if event.type ~= "InputEventType_FirstPress" then return end
+            if not (INPUTFILTER:IsControlPressed() and INPUTFILTER:IsShiftPressed()) then return end
+            local key = event.DeviceInput and event.DeviceInput.button
+            if key == "DeviceButton_c" then
+                openMemoEntry()
+            elseif key == "DeviceButton_t" then
+                cycleToggleTag()
+            end
+        end)
+    end,
+}
+
+return t

--- a/Themes/Rebirth/BGAnimations/ScreenSystemLayer overlay.lua
+++ b/Themes/Rebirth/BGAnimations/ScreenSystemLayer overlay.lua
@@ -101,4 +101,14 @@ t[#t + 1] =
     }
 }
 
+-- etterna-journal: global screenshot listener (active on all screens)
+t[#t + 1] = Def.Actor {
+    Name = "JournalScreenshotListener",
+    ScreenshotSavedMessageCommand = function(self, params)
+        if JOURNAL and JOURNAL.isEnabled and JOURNAL.isEnabled() then
+            JOURNAL.screenshot.handle(params.FileName, params.Path)
+        end
+    end,
+}
+
 return t

--- a/Themes/Rebirth/Scripts/50 JournalBanner.lua
+++ b/Themes/Rebirth/Scripts/50 JournalBanner.lua
@@ -1,0 +1,59 @@
+-- Journal: banner image copy + naming
+-- Spec: Docs/Journal.md §2 (filename rule), §7 (banner copy on pack reload).
+
+JOURNAL = JOURNAL or {}
+JOURNAL.banner = {}
+
+---------------------------------------------------------------
+-- Parse extension from #BANNER path (lowercase). Default to "png" if ambiguous.
+local function extOf(path)
+    if not path or path == "" then return "png" end
+    local ext = path:match("%.([%w]+)$")
+    if not ext then return "png" end
+    return ext:lower()
+end
+
+---------------------------------------------------------------
+-- Resolve Song object's banner source path on disk.
+-- Song:GetBannerPath() returns either absolute or relative-to-song-dir path.
+-- Returns nil if no banner available.
+local function resolveBannerSrc(song)
+    if not song then return nil end
+    local fn = nil
+    if song.GetBannerPath then
+        fn = song:GetBannerPath()
+    end
+    if fn == nil or fn == "" then
+        if song.GetBackgroundPath then
+            fn = song:GetBackgroundPath()
+        end
+    end
+    if fn == nil or fn == "" then return nil end
+    return fn
+end
+
+---------------------------------------------------------------
+-- Copy banner for a single song.
+-- Returns relative path (relative to JournalRoot) like "banners/Pack__Song.png"
+-- or nil if no banner / copy failed.
+
+function JOURNAL.banner.copyFor(song, packName, songDir)
+    local src = resolveBannerSrc(song)
+    if not src then return nil end
+    local ext = extOf(src)
+    local name = JOURNAL.bannerName(packName, songDir, ext)
+    local dst = JOURNAL.joinPath(JOURNAL.bannerRoot(), name)
+    local relPath = JOURNAL.cfg().bannerDir .. "/" .. name
+
+    -- Skip copy if dst already exists and size matches (cheap check).
+    if JOURNAL.fileExists(dst) then
+        return relPath
+    end
+
+    local ok = JOURNAL.copyBinary(src, dst)
+    if not ok then
+        JOURNAL.log("banner copy failed: " .. src .. " -> " .. dst)
+        return nil
+    end
+    return relPath
+end

--- a/Themes/Rebirth/Scripts/50 JournalCore.lua
+++ b/Themes/Rebirth/Scripts/50 JournalCore.lua
@@ -1,0 +1,199 @@
+-- Journal: core module
+-- Provides: config (JOURNAL.cfg), path helpers, file I/O, sanitization, date.
+-- Loaded before other Journal modules (50-prefix). Spec: Docs/Journal.md.
+
+JOURNAL = JOURNAL or {}
+
+---------------------------------------------------------------
+-- Config (persisted via theme ThemePrefs under Save/<Theme>/journal.lua)
+
+local defaultConfig = {
+    enabled = false,           -- master switch, default off so vanilla users unaffected
+    outputDir = "",            -- absolute path to journal root (Obsidian vault)
+    bannerDir = "banners",     -- relative to outputDir
+    screenshotDir = "screenshots",
+    tagsFile = "tags.json",
+    cacheFile = ".journal-cache.json",
+}
+
+journalConfig = create_setting("journal", "journal.lua", defaultConfig, -1)
+journalConfig:load()
+
+function JOURNAL.cfg()
+    return journalConfig:get_data()
+end
+
+function JOURNAL.saveCfg()
+    journalConfig:set_dirty()
+    journalConfig:save()
+end
+
+function JOURNAL.isEnabled()
+    local c = JOURNAL.cfg()
+    return c.enabled and c.outputDir ~= nil and c.outputDir ~= ""
+end
+
+---------------------------------------------------------------
+-- Path helpers (all absolute, using `/` — normalized for Windows by io.open)
+
+local function joinPath(a, b)
+    if a:sub(-1) == "/" or a:sub(-1) == "\\" then
+        return a .. b
+    end
+    return a .. "/" .. b
+end
+JOURNAL.joinPath = joinPath
+
+function JOURNAL.root()
+    return JOURNAL.cfg().outputDir
+end
+
+function JOURNAL.bannerRoot()
+    return joinPath(JOURNAL.root(), JOURNAL.cfg().bannerDir)
+end
+
+function JOURNAL.screenshotRoot()
+    return joinPath(JOURNAL.root(), JOURNAL.cfg().screenshotDir)
+end
+
+function JOURNAL.tagsPath()
+    return joinPath(JOURNAL.root(), JOURNAL.cfg().tagsFile)
+end
+
+function JOURNAL.cachePath()
+    return joinPath(JOURNAL.root(), JOURNAL.cfg().cacheFile)
+end
+
+function JOURNAL.packMarkdownPath(packName)
+    return joinPath(JOURNAL.root(), JOURNAL.sanitize(packName) .. ".md")
+end
+
+---------------------------------------------------------------
+-- Name sanitization: safe filename on both Linux and Windows.
+-- Replace reserved chars with `_`. Preserves unicode.
+
+local FORBIDDEN = "[\\/:%*%?\"<>%|%c]"
+
+function JOURNAL.sanitize(s)
+    if not s or s == "" then return "_" end
+    local out = s:gsub(FORBIDDEN, "_"):gsub("%s+$", ""):gsub("^%s+", "")
+    if out == "" then return "_" end
+    return out
+end
+
+-- Banner / screenshot filename: {pack}__{song}[.ext]
+function JOURNAL.bannerName(packName, songDir, ext)
+    return JOURNAL.sanitize(packName) .. "__" .. JOURNAL.sanitize(songDir) .. "." .. ext
+end
+
+function JOURNAL.screenshotName(packName, songDir, ext)
+    local ts = os.date("%Y%m%d_%H%M%S")
+    return JOURNAL.sanitize(packName) .. "__" .. JOURNAL.sanitize(songDir) .. "__" .. ts .. "." .. ext
+end
+
+---------------------------------------------------------------
+-- File I/O via Lua stdlib (works on any absolute path, no VFS needed).
+
+local function detectWindows()
+    -- Etterna's Lua exposes os.getenv; Windows sets COMSPEC, Unix doesn't.
+    local cs = os.getenv and os.getenv("COMSPEC")
+    if cs and cs ~= "" then return true end
+    -- fallback: package.config first char is path sep
+    if package and package.config then
+        return package.config:sub(1, 1) == "\\"
+    end
+    return false
+end
+JOURNAL.isWindows = detectWindows()
+
+-- mkdir -p equivalent. Returns true on success.
+function JOURNAL.ensureDir(path)
+    if not path or path == "" then return false end
+    local cmd
+    if JOURNAL.isWindows then
+        -- Windows mkdir recursively creates with extensions enabled (default)
+        -- Quote path; backslash or forward-slash both accepted.
+        cmd = 'if not exist "' .. path .. '" mkdir "' .. path .. '"'
+    else
+        cmd = 'mkdir -p "' .. path .. '"'
+    end
+    local ok = os.execute(cmd)
+    return ok == true or ok == 0
+end
+
+function JOURNAL.readText(path)
+    local f = io.open(path, "r")
+    if not f then return nil end
+    local s = f:read("*all")
+    f:close()
+    return s
+end
+
+-- Atomic write: write to tmp then rename. Returns true on success.
+function JOURNAL.writeText(path, content)
+    local tmp = path .. ".tmp"
+    local f, err = io.open(tmp, "w")
+    if not f then
+        print("[Journal] writeText open failed: " .. tostring(err))
+        return false
+    end
+    f:write(content)
+    f:close()
+    local ok, rerr = os.rename(tmp, path)
+    if not ok then
+        print("[Journal] writeText rename failed: " .. tostring(rerr))
+        os.remove(tmp)
+        return false
+    end
+    return true
+end
+
+function JOURNAL.copyBinary(srcPath, dstPath)
+    local src = io.open(srcPath, "rb")
+    if not src then return false end
+    local data = src:read("*all")
+    src:close()
+    local dst = io.open(dstPath, "wb")
+    if not dst then return false end
+    dst:write(data)
+    dst:close()
+    return true
+end
+
+function JOURNAL.fileExists(path)
+    local f = io.open(path, "rb")
+    if f then f:close(); return true end
+    return false
+end
+
+---------------------------------------------------------------
+-- Date / timestamp
+
+function JOURNAL.today()
+    return os.date("%Y-%m-%d")
+end
+
+function JOURNAL.nowStamp()
+    return os.date("%Y%m%d_%H%M%S")
+end
+
+---------------------------------------------------------------
+-- Logging (single prefix for easy grep)
+
+function JOURNAL.log(msg)
+    print("[Journal] " .. tostring(msg))
+end
+
+---------------------------------------------------------------
+-- Initialize required directories. Safe to call repeatedly.
+function JOURNAL.ensureLayout()
+    if not JOURNAL.isEnabled() then return false end
+    local root = JOURNAL.root()
+    if not JOURNAL.ensureDir(root) then
+        JOURNAL.log("ensureDir failed for root: " .. root)
+        return false
+    end
+    JOURNAL.ensureDir(JOURNAL.bannerRoot())
+    JOURNAL.ensureDir(JOURNAL.screenshotRoot())
+    return true
+end

--- a/Themes/Rebirth/Scripts/50 JournalMarkdown.lua
+++ b/Themes/Rebirth/Scripts/50 JournalMarkdown.lua
@@ -1,0 +1,198 @@
+-- Journal: markdown parse / merge / write
+-- Spec: Docs/Journal.md §3 (format), §4 (merge strategy).
+
+JOURNAL = JOURNAL or {}
+JOURNAL.md = {}
+
+---------------------------------------------------------------
+-- Section model:
+--   A section = one song entry.
+--   - heading   : "# <title>"  (line starting with `#` followed by space)
+--   - bannerLn  : auto-managed, pattern `^%!%[%[.*banners/.*%]%]`
+--   - tagLine   : auto-managed, line that starts with `#Etterna/` (or the user's tag prefix)
+--   - body      : everything else (memos, screenshots, user heading, etc.) — untouched
+--
+-- Non-section prefix (lines before the first `# ` heading) = preserved as-is.
+
+local BANNER_LINE_PATTERN = "^%!%[%[.-banners/"        -- `![[.../banners/...]]`
+local TAG_LINE_PATTERN    = "^#Etterna[/%w]"           -- `#Etterna/...`
+local HEADING_PATTERN     = "^# (.+)$"                 -- top-level heading only
+
+---------------------------------------------------------------
+-- Parse .md text into { preface, sections = [{title, lines}, ...] }
+
+function JOURNAL.md.parse(text)
+    local doc = { preface = {}, sections = {} }
+    if not text or text == "" then return doc end
+
+    local current = nil
+    for line in (text .. "\n"):gmatch("([^\n]*)\n") do
+        local title = line:match(HEADING_PATTERN)
+        if title then
+            current = { title = title, lines = { line } }
+            doc.sections[#doc.sections + 1] = current
+        elseif current then
+            current.lines[#current.lines + 1] = line
+        else
+            doc.preface[#doc.preface + 1] = line
+        end
+    end
+    return doc
+end
+
+---------------------------------------------------------------
+-- Within a section's `lines` array, find index of banner / tag lines.
+-- Returns (bannerIdx or nil, tagIdx or nil). Search only first ~8 lines
+-- to avoid matching user's own `#` tags buried deep in memo body.
+
+local function locateManagedLines(lines)
+    local bannerIdx, tagIdx = nil, nil
+    local limit = math.min(#lines, 8)
+    for i = 2, limit do  -- skip heading at [1]
+        local l = lines[i]
+        if not bannerIdx and l:match(BANNER_LINE_PATTERN) then
+            bannerIdx = i
+        elseif not tagIdx and l:match(TAG_LINE_PATTERN) then
+            tagIdx = i
+        end
+    end
+    return bannerIdx, tagIdx
+end
+
+---------------------------------------------------------------
+-- Build a fresh section for a newly-seen song.
+-- info = { title, bannerPath or nil, tags = {} or nil }
+
+function JOURNAL.md.newSection(info)
+    local lines = { "# " .. info.title, "" }
+    if info.bannerPath and info.bannerPath ~= "" then
+        lines[#lines + 1] = "![[" .. info.bannerPath .. "|128]]"
+        lines[#lines + 1] = ""
+    end
+    if info.tags and #info.tags > 0 then
+        lines[#lines + 1] = JOURNAL.md.formatTagLine(info.tags)
+        lines[#lines + 1] = ""
+    end
+    return { title = info.title, lines = lines }
+end
+
+---------------------------------------------------------------
+-- Format tag list as single space-separated line.
+function JOURNAL.md.formatTagLine(tags)
+    local parts = {}
+    for _, t in ipairs(tags) do
+        parts[#parts + 1] = "#" .. t
+    end
+    return table.concat(parts, " ")
+end
+
+---------------------------------------------------------------
+-- Sync managed lines in an existing section.
+-- bannerPath / tags may be nil (leave unchanged).
+function JOURNAL.md.syncManagedLines(section, bannerPath, tags)
+    local bannerIdx, tagIdx = locateManagedLines(section.lines)
+
+    if bannerPath and bannerPath ~= "" then
+        local newLn = "![[" .. bannerPath .. "|128]]"
+        if bannerIdx then
+            section.lines[bannerIdx] = newLn
+        else
+            -- insert after heading + blank
+            table.insert(section.lines, 2, "")
+            table.insert(section.lines, 2, newLn)
+        end
+    end
+
+    if tags then
+        local newLn = JOURNAL.md.formatTagLine(tags)
+        -- tag line is intentionally empty if no tags — keep user's manual tags out of our scope
+        if newLn == "" then
+            if tagIdx then
+                table.remove(section.lines, tagIdx)
+            end
+        else
+            if tagIdx then
+                section.lines[tagIdx] = newLn
+            else
+                -- insert after banner area (or after heading if no banner)
+                local insertAt = (bannerIdx or 1) + 1
+                -- skip trailing blank
+                while section.lines[insertAt] == "" and insertAt < #section.lines do
+                    insertAt = insertAt + 1
+                end
+                table.insert(section.lines, insertAt, newLn)
+                table.insert(section.lines, insertAt + 1, "")
+            end
+        end
+    end
+end
+
+---------------------------------------------------------------
+-- Serialize doc back to text.
+
+function JOURNAL.md.serialize(doc)
+    local buf = {}
+    for _, l in ipairs(doc.preface) do buf[#buf + 1] = l end
+    for _, s in ipairs(doc.sections) do
+        for _, l in ipairs(s.lines) do buf[#buf + 1] = l end
+    end
+    -- trim duplicate trailing blanks
+    while #buf > 0 and buf[#buf] == "" do buf[#buf] = nil end
+    buf[#buf + 1] = ""  -- single trailing newline
+    return table.concat(buf, "\n")
+end
+
+---------------------------------------------------------------
+-- Index sections by title for fast lookup
+function JOURNAL.md.indexByTitle(doc)
+    local idx = {}
+    for i, s in ipairs(doc.sections) do idx[s.title] = i end
+    return idx
+end
+
+---------------------------------------------------------------
+-- Append a dated memo line to the given section.
+-- If today's entry already exists, append to end of today's block.
+-- Otherwise append `* YYYY-MM-DD <text>` at end of section.
+function JOURNAL.md.appendMemo(section, text)
+    local today = JOURNAL.today()
+    local line = "* " .. today .. " " .. text
+    -- find last blank then append
+    local insertAt = #section.lines
+    while insertAt > 1 and section.lines[insertAt] == "" do
+        insertAt = insertAt - 1
+    end
+    table.insert(section.lines, insertAt + 1, line)
+    table.insert(section.lines, insertAt + 2, "")
+end
+
+---------------------------------------------------------------
+-- Attach a screenshot link under today's entry (or create today's entry first).
+function JOURNAL.md.attachScreenshot(section, relPath)
+    local today = JOURNAL.today()
+    local todayLn = "* " .. today
+    -- find today's entry (any line starting with `* YYYY-MM-DD`, YYYY-MM-DD = today)
+    local idx = nil
+    for i = 1, #section.lines do
+        local l = section.lines[i]
+        if l:find("^%* " .. today) then
+            idx = i
+        end
+    end
+    local attach = "  [[" .. relPath .. "]]"
+    if idx then
+        -- insert after the last contiguous block belonging to today's entry
+        local insertAt = idx + 1
+        while insertAt <= #section.lines do
+            local l = section.lines[insertAt]
+            if l:sub(1, 2) == "* " or l:match(HEADING_PATTERN) then break end
+            insertAt = insertAt + 1
+        end
+        table.insert(section.lines, insertAt, attach)
+    else
+        -- create today's stub, then attach under it
+        JOURNAL.md.appendMemo(section, "")
+        -- appendMemo inserted "* today " + trailing "" at end; attach goes right before trailing blank
+        table.insert(section.lines, #section.lines, attach)
+    end
+end

--- a/Themes/Rebirth/Scripts/50 JournalPack.lua
+++ b/Themes/Rebirth/Scripts/50 JournalPack.lua
@@ -1,0 +1,137 @@
+-- Journal: top-level pack markdown generator (ties banner + tags + markdown)
+-- Spec: Docs/Journal.md §3, §4.
+
+JOURNAL = JOURNAL or {}
+JOURNAL.pack = {}
+
+---------------------------------------------------------------
+-- Get Song's directory name (last path segment of song dir, stable identifier).
+
+local function songDirName(song)
+    if not song or not song.GetSongDir then return "_" end
+    local d = song:GetSongDir()
+    if not d or d == "" then return "_" end
+    -- strip trailing slash
+    d = d:gsub("[/\\]$", "")
+    -- take last segment
+    local seg = d:match("([^/\\]+)$")
+    return seg or d
+end
+
+---------------------------------------------------------------
+-- Display title for heading. Falls back gracefully.
+
+local function songTitle(song)
+    if not song then return "" end
+    if song.GetDisplayMainTitle then
+        local t = song:GetDisplayMainTitle()
+        if t and t ~= "" then return t end
+    end
+    if song.GetMainTitle then
+        local t = song:GetMainTitle()
+        if t and t ~= "" then return t end
+    end
+    return songDirName(song)
+end
+
+---------------------------------------------------------------
+-- Group songs by group (pack) name.
+-- Returns map: packName -> { [songDirName] = songObj, ... }
+
+local function collectByPack()
+    local map = {}
+    if not SONGMAN or not SONGMAN.GetAllSongs then return map end
+    local all = SONGMAN:GetAllSongs()
+    for _, s in ipairs(all) do
+        local grp = s.GetGroupName and s:GetGroupName() or "Unknown"
+        map[grp] = map[grp] or {}
+        map[grp][songDirName(s)] = s
+    end
+    return map
+end
+JOURNAL.pack.collectByPack = collectByPack
+
+---------------------------------------------------------------
+-- Regenerate / update .md for a single pack. Preserves user memos.
+-- songs = { [songDirName] = songObj, ... }
+-- Returns (newSectionCount, updatedSectionCount).
+
+function JOURNAL.pack.regenerate(packName, songs)
+    local path = JOURNAL.packMarkdownPath(packName)
+    local existing = JOURNAL.readText(path) or ""
+    local doc = JOURNAL.md.parse(existing)
+    local byTitle = JOURNAL.md.indexByTitle(doc)
+
+    local added, updated = 0, 0
+
+    -- Stable order: sort song dir names
+    local dirs = {}
+    for k in pairs(songs) do dirs[#dirs + 1] = k end
+    table.sort(dirs)
+
+    for _, dir in ipairs(dirs) do
+        local song = songs[dir]
+        local title = songTitle(song)
+        local bannerRel = JOURNAL.banner.copyFor(song, packName, dir)
+        local tags = JOURNAL.tags.get(packName, dir)
+
+        local idx = byTitle[title]
+        if idx then
+            -- Existing section: sync managed lines only.
+            JOURNAL.md.syncManagedLines(doc.sections[idx], bannerRel, tags)
+            updated = updated + 1
+        else
+            -- New section: append fresh template.
+            local section = JOURNAL.md.newSection({
+                title = title,
+                bannerPath = bannerRel,
+                tags = tags,
+            })
+            doc.sections[#doc.sections + 1] = section
+            byTitle[title] = #doc.sections
+            added = added + 1
+        end
+    end
+
+    local text = JOURNAL.md.serialize(doc)
+    JOURNAL.writeText(path, text)
+    return added, updated
+end
+
+---------------------------------------------------------------
+-- Full regenerate across all packs. Called on DFRFinished.
+
+function JOURNAL.pack.regenerateAll()
+    if not JOURNAL.isEnabled() then return end
+    if not JOURNAL.ensureLayout() then
+        JOURNAL.log("ensureLayout failed; aborting regenerateAll")
+        return
+    end
+    JOURNAL.tags.load()
+
+    local t0 = GetTimeSinceStart and GetTimeSinceStart() or 0
+    local byPack = collectByPack()
+    local packCount, addedTotal, updatedTotal = 0, 0, 0
+    for packName, songs in pairs(byPack) do
+        local a, u = JOURNAL.pack.regenerate(packName, songs)
+        packCount = packCount + 1
+        addedTotal = addedTotal + a
+        updatedTotal = updatedTotal + u
+    end
+    local t1 = GetTimeSinceStart and GetTimeSinceStart() or 0
+    JOURNAL.log(string.format(
+        "regenerateAll: %d packs, +%d new sections, %d updated (%.2fs)",
+        packCount, addedTotal, updatedTotal, t1 - t0
+    ))
+end
+
+---------------------------------------------------------------
+-- Register MessageManager hook: regenerate on DFRFinished (and once on boot).
+
+local function registerHook()
+    if not MESSAGEMAN then return end
+    -- MessageCommand-style handlers expect an actor; we use a global listener.
+    -- The ScreenSelectMusic overlay will also trigger manual regen on demand.
+end
+
+registerHook()

--- a/Themes/Rebirth/Scripts/50 JournalScreenshot.lua
+++ b/Themes/Rebirth/Scripts/50 JournalScreenshot.lua
@@ -1,0 +1,87 @@
+-- Journal: screenshot auto-attach.
+-- Hooks `ScreenshotSaved` broadcast (from StepMania::SaveScreenshot in C++).
+-- Copies the image into <Root>/screenshots/ with a collision-free name and
+-- appends a `[[path]]` link to the current song's today-entry.
+-- Spec: Docs/Journal.md §7.
+
+JOURNAL = JOURNAL or {}
+JOURNAL.screenshot = {}
+
+---------------------------------------------------------------
+-- Resolve the absolute on-disk source path of a just-saved screenshot.
+-- C++ Path parameter is VFS-relative, e.g. "Screenshots/screen001.png".
+-- We need to resolve it to the OS path. RageFileManager exposes
+-- ResolvePath via MemoryDriver but not directly to Lua; instead we use
+-- PROFILEMAN or the documented convention: Save/<Path>.
+
+local function resolveSourcePath(path)
+    if not path or path == "" then return nil end
+    -- Etterna root is usually Etterna install dir OR Save dir. Screenshots
+    -- always go under Save/. PROFILEMAN:GetStatsPrefix() exposes Save dir root.
+    local saveDir = nil
+    if PROFILEMAN and PROFILEMAN.GetStatsPrefix then
+        saveDir = PROFILEMAN:GetStatsPrefix()  -- not ideal, but often usable
+    end
+    -- Fallback: use relative; io.open called from Etterna cwd will find "Save/..."
+    -- prefix.
+    return "Save/" .. path
+end
+
+---------------------------------------------------------------
+-- Main handler
+
+function JOURNAL.screenshot.handle(fileName, path)
+    if not JOURNAL.isEnabled() then return end
+    if not GAMESTATE then return end
+    local song = GAMESTATE:GetCurrentSong()
+    if not song then
+        -- No song context (e.g. title screen) — keep original, no attach.
+        return
+    end
+    if not JOURNAL.ensureLayout() then return end
+
+    local pack = song.GetGroupName and song:GetGroupName() or "Unknown"
+    local songDir = song.GetSongDir and song:GetSongDir() or ""
+    songDir = songDir:gsub("[/\\]$", "")
+    local seg = songDir:match("([^/\\]+)$") or songDir
+    local title = (song.GetDisplayMainTitle and song:GetDisplayMainTitle()) or
+                  (song.GetMainTitle and song:GetMainTitle()) or seg
+
+    -- ext from fileName
+    local ext = fileName:match("%.([%w]+)$") or "png"
+
+    -- Compute source path. C++ returns FileName (basename) + Path (VFS). The
+    -- simplest reliable approach: read via io.open relative to cwd.
+    local src = resolveSourcePath(path)
+    if not src or not JOURNAL.fileExists(src) then
+        JOURNAL.log("screenshot source not found: " .. tostring(src))
+        return
+    end
+
+    local dstName = JOURNAL.screenshotName(pack, seg, ext)
+    local dstAbs = JOURNAL.joinPath(JOURNAL.screenshotRoot(), dstName)
+    if not JOURNAL.copyBinary(src, dstAbs) then
+        JOURNAL.log("screenshot copy failed to " .. dstAbs)
+        return
+    end
+
+    local relPath = JOURNAL.cfg().screenshotDir .. "/" .. dstName
+
+    -- Append link to today's memo
+    local mdPath = JOURNAL.packMarkdownPath(pack)
+    local existing = JOURNAL.readText(mdPath) or ""
+    local doc = JOURNAL.md.parse(existing)
+    local idx = JOURNAL.md.indexByTitle(doc)[title]
+    local section
+    if idx then
+        section = doc.sections[idx]
+    else
+        local banner = JOURNAL.banner.copyFor(song, pack, seg)
+        local tags = JOURNAL.tags.get(pack, seg)
+        section = JOURNAL.md.newSection({ title = title, bannerPath = banner, tags = tags })
+        doc.sections[#doc.sections + 1] = section
+    end
+    JOURNAL.md.attachScreenshot(section, relPath)
+    JOURNAL.writeText(mdPath, JOURNAL.md.serialize(doc))
+    JOURNAL.log("attached screenshot to " .. title)
+end

--- a/Themes/Rebirth/Scripts/50 JournalTags.lua
+++ b/Themes/Rebirth/Scripts/50 JournalTags.lua
@@ -1,0 +1,246 @@
+-- Journal: tags.json persistence
+-- Schema (Docs/Journal.md §6):
+--   { defined = {tag, ...}, assigned = { ["pack/song"] = {tag, ...} } }
+
+JOURNAL = JOURNAL or {}
+JOURNAL.tags = {}
+
+local DEFAULT_DEFINED = {
+    "Etterna/4KEY/Jumpstream",
+    "Etterna/4KEY/Handstream",
+    "Etterna/4KEY/Chordjack",
+    "Etterna/4KEY/Stream",
+    "Etterna/4KEY/Technical",
+    "Etterna/4KEY/Jack",
+    "Etterna/4KEY/Stamina",
+    "Etterna/4KEY/LN",
+}
+
+---------------------------------------------------------------
+-- Minimal JSON encode/decode (sufficient for our flat schema).
+-- For production maps with nested tables of strings, this works; if we ever
+-- need richer structures, swap in a proper lib.
+
+local json = {}
+
+local function escape_str(s)
+    return (s:gsub("[\\\"\n\r\t]", {
+        ["\\"] = "\\\\", ['"'] = '\\"',
+        ["\n"] = "\\n", ["\r"] = "\\r", ["\t"] = "\\t",
+    }))
+end
+
+local function encode_value(v, indent)
+    local t = type(v)
+    if t == "string" then
+        return '"' .. escape_str(v) .. '"'
+    elseif t == "number" or t == "boolean" then
+        return tostring(v)
+    elseif t == "nil" then
+        return "null"
+    elseif t == "table" then
+        -- array if sequential 1..n with no gaps
+        local n = #v
+        local isArr = (n > 0)
+        for k in pairs(v) do
+            if type(k) ~= "number" or k ~= math.floor(k) or k < 1 or k > n then
+                isArr = false; break
+            end
+        end
+        local pad = string.rep("  ", indent or 0)
+        local padInner = string.rep("  ", (indent or 0) + 1)
+        if isArr then
+            if n == 0 then return "[]" end
+            local parts = {}
+            for i = 1, n do parts[i] = padInner .. encode_value(v[i], (indent or 0) + 1) end
+            return "[\n" .. table.concat(parts, ",\n") .. "\n" .. pad .. "]"
+        else
+            local keys = {}
+            for k in pairs(v) do keys[#keys + 1] = k end
+            table.sort(keys, function(a, b) return tostring(a) < tostring(b) end)
+            if #keys == 0 then return "{}" end
+            local parts = {}
+            for _, k in ipairs(keys) do
+                parts[#parts + 1] = padInner .. '"' .. escape_str(tostring(k)) .. '": ' .. encode_value(v[k], (indent or 0) + 1)
+            end
+            return "{\n" .. table.concat(parts, ",\n") .. "\n" .. pad .. "}"
+        end
+    end
+    return "null"
+end
+json.encode = function(v) return encode_value(v, 0) end
+
+-- Decode: minimal recursive-descent. Enough for round-tripping encode().
+local pos
+local function skip_ws(s)
+    while pos <= #s do
+        local c = s:sub(pos, pos)
+        if c == " " or c == "\t" or c == "\n" or c == "\r" then pos = pos + 1 else break end
+    end
+end
+local decode_value
+local function decode_string(s)
+    assert(s:sub(pos, pos) == '"'); pos = pos + 1
+    local out = {}
+    while pos <= #s do
+        local c = s:sub(pos, pos)
+        if c == '"' then pos = pos + 1; return table.concat(out) end
+        if c == "\\" then
+            local e = s:sub(pos + 1, pos + 1)
+            pos = pos + 2
+            if e == "n" then out[#out + 1] = "\n"
+            elseif e == "t" then out[#out + 1] = "\t"
+            elseif e == "r" then out[#out + 1] = "\r"
+            elseif e == "\"" then out[#out + 1] = "\""
+            elseif e == "\\" then out[#out + 1] = "\\"
+            elseif e == "/" then out[#out + 1] = "/"
+            else out[#out + 1] = e end
+        else
+            out[#out + 1] = c; pos = pos + 1
+        end
+    end
+    error("unterminated string")
+end
+local function decode_array(s)
+    pos = pos + 1  -- '['
+    skip_ws(s)
+    local arr = {}
+    if s:sub(pos, pos) == "]" then pos = pos + 1; return arr end
+    while true do
+        skip_ws(s)
+        arr[#arr + 1] = decode_value(s)
+        skip_ws(s)
+        local c = s:sub(pos, pos)
+        if c == "," then pos = pos + 1
+        elseif c == "]" then pos = pos + 1; return arr
+        else error("expected , or ]") end
+    end
+end
+local function decode_object(s)
+    pos = pos + 1  -- '{'
+    skip_ws(s)
+    local obj = {}
+    if s:sub(pos, pos) == "}" then pos = pos + 1; return obj end
+    while true do
+        skip_ws(s)
+        local k = decode_string(s)
+        skip_ws(s)
+        assert(s:sub(pos, pos) == ":", "expected :"); pos = pos + 1
+        skip_ws(s)
+        obj[k] = decode_value(s)
+        skip_ws(s)
+        local c = s:sub(pos, pos)
+        if c == "," then pos = pos + 1
+        elseif c == "}" then pos = pos + 1; return obj
+        else error("expected , or }") end
+    end
+end
+decode_value = function(s)
+    skip_ws(s)
+    local c = s:sub(pos, pos)
+    if c == '"' then return decode_string(s) end
+    if c == "{" then return decode_object(s) end
+    if c == "[" then return decode_array(s) end
+    if c == "t" and s:sub(pos, pos + 3) == "true" then pos = pos + 4; return true end
+    if c == "f" and s:sub(pos, pos + 4) == "false" then pos = pos + 5; return false end
+    if c == "n" and s:sub(pos, pos + 3) == "null" then pos = pos + 4; return nil end
+    -- number
+    local numStr = s:match("^(%-?%d+%.?%d*[eE]?[+%-]?%d*)", pos)
+    if numStr and numStr ~= "" then pos = pos + #numStr; return tonumber(numStr) end
+    error("unexpected char at pos " .. pos .. ": " .. c)
+end
+json.decode = function(str)
+    pos = 1
+    return decode_value(str)
+end
+
+JOURNAL.tags.json = json  -- exposed for other modules / tests
+
+---------------------------------------------------------------
+-- Keys
+
+local function songKey(packName, songDir)
+    return packName .. "/" .. songDir
+end
+JOURNAL.tags.songKey = songKey
+
+---------------------------------------------------------------
+-- Cache (in-memory mirror of tags.json)
+
+local cached = nil
+
+function JOURNAL.tags.load()
+    if not JOURNAL.isEnabled() then return nil end
+    local path = JOURNAL.tagsPath()
+    local text = JOURNAL.readText(path)
+    if not text or text == "" then
+        cached = { defined = DEFAULT_DEFINED, assigned = {} }
+        JOURNAL.tags.save()
+        return cached
+    end
+    local ok, data = pcall(json.decode, text)
+    if not ok or type(data) ~= "table" then
+        JOURNAL.log("tags.json parse failed, using defaults: " .. tostring(data))
+        cached = { defined = DEFAULT_DEFINED, assigned = {} }
+        return cached
+    end
+    data.defined = data.defined or {}
+    data.assigned = data.assigned or {}
+    cached = data
+    return cached
+end
+
+function JOURNAL.tags.save()
+    if not cached then return false end
+    if not JOURNAL.isEnabled() then return false end
+    return JOURNAL.writeText(JOURNAL.tagsPath(), json.encode(cached))
+end
+
+function JOURNAL.tags.get(packName, songDir)
+    if not cached then JOURNAL.tags.load() end
+    if not cached then return {} end
+    return cached.assigned[songKey(packName, songDir)] or {}
+end
+
+function JOURNAL.tags.set(packName, songDir, tagList)
+    if not cached then JOURNAL.tags.load() end
+    if not cached then return false end
+    local key = songKey(packName, songDir)
+    if tagList and #tagList > 0 then
+        cached.assigned[key] = tagList
+    else
+        cached.assigned[key] = nil
+    end
+    return JOURNAL.tags.save()
+end
+
+function JOURNAL.tags.defined()
+    if not cached then JOURNAL.tags.load() end
+    if not cached then return {} end
+    return cached.defined
+end
+
+function JOURNAL.tags.addDefined(tag)
+    if not cached then JOURNAL.tags.load() end
+    if not cached then return false end
+    for _, t in ipairs(cached.defined) do
+        if t == tag then return true end
+    end
+    cached.defined[#cached.defined + 1] = tag
+    return JOURNAL.tags.save()
+end
+
+function JOURNAL.tags.toggle(packName, songDir, tag)
+    local cur = JOURNAL.tags.get(packName, songDir)
+    local found = nil
+    for i, t in ipairs(cur) do
+        if t == tag then found = i; break end
+    end
+    if found then
+        table.remove(cur, found)
+    else
+        cur[#cur + 1] = tag
+    end
+    JOURNAL.tags.set(packName, songDir, cur)
+    return not found  -- returns true if tag was ADDED
+end

--- a/src/Etterna/Globals/StepMania.cpp
+++ b/src/Etterna/Globals/StepMania.cpp
@@ -1233,6 +1233,13 @@ StepMania::SaveScreenshot(const std::string& Dir,
 
 	SCREENMAN->PlayScreenshotSound();
 
+	// etterna-journal: notify Lua so Journal overlay can attach the screenshot
+	// to the current song's daily memo.
+	Message msg("ScreenshotSaved");
+	msg.SetParam("FileName", FileName);
+	msg.SetParam("Path", Path);
+	MESSAGEMAN->Broadcast(msg);
+
 	return FileName;
 }
 


### PR DESCRIPTION
…t attach

On DFRFinished, regenerate per-pack `.md` files at a user-configured vault path (default off). Existing sections are preserved except for banner/tag lines, which are kept in sync. Banners are copied into `<root>/banners/` with `<pack>__<song>.<ext>` names.

Song-select hotkeys (Ctrl+Shift+C for dated memos via ScreenTextEntry, Ctrl+Shift+T for a defined-tag cycle toggle) append to the current song's section.

PrintScreen fires a new `ScreenshotSaved` broadcast from SaveScreenshot; the journal then copies the image to `<root>/screenshots/` with a `<pack>__<song>__<ts>.<ext>` name and appends a `[[...]]` link under the current day's memo.

Config persists via `create_setting` (`Save/Rebirth/journal.lua`); no PrefsManager changes. Design: `Docs/Journal.md`. Verification checklist: `Docs/Journal_Verification.md`.