### PR TITLE
Patch up Vulkan renderer inconsistencies pt. 1

### DIFF
--- a/.ci/generate_doc_configs.sh
+++ b/.ci/generate_doc_configs.sh
@@ -10,4 +10,4 @@ eval "$(luarocks path --bin)"
 
 # Generate Etterna CMake
 mkdir build && cd build
-cmake -G "Unix Makefiles" -DWITH_CRASHPAD=OFF -DOPENSSL_ROOT_DIR=~/toolchain/ -DBUILD_TESTS=FALSE -DBUILD_EXAMPLES=FALSE ..
+cmake -G "Unix Makefiles" -DWITH_CRASHPAD=OFF -DWITH_VULKAN=OFF -DOPENSSL_ROOT_DIR=~/toolchain/ -DBUILD_TESTS=FALSE -DBUILD_EXAMPLES=FALSE ..

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -172,7 +172,7 @@ jobs:
           echo "ETT_MAC_SYS_NAME=M1" >> $GITHUB_ENV
 
       - name: Generate CMake
-        run: mkdir main/build && cd main/build && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CRASHPAD=OFF -DBUILD_TESTS=FALSE -DBUILD_EXAMPLES=FALSE -G Ninja ..
+        run: mkdir main/build && cd main/build && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DWITH_CRASHPAD=OFF -DWITH_VULKAN=OFF -DBUILD_TESTS=FALSE -DBUILD_EXAMPLES=FALSE -G Ninja ..
 
       - name: Build Project
         run: cd main/build && ninja
@@ -391,7 +391,7 @@ jobs:
           echo "ETT_MAC_SYS_NAME=High-Sierra" >> $GITHUB_ENV
 
       - name: Generate CMake
-        run: mkdir main/build && cd main/build && cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DWITH_CRASHPAD=OFF -DBUILD_TESTS=FALSE -DBUILD_EXAMPLES=FALSE -DCMAKE_BUILD_TYPE=RelWithDebInfo -G Ninja ..
+        run: mkdir main/build && cd main/build && cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DWITH_CRASHPAD=OFF -DWITH_VULKAN=OFF -DBUILD_TESTS=FALSE -DBUILD_EXAMPLES=FALSE -DCMAKE_BUILD_TYPE=RelWithDebInfo -G Ninja ..
 
       - name: Build Project
         run: cd main/build && ninja

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(Etterna)
 # Project Compile Options
 set(WITH_CRASHPAD TRUE CACHE BOOL "Compile with Crash Handler (Requires depot_tools installed)")
 set(WITH_VULKAN TRUE CACHE BOOL "Compile Vulkan support (Requires Vulkan SDK to be installed and VULKAN_SDK environment variable to be set to SDK root dir)")
+set(WITH_VULKAN_LINUX_EXTRAS FALSE CACHE BOOL "Link additional Vulkan dependencies (fix for some Linux distros)")
 
 # Discord doesn't seem to provide Linux arm64 binaries...
 set(SUPPORT_DISCORD_SDK ON)
@@ -141,7 +142,7 @@ if(WITH_VULKAN)
         Vulkan::Vulkan
         Vulkan::shaderc_combined)
 
-    if(UNIX AND NOT APPLE)
+    if(WITH_VULKAN_LINUX_EXTRAS AND UNIX AND NOT APPLE)
         target_link_libraries(Etterna PRIVATE
             glslang
             MachineIndependent

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,18 @@ if(WITH_VULKAN)
     target_link_libraries(Etterna PRIVATE
         Vulkan::Vulkan
         Vulkan::shaderc_combined)
+
+    if(UNIX AND NOT APPLE)
+        target_link_libraries(Etterna PRIVATE
+            glslang
+            MachineIndependent
+            OSDependent
+            GenericCodeGen
+            SPIRV
+            glslang-default-resource-limits
+            SPIRV-Tools
+            SPIRV-Tools-opt)
+    endif()
 endif()
 
 string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _proc)

--- a/src/Etterna/Globals/StepMania.cpp
+++ b/src/Etterna/Globals/StepMania.cpp
@@ -29,9 +29,9 @@
 #include "RageUtil/Graphics/RageSurface_Load.h"
 #include "Etterna/Screen/Others/Screen.h"
 #include "Etterna/Globals/GameLoop.h"
-#include "RageUtil/Graphics/Display/Display.h"
 
 #if defined(WITH_VULKAN)
+#include "RageUtil/Graphics/Display/Display.h"
 #include "RageUtil/Graphics/RendererVK/RendererVK.h"
 #endif
 

--- a/src/RageUtil/CMakeLists.txt
+++ b/src/RageUtil/CMakeLists.txt
@@ -102,21 +102,21 @@ list(APPEND SMDATA_RAGE_GRAPHICS_HPP
   "Graphics/RageTextureID.h"
   "Graphics/RageTextureManager.h"
   "Graphics/RageTextureRenderTarget.h"
-
-  "Graphics/Display/CommandBatcher.h"
-  "Graphics/Display/DrawMode.h"
-  "Graphics/Display/MatrixState.h"
-  "Graphics/Display/RenderState.h"
-  "Graphics/Display/Display.h"
-  "Graphics/Display/Renderer.h"
-  "Graphics/Display/CompiledGeometry.h"
-  "Graphics/Display/RenderNode.h"
-  "Graphics/Display/Vertex.h"
-  "Graphics/Display/PipelineHandle.h"
 )
 
 if(WITH_VULKAN)
   list(APPEND SMDATA_RAGE_GRAPHICS_HPP
+    "Graphics/Display/CommandBatcher.h"
+    "Graphics/Display/DrawMode.h"
+    "Graphics/Display/MatrixState.h"
+    "Graphics/Display/RenderState.h"
+    "Graphics/Display/Display.h"
+    "Graphics/Display/Renderer.h"
+    "Graphics/Display/CompiledGeometry.h"
+    "Graphics/Display/RenderNode.h"
+    "Graphics/Display/Vertex.h"
+    "Graphics/Display/PipelineHandle.h"
+
     "Graphics/RendererVK/RendererVK.h"
     "Graphics/RendererVK/VkUtils.h"
     "Graphics/RendererVK/PersistentBuffer.h"

--- a/src/RageUtil/Graphics/Display/Display.cpp
+++ b/src/RageUtil/Graphics/Display/Display.cpp
@@ -44,6 +44,10 @@ DisplayAdapter::Display::BeginFrame()
 {
 	m_Window->Update();
 
+	if (!m_Renderer->IsReadyForRender()) {
+		return false;
+	}
+
 	m_Batcher.Clear();
 
 	m_RenderState.textureFiltering = true;
@@ -116,7 +120,11 @@ DisplayAdapter::Display::TryVideoMode(const VideoModeParams& p,
 	if (!m_IsInitDone) {
 		m_Renderer->InitializeRenderer(p);
 	} else {
-		m_Renderer->TryVideoMode(p);
+		try {
+			m_Renderer->TryVideoMode(p);
+		} catch (std::exception e) {
+			return std::string("Display::TryVideoMode() failed: ") + e.what();
+		}
 	}
 
 	ResolutionChanged();

--- a/src/RageUtil/Graphics/Display/Renderer.h
+++ b/src/RageUtil/Graphics/Display/Renderer.h
@@ -13,6 +13,7 @@ class Renderer
 	virtual ~Renderer() {}
 	virtual std::string GetApiDescription() const = 0;
 	virtual void InitializeRenderer(const VideoModeParams& p) = 0;
+	virtual bool IsReadyForRender() = 0;
 	virtual void OnRender(const ActualVideoModeParams* p,
 						  const CommandBatcher& batcher) = 0;
 	virtual bool IsD3DInternal() = 0;

--- a/src/RageUtil/Graphics/RendererVK/PipelineCache.cpp
+++ b/src/RageUtil/Graphics/RendererVK/PipelineCache.cpp
@@ -100,7 +100,8 @@ PipelineCache::CreateGraphicsPipeline(vk::raii::Device& device,
 								  vk::DynamicState::eDepthCompareOp,
 								  vk::DynamicState::eColorBlendEnableEXT,
 								  vk::DynamicState::eColorBlendEquationEXT,
-								  vk::DynamicState::eColorWriteMaskEXT };
+								  vk::DynamicState::eColorWriteMaskEXT,
+								  vk::DynamicState::eRasterizationSamplesEXT };
 
 	vk::PipelineDynamicStateCreateInfo dynamicState{};
 	dynamicState.dynamicStateCount =

--- a/src/RageUtil/Graphics/RendererVK/RendererVK.cpp
+++ b/src/RageUtil/Graphics/RendererVK/RendererVK.cpp
@@ -563,7 +563,9 @@ RendererVK::~RendererVK()
 		DestroyTexture(texture);
 	}
 
-	DestroyTexture(m_DepthTexture);
+	for (auto& texture : m_SwapchainDepthTextures) {
+		DestroyTexture(texture);
+	}
 
 	for (int i = 0; i < FramesInFlight; i++) {
 		m_VertexBuffer[i].Destroy();
@@ -709,7 +711,7 @@ RendererVK::InitVulkanState()
 	m_Device = vk::raii::Device(m_PhysicalDevice, deviceResult->device);
 
 	Locator::getLogger()->info("RendererVK: selected GPU: {}",
-								physicalDeviceResult->name);
+							   physicalDeviceResult->name);
 
 	m_GraphicsQueue = vk::raii::Queue(
 	  m_Device, deviceResult->get_queue(vkb::QueueType::graphics).value());
@@ -806,45 +808,53 @@ RendererVK::InitSwapchain(uint32_t width,
 	m_SwapchainExtent =
 	  vk::Extent2D(vkbSwapchain.extent.width, vkbSwapchain.extent.height);
 
-	m_DepthTexture.width = vkbSwapchain.extent.width;
-	m_DepthTexture.height = vkbSwapchain.extent.height;
-	vk::ImageCreateInfo depthImageInfo = {};
-	depthImageInfo.imageType = vk::ImageType::e2D;
-	depthImageInfo.format = m_DepthFormat;
-	depthImageInfo.extent =
-	  vk::Extent3D(vkbSwapchain.extent.width, vkbSwapchain.extent.height, 1);
-	depthImageInfo.mipLevels = 1;
-	depthImageInfo.arrayLayers = 1;
-	depthImageInfo.samples = vk::SampleCountFlagBits::e1;
-	depthImageInfo.tiling = vk::ImageTiling::eOptimal;
-	depthImageInfo.usage = vk::ImageUsageFlagBits::eDepthStencilAttachment;
-	depthImageInfo.initialLayout = vk::ImageLayout::eUndefined;
+	for (int i = 0; auto& texture : m_SwapchainDepthTextures) {
+		DestroyTexture(texture);
 
-	VmaAllocationCreateInfo depthAllocInfo = {};
-	depthAllocInfo.usage = VMA_MEMORY_USAGE_AUTO;
-	depthAllocInfo.flags = VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT;
+		texture.width = vkbSwapchain.extent.width;
+		texture.height = vkbSwapchain.extent.height;
 
-	VkImage depthImagePtr = VK_NULL_HANDLE;
-	ThrowIfFail(vmaCreateImage(m_Allocator,
-							   &*depthImageInfo,
-							   &depthAllocInfo,
-							   &depthImagePtr,
-							   &m_DepthTexture.allocation,
-							   nullptr));
-	m_DepthTexture.image = depthImagePtr;
+		vk::ImageCreateInfo depthImageInfo = {};
+		depthImageInfo.imageType = vk::ImageType::e2D;
+		depthImageInfo.format = m_DepthFormat;
+		depthImageInfo.extent = vk::Extent3D(
+		  vkbSwapchain.extent.width, vkbSwapchain.extent.height, 1);
+		depthImageInfo.mipLevels = 1;
+		depthImageInfo.arrayLayers = 1;
+		depthImageInfo.samples = vk::SampleCountFlagBits::e1;
+		depthImageInfo.tiling = vk::ImageTiling::eOptimal;
+		depthImageInfo.usage = vk::ImageUsageFlagBits::eDepthStencilAttachment;
+		depthImageInfo.initialLayout = vk::ImageLayout::eUndefined;
 
-	vk::ImageViewCreateInfo depthViewInfo = {};
-	depthViewInfo.image = m_DepthTexture.image;
-	depthViewInfo.viewType = vk::ImageViewType::e2D;
-	depthViewInfo.format = m_DepthFormat;
-	vk::ImageSubresourceRange subRange = {};
-	subRange.aspectMask =
-	  vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil;
-	subRange.levelCount = 1;
-	subRange.layerCount = 1;
-	depthViewInfo.subresourceRange = subRange;
-	m_DepthTexture.view = (*m_Device).createImageView(depthViewInfo);
-	m_DirtyDepthTextures.push_back(0);
+		VmaAllocationCreateInfo depthAllocInfo = {};
+		depthAllocInfo.usage = VMA_MEMORY_USAGE_AUTO;
+		depthAllocInfo.flags = VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT;
+
+		VkImage depthImagePtr = VK_NULL_HANDLE;
+		ThrowIfFail(vmaCreateImage(m_Allocator,
+								   &*depthImageInfo,
+								   &depthAllocInfo,
+								   &depthImagePtr,
+								   &texture.allocation,
+								   nullptr));
+		texture.image = depthImagePtr;
+
+		vk::ImageViewCreateInfo depthViewInfo = {};
+		depthViewInfo.image = texture.image;
+		depthViewInfo.viewType = vk::ImageViewType::e2D;
+		depthViewInfo.format = m_DepthFormat;
+		vk::ImageSubresourceRange subRange = {};
+		subRange.aspectMask =
+		  vk::ImageAspectFlagBits::eDepth | vk::ImageAspectFlagBits::eStencil;
+		subRange.levelCount = 1;
+		subRange.layerCount = 1;
+		depthViewInfo.subresourceRange = subRange;
+		texture.view = (*m_Device).createImageView(depthViewInfo);
+
+		m_DirtyDepthTextures.push_back(-1 * i);
+
+		i++;
+	}
 }
 
 void
@@ -867,7 +877,9 @@ RendererVK::CleanupSwapchain()
 	m_SwapchainImageViews.clear();
 	m_Swapchain = nullptr;
 
-	DestroyTexture(m_DepthTexture);
+	for (auto& texture : m_SwapchainDepthTextures) {
+		DestroyTexture(texture);
+	}
 }
 
 void
@@ -1119,12 +1131,13 @@ RendererVK::RecordCommands(uint32_t imageIndex,
 	}
 
 	for (auto& textureHandle : m_DirtyDepthTextures) {
-		if (textureHandle != 0 && !m_Textures.contains(textureHandle)) {
+		if (textureHandle > 0 && !m_Textures.contains(textureHandle)) {
 			continue;
 		}
 
-		auto& texture =
-		  textureHandle == 0 ? m_DepthTexture : m_DepthTextures.at(textureHandle);
+		auto& texture = textureHandle <= 0
+						  ? m_SwapchainDepthTextures[-1 * textureHandle]
+						  : m_DepthTextures.at(textureHandle);
 		TransitionImageLayout(texture.image,
 							  texture.currentLayout,
 							  vk::ImageLayout::eDepthStencilAttachmentOptimal,
@@ -1300,7 +1313,7 @@ RendererVK::RecordCommands(uint32_t imageIndex,
 		depthInfo.imageView =
 		  (!swapchain && m_DepthTextures.contains(node.RenderTarget))
 			? m_DepthTextures[node.RenderTarget].view
-			: m_DepthTexture.view;
+			: m_SwapchainDepthTextures[m_CurrentFrame].view;
 		depthInfo.imageLayout = vk::ImageLayout::eDepthStencilAttachmentOptimal;
 		depthInfo.storeOp = vk::AttachmentStoreOp::eDontCare;
 		if (node.PreserveRenderTarget && !swapchain &&

--- a/src/RageUtil/Graphics/RendererVK/RendererVK.cpp
+++ b/src/RageUtil/Graphics/RendererVK/RendererVK.cpp
@@ -249,6 +249,7 @@ RendererVK::DeleteTexture(intptr_t handle)
 {
 	m_GraphicsQueue.waitIdle();
 
+	assert(m_Textures.contains(handle));
 	DestroyTexture(m_Textures[handle]);
 	if (m_DepthTextures.contains(handle)) {
 		DestroyTexture(m_DepthTextures[handle]);
@@ -692,6 +693,7 @@ RendererVK::InitVulkanState()
 	dynamicState3Features.extendedDynamicState3ColorBlendEnable = VK_TRUE;
 	dynamicState3Features.extendedDynamicState3ColorBlendEquation = VK_TRUE;
 	dynamicState3Features.extendedDynamicState3ColorWriteMask = VK_TRUE;
+	dynamicState3Features.extendedDynamicState3RasterizationSamples = VK_TRUE;
 
 	vkb::DeviceBuilder deviceBuilder(*physicalDeviceResult);
 	auto deviceResult = deviceBuilder.add_pNext(&dynamicState3Features).build();
@@ -706,7 +708,7 @@ RendererVK::InitVulkanState()
 	  m_Instance, physicalDeviceResult->physical_device);
 	m_Device = vk::raii::Device(m_PhysicalDevice, deviceResult->device);
 
-	Locator::getLogger()->debug("RendererVK: selected GPU: {}",
+	Locator::getLogger()->info("RendererVK: selected GPU: {}",
 								physicalDeviceResult->name);
 
 	m_GraphicsQueue = vk::raii::Queue(
@@ -1019,7 +1021,11 @@ RendererVK::RecordCommands(uint32_t imageIndex,
 	m_DirtyPostBarriers.reserve(m_DirtyTextures.size());
 
 	for (auto& textureHandle : m_DirtyTextures) {
-		auto& texture = m_Textures[textureHandle];
+		if (!m_Textures.contains(textureHandle)) {
+			continue;
+		}
+
+		auto& texture = m_Textures.at(textureHandle);
 		vk::ImageMemoryBarrier2 barrier{};
 		barrier.srcStageMask =
 		  (texture.currentLayout == vk::ImageLayout::eUndefined)
@@ -1051,7 +1057,11 @@ RendererVK::RecordCommands(uint32_t imageIndex,
 	}
 
 	for (auto& textureHandle : m_DirtyTextures) {
-		auto& texture = m_Textures[textureHandle];
+		if (!m_Textures.contains(textureHandle)) {
+			continue;
+		}
+
+		auto& texture = m_Textures.at(textureHandle);
 		vk::BufferImageCopy2 copyRegion{};
 		copyRegion.imageExtent =
 		  vk::Extent3D{ texture.width, texture.height, 1 };
@@ -1068,7 +1078,11 @@ RendererVK::RecordCommands(uint32_t imageIndex,
 	}
 
 	for (auto& textureHandle : m_DirtyTextures) {
-		auto& texture = m_Textures[textureHandle];
+		if (!m_Textures.contains(textureHandle)) {
+			continue;
+		}
+
+		auto& texture = m_Textures.at(textureHandle);
 		vk::ImageMemoryBarrier2 barrier{};
 		barrier.srcStageMask = vk::PipelineStageFlagBits2::eTransfer;
 		barrier.srcAccessMask = vk::AccessFlagBits2::eTransferWrite;
@@ -1094,15 +1108,23 @@ RendererVK::RecordCommands(uint32_t imageIndex,
 	}
 
 	for (auto& textureHandle : m_DirtyTextures) {
-		auto& texture = m_Textures[textureHandle];
+		if (!m_Textures.contains(textureHandle)) {
+			continue;
+		}
+
+		auto& texture = m_Textures.at(textureHandle);
 		texture.currentLayout = vk::ImageLayout::eShaderReadOnlyOptimal;
 		texture.dirty = false;
 		texture.initialized = true;
 	}
 
 	for (auto& textureHandle : m_DirtyDepthTextures) {
+		if (textureHandle != 0 && !m_Textures.contains(textureHandle)) {
+			continue;
+		}
+
 		auto& texture =
-		  textureHandle == 0 ? m_DepthTexture : m_DepthTextures[textureHandle];
+		  textureHandle == 0 ? m_DepthTexture : m_DepthTextures.at(textureHandle);
 		TransitionImageLayout(texture.image,
 							  texture.currentLayout,
 							  vk::ImageLayout::eDepthStencilAttachmentOptimal,
@@ -1129,7 +1151,7 @@ RendererVK::RecordCommands(uint32_t imageIndex,
 		imageInfo.imageLayout = vk::ImageLayout::eShaderReadOnlyOptimal;
 		imageInfo.imageView = m_EmptyTextureSlots.contains(handle)
 								? m_Textures[0].view
-								: m_Textures[handle].view;
+								: m_Textures.at(handle).view;
 
 		vk::WriteDescriptorSet write{};
 		write.dstSet = m_TextureDescriptorSet;
@@ -1310,6 +1332,7 @@ RendererVK::RecordCommands(uint32_t imageIndex,
 										1.0f));
 
 		buffer.beginRendering(renderInfo);
+		buffer.setRasterizationSamplesEXT(vk::SampleCountFlagBits::e1);
 
 		for (auto& call : node.DrawCalls) {
 			buffer.setDepthTestEnable(

--- a/src/RageUtil/Graphics/RendererVK/RendererVK.cpp
+++ b/src/RageUtil/Graphics/RendererVK/RendererVK.cpp
@@ -45,7 +45,7 @@ void
 RendererVK::InitializeRenderer(const VideoModeParams& p)
 {
 	InitVulkanState();
-	InitSwapchain(p);
+	InitSwapchain(p.width, p.height, p.vsync, p.bWindowIsFullscreenBorderless);
 	InitImageViews();
 	InitBatchDescriptors();
 	InitBatchBuffers(1);
@@ -64,9 +64,15 @@ RendererVK::IsReadyForRender()
 		return true;
 	}
 
-	// TODO: check if we can recreate swapchain and such
+	try {
+		RecreateSwapchain();
+	} catch (std::exception e) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+		return false;
+	}
 
-	return false;
+	m_SwapchainIsInvalid = false;
+	return true;
 }
 
 /// ----------------------------------------
@@ -76,6 +82,13 @@ void
 RendererVK::OnRender(const ActualVideoModeParams* p,
 					 const DisplayAdapter::CommandBatcher& batcher)
 {
+	if (m_SwapchainIsInvalid) {
+		// pause the current thread in IsReadyForRender() so we don't do a heavy
+		// spin thing
+		// we'll attempt to recreate the swapchain in IsReadyForRender() too
+		return;
+	}
+
 	ThrowIfFail(m_Device.waitForFences(
 	  *m_InFlightFence[m_CurrentFrame], vk::True, Timeout));
 
@@ -86,9 +99,8 @@ RendererVK::OnRender(const ActualVideoModeParams* p,
 	m_CurrentImage = imageIndex;
 
 	if (result == vk::Result::eErrorOutOfDateKHR ||
-		result == vk::Result::eSuboptimalKHR || m_SwapchainIsInvalid) {
-		RecreateSwapchain(*p);
-		m_SwapchainIsInvalid = false;
+		result == vk::Result::eSuboptimalKHR) {
+		m_SwapchainIsInvalid = true;
 		return;
 	}
 	ThrowIfFail(result);
@@ -118,17 +130,20 @@ RendererVK::OnRender(const ActualVideoModeParams* p,
 	presentInfoKHR.pImageIndices = &imageIndex;
 
 	try {
+		// for frame pacing/limiting there's VK_EXT_present_timing but it's
+		// kinda fresh at the time of writing so eh
+
 		const auto beforePresent = std::chrono::steady_clock::now();
 		result = m_PresentQueue.presentKHR(presentInfoKHR);
 		const auto afterPresent = std::chrono::steady_clock::now();
 		DISPLAY->SetPresentTime(afterPresent - beforePresent);
 	} catch (vk::OutOfDateKHRError error) {
-		RecreateSwapchain(*p);
+		m_SwapchainIsInvalid = true;
 		return;
 	}
 
 	if (result == vk::Result::eSuboptimalKHR) {
-		RecreateSwapchain(*p);
+		m_SwapchainIsInvalid = true;
 		return;
 	}
 
@@ -721,8 +736,14 @@ RendererVK::InitVulkanState()
 }
 
 void
-RendererVK::InitSwapchain(const VideoModeParams& p)
+RendererVK::InitSwapchain(uint32_t width,
+						  uint32_t height,
+						  bool vSync,
+						  bool borderlessWindow)
 {
+	m_SwapchainVSync = vSync;
+	m_SwapchainBorderless = borderlessWindow;
+
 	vkb::SwapchainBuilder swapchainBuilder(
 	  *m_PhysicalDevice, *m_Device, *m_Surface);
 
@@ -731,8 +752,9 @@ RendererVK::InitSwapchain(const VideoModeParams& p)
 		{ VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR })
 	  .set_desired_format(
 		{ VK_FORMAT_R8G8B8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR })
-	  .set_desired_present_mode(p.vsync ? VK_PRESENT_MODE_FIFO_KHR : VK_PRESENT_MODE_IMMEDIATE_KHR)
-	  .set_desired_extent(p.width, p.height)
+	  .set_desired_present_mode(vSync ? VK_PRESENT_MODE_FIFO_KHR
+									  : VK_PRESENT_MODE_IMMEDIATE_KHR)
+	  .set_desired_extent(width, height)
 	  .set_image_usage_flags(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
 							 VK_IMAGE_USAGE_TRANSFER_SRC_BIT)
 	  .set_clipped(true);
@@ -756,8 +778,8 @@ RendererVK::InitSwapchain(const VideoModeParams& p)
 		VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT
 	};
 	fullScreenInfo.fullScreenExclusive =
-	  p.bWindowIsFullscreenBorderless ? VK_FULL_SCREEN_EXCLUSIVE_DISALLOWED_EXT
-									  : VK_FULL_SCREEN_EXCLUSIVE_ALLOWED_EXT;
+	  borderlessWindow ? VK_FULL_SCREEN_EXCLUSIVE_DISALLOWED_EXT
+					   : VK_FULL_SCREEN_EXCLUSIVE_ALLOWED_EXT;
 	swapchainBuilder.add_pNext(&fullScreenInfo);
 #endif
 
@@ -819,12 +841,15 @@ RendererVK::InitSwapchain(const VideoModeParams& p)
 }
 
 void
-RendererVK::RecreateSwapchain(const VideoModeParams& p)
+RendererVK::RecreateSwapchain()
 {
 	m_Device.waitIdle();
 
 	CleanupSwapchain();
-	InitSwapchain(p);
+	InitSwapchain(m_SwapchainExtent.width,
+				  m_SwapchainExtent.height,
+				  m_SwapchainVSync,
+				  m_SwapchainBorderless);
 	InitImageViews();
 	InitSyncStructures();
 }
@@ -1927,5 +1952,10 @@ RendererVK::TryVideoMode(const VideoModeParams& params)
 	}
 
 	m_Surface = CreateSurfaceKHR(m_Instance);
-	RecreateSwapchain(params);
+	InitSwapchain(params.width,
+				  params.height,
+				  params.vsync,
+				  params.bWindowIsFullscreenBorderless);
+	InitImageViews();
+	InitSyncStructures();
 }

--- a/src/RageUtil/Graphics/RendererVK/RendererVK.cpp
+++ b/src/RageUtil/Graphics/RendererVK/RendererVK.cpp
@@ -57,6 +57,18 @@ RendererVK::InitializeRenderer(const VideoModeParams& p)
 	InitTextures();
 }
 
+bool
+RendererVK::IsReadyForRender()
+{
+	if (!m_SwapchainIsInvalid) {
+		return true;
+	}
+
+	// TODO: check if we can recreate swapchain and such
+
+	return false;
+}
+
 /// ----------------------------------------
 /// here be hazards and unsignaled fences...
 /// ----------------------------------------

--- a/src/RageUtil/Graphics/RendererVK/RendererVK.cpp
+++ b/src/RageUtil/Graphics/RendererVK/RendererVK.cpp
@@ -15,6 +15,7 @@
 #include <RageUtil/File/RageFileManager.h>
 #include <RageUtil/Misc/RageMath.h>
 #include <vulkan/vulkan_beta.h>
+#include <thread>
 #include "RenderTargetVK.h"
 #include "PlatformUtils.h"
 

--- a/src/RageUtil/Graphics/RendererVK/RendererVK.cpp
+++ b/src/RageUtil/Graphics/RendererVK/RendererVK.cpp
@@ -175,7 +175,11 @@ RendererVK::CreateTexture(RageSurface* img, bool RGBA8)
 	imageInfo.imageType = VK_IMAGE_TYPE_2D;
 	imageInfo.format =
 	  RGBA8 ? VK_FORMAT_R8G8B8A8_UNORM : VK_FORMAT_B8G8R8A8_UNORM;
-	imageInfo.extent = { texture.width, texture.height, 1 };
+
+	// old ahh renderers scale the textures to powers-of-two for Reasons(TM)
+	imageInfo.extent = { (uint32_t)power_of_two(texture.width),
+						 (uint32_t)power_of_two(texture.height),
+						 1 };
 	imageInfo.mipLevels = 1;
 	imageInfo.arrayLayers = 1;
 	imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -208,7 +212,7 @@ RendererVK::CreateTexture(RageSurface* img, bool RGBA8)
 	texture.InitImageBuffer();
 	m_Textures.insert({ currentHandle, texture });
 
-	UpdateTexture(currentHandle, img, 0, 0, img->w, img->h);
+	UpdateTexture(currentHandle, img, 0, 0, texture.width, texture.height);
 	m_DirtyTextureDescriptors.push_back(currentHandle);
 
 	return currentHandle;

--- a/src/RageUtil/Graphics/RendererVK/RendererVK.cpp
+++ b/src/RageUtil/Graphics/RendererVK/RendererVK.cpp
@@ -46,7 +46,11 @@ void
 RendererVK::InitializeRenderer(const VideoModeParams& p)
 {
 	InitVulkanState();
-	InitSwapchain(p.width, p.height, p.vsync, p.bWindowIsFullscreenBorderless);
+	InitSwapchain(p.width,
+				  p.height,
+				  p.vsync,
+				  p.bWindowIsFullscreenBorderless,
+				  p.bSmoothLines);
 	InitImageViews();
 	InitBatchDescriptors();
 	InitBatchBuffers(1);
@@ -567,6 +571,10 @@ RendererVK::~RendererVK()
 		DestroyTexture(texture);
 	}
 
+	for (auto& texture : m_MsaaTextures) {
+		DestroyTexture(texture);
+	}
+
 	for (int i = 0; i < FramesInFlight; i++) {
 		m_VertexBuffer[i].Destroy();
 		m_IndexBuffer[i].Destroy();
@@ -742,16 +750,30 @@ RendererVK::InitVulkanState()
 			break;
 		}
 	}
+
+	auto limits = m_PhysicalDevice.getProperties().limits;
+	auto counts =
+	  limits.framebufferColorSampleCounts & limits.framebufferDepthSampleCounts;
+
+	if (counts & vk::SampleCountFlagBits::e4) {
+		m_MsaaSamples = vk::SampleCountFlagBits::e4;
+	} else if (counts & vk::SampleCountFlagBits::e2) {
+		m_MsaaSamples = vk::SampleCountFlagBits::e2;
+	} else {
+		m_MsaaSamples = vk::SampleCountFlagBits::e1;
+	}
 }
 
 void
 RendererVK::InitSwapchain(uint32_t width,
 						  uint32_t height,
 						  bool vSync,
-						  bool borderlessWindow)
+						  bool borderlessWindow,
+						  bool smoothLines)
 {
 	m_SwapchainVSync = vSync;
 	m_SwapchainBorderless = borderlessWindow;
+	m_SmoothLines = smoothLines;
 
 	vkb::SwapchainBuilder swapchainBuilder(
 	  *m_PhysicalDevice, *m_Device, *m_Surface);
@@ -821,7 +843,8 @@ RendererVK::InitSwapchain(uint32_t width,
 		  vkbSwapchain.extent.width, vkbSwapchain.extent.height, 1);
 		depthImageInfo.mipLevels = 1;
 		depthImageInfo.arrayLayers = 1;
-		depthImageInfo.samples = vk::SampleCountFlagBits::e1;
+		depthImageInfo.samples =
+		  smoothLines ? m_MsaaSamples : vk::SampleCountFlagBits::e1;
 		depthImageInfo.tiling = vk::ImageTiling::eOptimal;
 		depthImageInfo.usage = vk::ImageUsageFlagBits::eDepthStencilAttachment;
 		depthImageInfo.initialLayout = vk::ImageLayout::eUndefined;
@@ -851,10 +874,59 @@ RendererVK::InitSwapchain(uint32_t width,
 		depthViewInfo.subresourceRange = subRange;
 		texture.view = (*m_Device).createImageView(depthViewInfo);
 
-		m_DirtyDepthTextures.push_back(-1 * i);
+		m_DirtyDepthTextures.push_back(-1 * static_cast<intptr_t>(i));
 
 		i++;
 	}
+
+	if (!smoothLines || m_MsaaSamples & vk::SampleCountFlagBits::e1) {
+		return;
+	}
+
+	for (auto& texture : m_MsaaTextures) {
+		DestroyTexture(texture);
+
+		texture.width = vkbSwapchain.extent.width;
+		texture.height = vkbSwapchain.extent.height;
+
+		vk::ImageCreateInfo imageInfo = {};
+		imageInfo.imageType = vk::ImageType::e2D;
+		imageInfo.format = m_ImageFormat;
+		imageInfo.extent = vk::Extent3D(
+		  vkbSwapchain.extent.width, vkbSwapchain.extent.height, 1);
+		imageInfo.mipLevels = 1;
+		imageInfo.arrayLayers = 1;
+		imageInfo.samples = m_MsaaSamples;
+		imageInfo.tiling = vk::ImageTiling::eOptimal;
+		imageInfo.usage = vk::ImageUsageFlagBits::eColorAttachment |
+						  vk::ImageUsageFlagBits::eTransientAttachment;
+		imageInfo.initialLayout = vk::ImageLayout::eUndefined;
+
+		VmaAllocationCreateInfo allocInfo = {};
+		allocInfo.usage = VMA_MEMORY_USAGE_AUTO;
+
+		VkImage depthImagePtr = VK_NULL_HANDLE;
+		ThrowIfFail(vmaCreateImage(m_Allocator,
+								   &*imageInfo,
+								   &allocInfo,
+								   &depthImagePtr,
+								   &texture.allocation,
+								   nullptr));
+		texture.image = depthImagePtr;
+
+		vk::ImageViewCreateInfo viewInfo = {};
+		viewInfo.image = texture.image;
+		viewInfo.viewType = vk::ImageViewType::e2D;
+		viewInfo.format = m_ImageFormat;
+		vk::ImageSubresourceRange subRange = {};
+		subRange.aspectMask = vk::ImageAspectFlagBits::eColor;
+		subRange.levelCount = 1;
+		subRange.layerCount = 1;
+		viewInfo.subresourceRange = subRange;
+		texture.view = (*m_Device).createImageView(viewInfo);
+	}
+
+	m_MsaaTexturesAreDirty = true;
 }
 
 void
@@ -866,7 +938,8 @@ RendererVK::RecreateSwapchain()
 	InitSwapchain(m_SwapchainExtent.width,
 				  m_SwapchainExtent.height,
 				  m_SwapchainVSync,
-				  m_SwapchainBorderless);
+				  m_SwapchainBorderless,
+				  m_SmoothLines);
 	InitImageViews();
 	InitSyncStructures();
 }
@@ -878,6 +951,10 @@ RendererVK::CleanupSwapchain()
 	m_Swapchain = nullptr;
 
 	for (auto& texture : m_SwapchainDepthTextures) {
+		DestroyTexture(texture);
+	}
+
+	for (auto& texture : m_MsaaTextures) {
 		DestroyTexture(texture);
 	}
 }
@@ -1185,6 +1262,25 @@ RendererVK::RecordCommands(uint32_t imageIndex,
 	m_DirtyImageInfos.clear();
 	m_DirtyImageDescWrites.clear();
 
+	if (m_MsaaTexturesAreDirty) {
+		for (auto& texture : m_MsaaTextures) {
+			TransitionImageLayout(
+			  texture.image,
+			  texture.currentLayout,
+			  vk::ImageLayout::eColorAttachmentOptimal,
+			  vk::AccessFlags2(),
+			  vk::AccessFlagBits2::eColorAttachmentWrite,
+			  vk::PipelineStageFlagBits2::eColorAttachmentOutput,
+			  vk::PipelineStageFlagBits2::eColorAttachmentOutput,
+			  vk::ImageAspectFlagBits::eColor,
+			  buffer);
+
+			texture.currentLayout = vk::ImageLayout::eColorAttachmentOptimal;
+		}
+
+		m_MsaaTexturesAreDirty = false;
+	}
+
 	vk::BufferCopy stagingCopy{};
 	stagingCopy.srcOffset = 0;
 	stagingCopy.dstOffset = 0;
@@ -1269,6 +1365,8 @@ RendererVK::RecordCommands(uint32_t imageIndex,
 
 	for (auto& node : batcher.m_RenderNodes) {
 		bool swapchain = node.RenderTarget == 0;
+		bool useMsaa = swapchain && m_SmoothLines &&
+					   !(m_MsaaSamples & vk::SampleCountFlagBits::e1);
 
 		auto image = swapchain ? m_SwapchainImages[imageIndex]
 							   : m_Textures[node.RenderTarget].image;
@@ -1324,6 +1422,17 @@ RendererVK::RecordCommands(uint32_t imageIndex,
 			depthInfo.clearValue = vk::ClearDepthStencilValue(1.0f, 0);
 		}
 
+		if (useMsaa) {
+			colorInfo.imageView = m_MsaaTextures[m_CurrentFrame].view;
+			colorInfo.resolveMode = vk::ResolveModeFlagBits::eAverage;
+			colorInfo.resolveImageView = view;
+			colorInfo.resolveImageLayout =
+			  vk::ImageLayout::eColorAttachmentOptimal;
+			colorInfo.loadOp = vk::AttachmentLoadOp::eClear;
+			colorInfo.storeOp = vk::AttachmentStoreOp::eDontCare;
+			colorInfo.clearValue = vk::ClearColorValue(0.0f, 0.0f, 0.0f, 0.0f);
+		}
+
 		vk::RenderingInfo renderInfo = {};
 		renderInfo.renderArea =
 		  vk::Rect2D{ { 0, 0 }, { extent.width, extent.height } };
@@ -1344,10 +1453,16 @@ RendererVK::RecordCommands(uint32_t imageIndex,
 										0.0f,
 										1.0f));
 
+		buffer.setRasterizationSamplesEXT(
+		  useMsaa ? m_MsaaSamples : vk::SampleCountFlagBits::e1);
+
 		buffer.beginRendering(renderInfo);
-		buffer.setRasterizationSamplesEXT(vk::SampleCountFlagBits::e1);
 
 		for (auto& call : node.DrawCalls) {
+			if (call.IndexCount == 0) {
+				continue;
+			}
+
 			buffer.setDepthTestEnable(
 			  call.DepthTestMode != ZTEST_OFF ? VK_TRUE : VK_FALSE);
 			buffer.setDepthWriteEnable(call.DepthWriteEnabled ? VK_TRUE
@@ -1996,7 +2111,8 @@ RendererVK::TryVideoMode(const VideoModeParams& params)
 	InitSwapchain(params.width,
 				  params.height,
 				  params.vsync,
-				  params.bWindowIsFullscreenBorderless);
+				  params.bWindowIsFullscreenBorderless,
+				  params.bSmoothLines);
 	InitImageViews();
 	InitSyncStructures();
 }

--- a/src/RageUtil/Graphics/RendererVK/RendererVK.h
+++ b/src/RageUtil/Graphics/RendererVK/RendererVK.h
@@ -38,6 +38,7 @@ class RendererVK : public DisplayAdapter::Renderer
 	RendererVK();
 	std::string GetApiDescription() const override;
 	void InitializeRenderer(const VideoModeParams& p) override;
+	bool IsReadyForRender() override;
 	void OnRender(const ActualVideoModeParams* p,
 				  const DisplayAdapter::CommandBatcher& batcher) override;
 	bool IsD3DInternal() override;

--- a/src/RageUtil/Graphics/RendererVK/RendererVK.h
+++ b/src/RageUtil/Graphics/RendererVK/RendererVK.h
@@ -79,6 +79,7 @@ class RendererVK : public DisplayAdapter::Renderer
 	uint32_t m_PresentQueueFamily = 0;
 	VmaAllocator m_Allocator = nullptr;
 	vk::Format m_DepthFormat = {};
+	vk::SampleCountFlagBits m_MsaaSamples = {};
 	void InitVulkanState();
 
 	vk::raii::SwapchainKHR m_Swapchain = nullptr;
@@ -86,14 +87,18 @@ class RendererVK : public DisplayAdapter::Renderer
 	std::vector<vk::Image> m_SwapchainImages;
 	vk::Format m_ImageFormat = {};
 	std::array<Texture, FramesInFlight> m_SwapchainDepthTextures;
+	std::array<Texture, FramesInFlight> m_MsaaTextures;
+	bool m_MsaaTexturesAreDirty = false;
 	bool m_SwapchainVSync = false;
 	bool m_SwapchainBorderless = false;
 	bool m_SwapchainIsInvalid = false;
+	bool m_SmoothLines = false;
 
 	void InitSwapchain(uint32_t width,
 					   uint32_t height,
 					   bool vSync,
-					   bool borderlessWindow);
+					   bool borderlessWindow,
+					   bool smoothLines);
 	void RecreateSwapchain();
 	void CleanupSwapchain();
 

--- a/src/RageUtil/Graphics/RendererVK/RendererVK.h
+++ b/src/RageUtil/Graphics/RendererVK/RendererVK.h
@@ -84,10 +84,15 @@ class RendererVK : public DisplayAdapter::Renderer
 	std::vector<vk::Image> m_SwapchainImages;
 	vk::Format m_ImageFormat = {};
 	Texture m_DepthTexture = {};
-
+	bool m_SwapchainVSync = false;
+	bool m_SwapchainBorderless = false;
 	bool m_SwapchainIsInvalid = false;
-	void InitSwapchain(const VideoModeParams& p);
-	void RecreateSwapchain(const VideoModeParams& p);
+
+	void InitSwapchain(uint32_t width,
+					   uint32_t height,
+					   bool vSync,
+					   bool borderlessWindow);
+	void RecreateSwapchain();
 	void CleanupSwapchain();
 
 	std::vector<vk::raii::ImageView> m_SwapchainImageViews;

--- a/src/RageUtil/Graphics/RendererVK/RendererVK.h
+++ b/src/RageUtil/Graphics/RendererVK/RendererVK.h
@@ -65,6 +65,8 @@ class RendererVK : public DisplayAdapter::Renderer
 	void RescaleBatchBuffers(size_t sizeScale) override;
 
   private:
+	constexpr static size_t FramesInFlight = 3;
+
 	vk::raii::Context m_Context;
 	vk::raii::Instance m_Instance = nullptr;
 	vk::raii::DebugUtilsMessengerEXT m_DebugMessenger = nullptr;
@@ -83,7 +85,7 @@ class RendererVK : public DisplayAdapter::Renderer
 	vk::Extent2D m_SwapchainExtent;
 	std::vector<vk::Image> m_SwapchainImages;
 	vk::Format m_ImageFormat = {};
-	Texture m_DepthTexture = {};
+	std::array<Texture, FramesInFlight> m_SwapchainDepthTextures;
 	bool m_SwapchainVSync = false;
 	bool m_SwapchainBorderless = false;
 	bool m_SwapchainIsInvalid = false;
@@ -134,8 +136,6 @@ class RendererVK : public DisplayAdapter::Renderer
 	void RecordCommands(uint32_t imageIndex,
 						const DisplayAdapter::CommandBatcher& batcher);
 	void SetBlendMode(BlendMode mode, vk::raii::CommandBuffer& buffer);
-
-	constexpr static size_t FramesInFlight = 3;
 
 	std::array<PersistentBuffer, FramesInFlight> m_VertexBuffer;
 	std::array<PersistentBuffer, FramesInFlight> m_IndexBuffer;

--- a/src/arch/LowLevelWindowVK/LowLevelWindowVK_Win32.cpp
+++ b/src/arch/LowLevelWindowVK/LowLevelWindowVK_Win32.cpp
@@ -14,56 +14,10 @@ LowLevelWindowVK_Win32::TryVideoMode(const VideoModeParams& p,
 	return "";
 }
 
-static BOOL CALLBACK
-EnumerateMonitors(HMONITOR monitor,
-				  HDC deviceContextHandle,
-				  LPRECT monitorRect,
-				  LPARAM userData)
-{
-	auto* out = reinterpret_cast<DisplaySpecs*>(userData);
-
-	MONITORINFOEXW monitorInfo = {};
-	monitorInfo.cbSize = sizeof(monitorInfo);
-	if (!GetMonitorInfoW(monitor, &monitorInfo)) {
-		return TRUE;
-	}
-
-	std::set<DisplayMode> modes;
-	DEVMODEW deviceMode = {};
-	deviceMode.dmSize = sizeof(deviceMode);
-	deviceMode.dmDriverExtra = 0;
-	DWORD modeIndex = 0;
-	while (EnumDisplaySettingsW(monitorInfo.szDevice, modeIndex, &deviceMode)) {
-		modes.insert({ deviceMode.dmPelsWidth,
-					   deviceMode.dmPelsHeight,
-					   static_cast<double>(deviceMode.dmDisplayFrequency) });
-		modeIndex++;
-	}
-
-	DisplayMode active = { 0, 0, 0.0 };
-	if (EnumDisplaySettingsW(
-		  monitorInfo.szDevice, ENUM_CURRENT_SETTINGS, &deviceMode)) {
-		active.width = deviceMode.dmPelsWidth;
-		active.height = deviceMode.dmPelsHeight;
-		active.refreshRate = static_cast<double>(deviceMode.dmDisplayFrequency);
-	} else if (!modes.empty()) {
-		active = *modes.begin();
-	}
-
-	RectI bounds(monitorInfo.rcMonitor.left,
-				 monitorInfo.rcMonitor.top,
-				 monitorInfo.rcMonitor.right,
-				 monitorInfo.rcMonitor.bottom);
-
-	out->insert(DisplaySpec("", "Fullscreen", modes, active, bounds));
-	return TRUE;
-}
-
 void
 LowLevelWindowVK_Win32::GetDisplaySpecs(DisplaySpecs& out) const
 {
-	EnumDisplayMonitors(
-	  nullptr, nullptr, EnumerateMonitors, reinterpret_cast<LPARAM>(&out));
+	GraphicsWindow::GetDisplaySpecs(out);
 }
 
 void


### PR DESCRIPTION
- `WITH_VULKAN` CMake flag seems broken on some systems
- some things to fix (try MSAA from this): https://github.com/etternagame/etterna/pull/1418#issuecomment-5298996922
- videos get zoomed in / something something UpdateTexture broke
- some display mode info is missing (when compared w/ OpenGL & D3D9)
- swapchain creation is silly (crashes either on switching themes or on minified window)