### PR TITLE
Added clicking cdtitle filters by chart author

### DIFF
--- a/Themes/Rebirth/BGAnimations/ScreenSelectMusic decorations/generalPages/general.lua
+++ b/Themes/Rebirth/BGAnimations/ScreenSelectMusic decorations/generalPages/general.lua
@@ -745,7 +745,6 @@ t[#t+1] = UIElements.SpriteButton(1, 1, nil) .. {
             local theGroupThatTheAforementionedSongWasInBeforeTheWheelWasReset = self.group
             w:playcommand("ApplyFilter")
             w:playcommand("FindSong", {song = theSongThatWasSelectedBeforeTheWheelWasReset, group = theGroupThatTheAforementionedSongWasInBeforeTheWheelWasReset})
-
         end
     end
 }

--- a/Themes/Rebirth/BGAnimations/ScreenSelectMusic decorations/generalPages/general.lua
+++ b/Themes/Rebirth/BGAnimations/ScreenSelectMusic decorations/generalPages/general.lua
@@ -669,6 +669,7 @@ t[#t+1] = UIElements.SpriteButton(1, 1, nil) .. {
     SetCommand = function(self, params)
         self:finishtweening()
         self.song = params.song
+        self.group = params.group
         if params.song then
             self:diffusealpha(1)
 
@@ -728,6 +729,25 @@ t[#t+1] = UIElements.SpriteButton(1, 1, nil) .. {
         if self:IsInvisible() then return end
         TOOLTIP:Hide()
     end,
+    MouseDownCommand = function(self)
+        local scr = SCREENMAN:GetTopScreen()
+        local w = scr:GetChild("WheelFile")
+        local author = string.lower(self.song:GetOrTryAtLeastToGetSimfileAuthor())
+        local currentSearch = WHEELDATA:GetSearch()
+        if currentSearch.Author == author then --clicking on the cdtitle again resets the filter
+            WHEELDATA:ResetActiveFilterMetadata()
+            MESSAGEMAN:Broadcast("SetSearchFilter", getEmptyActiveFilterMetadata())
+            w:sleep(0.01):queuecommand("ApplyFilter")
+        elseif w ~= nil and author ~= nil then
+            WHEELDATA:SetSearch({Author = author})
+            MESSAGEMAN:Broadcast("SetSearchFilter", {Author = author})
+            local theSongThatWasSelectedBeforeTheWheelWasReset = self.song
+            local theGroupThatTheAforementionedSongWasInBeforeTheWheelWasReset = self.group
+            w:playcommand("ApplyFilter")
+            w:playcommand("FindSong", {song = theSongThatWasSelectedBeforeTheWheelWasReset, group = theGroupThatTheAforementionedSongWasInBeforeTheWheelWasReset})
+
+        end
+    end
 }
 
 t[#t+1] = createStatLines()

--- a/Themes/Rebirth/BGAnimations/playerInfoFrame/searchfilter.lua
+++ b/Themes/Rebirth/BGAnimations/playerInfoFrame/searchfilter.lua
@@ -140,8 +140,8 @@ local function upperSection()
     }
 
     -- used to actually search for things in WheelDataManager
-    -- get an empty one because we dont want to init with a search entry
-    searchentry = getEmptyActiveFilterMetadata()
+    -- set searchentry to the current filters so the search tab reflects the wheel
+    searchentry = WHEELDATA:GetSearch() or getEmptyActiveFilterMetadata()
 
     -- search on the wheel immediately based on the text entered
     local function searchNow()
@@ -417,43 +417,10 @@ local function upperSection()
             local snm = SCREENMAN:GetTopScreen():GetName()
             local anm = self:GetName()
 
-            local function updateFields()
-                -- im just gonna.. update all the fields... for your information....
-                -- this is ... the ... worst possible way .... but also the best....
-                if focusedField == 1 then
-                    self:GetDescendant("RowFrame_2", "RowInput"):settext(searchentry.Title)
-                    self:GetDescendant("RowFrame_3", "RowInput"):settext(searchentry.Subtitle)
-                    self:GetDescendant("RowFrame_4", "RowInput"):settext(searchentry.Artist)
-                    self:GetDescendant("RowFrame_5", "RowInput"):settext(searchentry.Author)
-                    self:GetDescendant("RowFrame_6", "RowInput"):settext(searchentry.Group)
-                else
-                    -- backwards engineering the any search field
-                    -- for the kids who have big brains and want bigger brains
-                    local finalstr = ""
-                    if searchentry.Title ~= "" or searchentry.Subtitle ~= "" or searchentry.Artist ~= "" or searchentry.Author ~= "" or searchentry.Group ~= "" then
-                        if searchentry.Title ~= "" then
-                            finalstr = finalstr .. "title="..searchentry.Title..";"
-                        end
-                        if searchentry.Subtitle ~= "" then
-                            finalstr = finalstr .. "subtitle="..searchentry.Subtitle..";"
-                        end
-                        if searchentry.Artist ~= "" then
-                            finalstr = finalstr .. "artist="..searchentry.Artist..";"
-                        end
-                        if searchentry.Author ~= "" then
-                            finalstr = finalstr .. "author="..searchentry.Author..";"
-                        end
-                        if searchentry.Group ~= "" then
-                            finalstr = finalstr .. "group="..searchentry.Group..";"
-                        end 
-                    end
-                    self:GetDescendant("RowFrame_1", "RowInput"):settext(finalstr)
-                end
-            end
             -- update all the search fields
-            updateFields()
+            self:playcommand("UpdateFields")
             focusedField = 2
-            updateFields()
+            self:playcommand("UpdateFields")
             focusedField = 1
             -- it works
 
@@ -498,13 +465,48 @@ local function upperSection()
 
                             focusedChild:playcommand("Input", {delete = del, backspace = bs, char = char})
 
-                            updateFields()
+                            self:playcommand("UpdateFields")
                         end
                     end
                 end
             end)
             self:playcommand("UpdateSearchFocus")
         end,
+
+        UpdateFieldsCommand = function(self)
+            -- im just gonna.. update all the fields... for your information....
+            -- this is ... the ... worst possible way .... but also the best....
+            if focusedField == 1 then
+                self:GetDescendant("RowFrame_2", "RowInput"):settext(searchentry.Title)
+                self:GetDescendant("RowFrame_3", "RowInput"):settext(searchentry.Subtitle)
+                self:GetDescendant("RowFrame_4", "RowInput"):settext(searchentry.Artist)
+                self:GetDescendant("RowFrame_5", "RowInput"):settext(searchentry.Author)
+                self:GetDescendant("RowFrame_6", "RowInput"):settext(searchentry.Group)
+            else
+                -- backwards engineering the any search field
+                -- for the kids who have big brains and want bigger brains
+                local finalstr = ""
+                if searchentry.Title ~= "" or searchentry.Subtitle ~= "" or searchentry.Artist ~= "" or searchentry.Author ~= "" or searchentry.Group ~= "" then
+                    if searchentry.Title ~= "" then
+                        finalstr = finalstr .. "title="..searchentry.Title..";"
+                    end
+                    if searchentry.Subtitle ~= "" then
+                        finalstr = finalstr .. "subtitle="..searchentry.Subtitle..";"
+                    end
+                    if searchentry.Artist ~= "" then
+                        finalstr = finalstr .. "artist="..searchentry.Artist..";"
+                    end
+                    if searchentry.Author ~= "" then
+                        finalstr = finalstr .. "author="..searchentry.Author..";"
+                    end
+                    if searchentry.Group ~= "" then
+                        finalstr = finalstr .. "group="..searchentry.Group..";"
+                    end 
+                end
+                self:GetDescendant("RowFrame_1", "RowInput"):settext(finalstr)
+            end
+        end,
+
         PlayerInfoFrameTabSetMessageCommand = function(self, params)
             if params.tab and params.tab == "Search" then
                 if focusedField ~= 1 then
@@ -512,6 +514,19 @@ local function upperSection()
                     self:playcommand("UpdateSearchFocus")
                 end
             end
+        end,
+
+        SetSearchFilterMessageCommand = function(self, params)
+            searchentry.Title = params.Title or ""
+            searchentry.Subtitle = params.Subtitle or ""
+            searchentry.Artist = params.Artist or ""
+            searchentry.Author = params.Author or ""
+            searchentry.Group = params.Group or ""
+            --update all the fields
+            focusedField = 2
+            self:playcommand("UpdateFields")
+            focusedField = 1
+            self:playcommand("UpdateFields")
         end
     }
 

--- a/Themes/Rebirth/Scripts/10 WheelDataManager.lua
+++ b/Themes/Rebirth/Scripts/10 WheelDataManager.lua
@@ -152,7 +152,7 @@ function WHEELDATA.SetSearch(self, t)
     if t.ChartKey ~= nil then
         self.ActiveFilter.metadata.ChartKey = t.ChartKey:lower()
     else
-        self.ActiveFilter.metadata.ChartKEy = ""
+        self.ActiveFilter.metadata.ChartKey = ""
     end
     -- end
 end

--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/songsearch.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/songsearch.lua
@@ -116,6 +116,10 @@ local t = Def.ActorFrame {
 		end,
 		UpdateStringMessageCommand = function(self)
 			self:queuecommand("Set")
+		end,
+		SetSearchStringMessageCommand = function(self, params)
+			searchstring = params.searchstring or searchstring
+			MESSAGEMAN:Broadcast("UpdateString")
 		end
 	},
 	Def.Quad {

--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/songsearch.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/songsearch.lua
@@ -118,8 +118,11 @@ local t = Def.ActorFrame {
 			self:queuecommand("Set")
 		end,
 		SetSearchStringMessageCommand = function(self, params)
-			searchstring = params.searchstring or searchstring
-			MESSAGEMAN:Broadcast("UpdateString")
+			if params.searchstring then
+				searchstring = params.searchstring
+				lastsearchstring = searchstring --i dont like this
+				MESSAGEMAN:Broadcast("UpdateString")
+			end
 		end
 	},
 	Def.Quad {

--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/wifeTwirl.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/wifeTwirl.lua
@@ -880,9 +880,6 @@ t[#t + 1] = UIElements.SpriteButton(1, 1, nil) .. {
 	UpdateStringMessageCommand = function(self)
 		--if the searchstring is updated at all then we are no longer solely searching for the chart author,
 		--so we should reset
-		--actually theres an annoying case where this is run when the user enters the search tab but
-		--doesnt type anything, so the search is unchanged but clicked is still set to false
-		--lets just say its the users fault for entering the search tab for no reason
 		self.clicked = false
 	end
 }

--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/wifeTwirl.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/wifeTwirl.lua
@@ -780,6 +780,7 @@ t[#t + 1] = UIElements.SpriteButton(1, 1, nil) .. {
 	InitCommand = function(self)
 		self:xy(capWideScale(get43size(344), 364) + 50, capWideScale(get43size(345), 255))
 		self:halign(0.5):valign(1)
+		self.clicked = false
 	end,
 	CurrentStyleChangedMessageCommand = function(self)
 		self:playcommand("MortyFarts")
@@ -857,6 +858,21 @@ t[#t + 1] = UIElements.SpriteButton(1, 1, nil) .. {
 		if params.event == "DeviceButton_right mouse button" then
 			SCREENMAN:GetTopScreen():PauseSampleMusic()
 			MESSAGEMAN:Broadcast("MusicPauseToggled")
+
+		elseif params.event == "DeviceButton_left mouse button" then
+			local whee = SCREENMAN:GetTopScreen():GetMusicWheel()
+			local author = string.lower(self.song:GetOrTryAtLeastToGetSimfileAuthor())
+
+			if self.clicked then
+				whee:ReloadSongList()
+				MESSAGEMAN:Broadcast("SetSearchString", {searchstring = ""})
+				self.clicked = false
+			elseif whee ~= nil and author ~= nil then
+				local searchstring = "author=" .. author
+				whee:SongSearch(searchstring)
+				MESSAGEMAN:Broadcast("SetSearchString", {searchstring = searchstring})
+				self.clicked = true
+			end
 		end
 	end,
 }

--- a/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/wifeTwirl.lua
+++ b/Themes/Til Death/BGAnimations/ScreenSelectMusic decorations/wifeTwirl.lua
@@ -868,13 +868,23 @@ t[#t + 1] = UIElements.SpriteButton(1, 1, nil) .. {
 				MESSAGEMAN:Broadcast("SetSearchString", {searchstring = ""})
 				self.clicked = false
 			elseif whee ~= nil and author ~= nil then
+				local theSongThatWasSelectedBeforeTheWheelWasReset = self.song
 				local searchstring = "author=" .. author
 				whee:SongSearch(searchstring)
+				whee:SelectSong(theSongThatWasSelectedBeforeTheWheelWasReset)
 				MESSAGEMAN:Broadcast("SetSearchString", {searchstring = searchstring})
 				self.clicked = true
 			end
 		end
 	end,
+	UpdateStringMessageCommand = function(self)
+		--if the searchstring is updated at all then we are no longer solely searching for the chart author,
+		--so we should reset
+		--actually theres an annoying case where this is run when the user enters the search tab but
+		--doesnt type anything, so the search is unchanged but clicked is still set to false
+		--lets just say its the users fault for entering the search tab for no reason
+		self.clicked = false
+	end
 }
 
 t[#t + 1] = Def.Sprite {


### PR DESCRIPTION
'Til Death:
* Click on a cdtitle to search by the chart author. Search tab is updated accordingly
* Click a cdtitle again (without typing in the search tab) to remove the search filter from the wheel
* Typing in the search tab after clicking a cdtitle means the next cdtitle click will NOT remove the search filter, and will instead search for the chart author

Rebirth:
* Click on a cdtitle to search by the chart author. Search tab is updated accordingly. All other search fields are reset
* Click a cdtitle again (without updating the author field) to remove the search filter from the wheel
* Updating the author field in the search tab after clicking a cdtitle means the next cdtitle click will NOT remove the search filter, and will instead search for the chart author