### PR TITLE
Fix mouse right-click pasting user password into room name

### DIFF
--- a/src/Etterna/Screen/Network/ScreenNetRoom.cpp
+++ b/src/Etterna/Screen/Network/ScreenNetRoom.cpp
@@ -38,6 +38,7 @@ ScreenNetRoom::ScreenNetRoom()
 {
 	m_Rooms = nullptr;
 	m_iRoomPlace = 0;
+	ScreenTextEntry::s_sLastAnswer.clear();
 }
 
 void


### PR DESCRIPTION
Clear `s_sLastAnswer` when the Multiplayer main screen loads, which guarantees that whatever has been inputted in the previous screens does not persist when prompted to enter the room name in the Multiplayer screen.