### PR TITLE
Fix volume scale bug in rebirth perceptual binner

### DIFF
--- a/Themes/Rebirth/Scripts/10 AudioVisualizer.lua
+++ b/Themes/Rebirth/Scripts/10 AudioVisualizer.lua
@@ -256,8 +256,8 @@ local function perceptualBins(bars, fft, values, lastframevals, samplingRate, nf
             weight_sum = weight_sum + weight
         end
 
-        -- vaguely dBish plus dumb hacks to get a decent scale
-        val = aweight(freq) * 2 * math.log(1.0 + nrg * 10 * val / (nfftbins * weight_sum), 10)
+        -- vaguely dBish
+        val = aweight(freq) * 2 * math.log(1.0 + nrg * val / (nfftbins * weight_sum), 10)
 
         -- percentage of val to use for this frame
         -- sample rate and fft size independent


### PR DESCRIPTION
... I had no idea about 52a0870 ....

So one of the factors of 10 in here was just to boost the volume cause I had the game at half volume. At full gain the visualiser looks pretty much exactly how I meant it to, so nice coincidence that. This way looks way cooler. imo