### PR TITLE
load Vulkan deps dynamically instead of linking & patch OpenSSL for Windows CI

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -511,7 +511,7 @@ jobs:
 
       - name: Install openSSL (x64)
         if: ${{ matrix.cfg.arch == 'x64' }}
-        run: choco install openssl -y
+        run: msiexec /i https://slproweb.com/download/Win64OpenSSL-4_0_2.msi /quiet
       
       #TODO: Also print Python install logs, more?
       - name: Print Install Failures (if present)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,7 @@ if(WITH_VULKAN)
 
     find_package(Vulkan REQUIRED COMPONENTS shaderc_combined)
     target_link_libraries(Etterna PRIVATE
-        Vulkan::Vulkan
+        Vulkan::Headers
         Vulkan::shaderc_combined)
 
     if(WITH_VULKAN_LINUX_EXTRAS AND UNIX AND NOT APPLE)

--- a/src/RageUtil/Graphics/RendererVK/RendererVK.cpp
+++ b/src/RageUtil/Graphics/RendererVK/RendererVK.cpp
@@ -29,6 +29,8 @@
 #endif
 #include <RageUtil/Graphics/Display/Display.h>
 
+VULKAN_HPP_DEFAULT_DISPATCH_LOADER_DYNAMIC_STORAGE
+
 constexpr uint64_t Timeout = 2000'000'000;
 
 RendererVK::RendererVK()
@@ -448,10 +450,7 @@ RendererVK::CreateScreenshot()
 	ThrowIfFail(m_Device.waitForFences({ fence }, VK_TRUE, Timeout));
 
 	VkImageSubresource subresource{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 0 };
-	VkSubresourceLayout subresourceLayout = {};
-
-	vkGetImageSubresourceLayout(
-	  (vk::Device)m_Device, destImageRaw, &subresource, &subresourceLayout);
+	VkSubresourceLayout subresourceLayout = (*m_Device).getImageSubresourceLayout(destImageRaw, subresource);
 
 	uint8_t* data = static_cast<uint8_t*>(destAllocInfo.pMappedData) +
 					subresourceLayout.offset;
@@ -640,6 +639,8 @@ VulkanDebugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
 void
 RendererVK::InitVulkanState()
 {
+	VULKAN_HPP_DEFAULT_DISPATCHER.init();
+
 	auto instanceResult = CreateInstance(VulkanDebugCallback);
 	if (!instanceResult) {
 		Locator::getLogger()->fatal("RendererVK: instance creation failed - {}",
@@ -648,6 +649,8 @@ RendererVK::InitVulkanState()
 	}
 
 	m_Instance = vk::raii::Instance(m_Context, instanceResult->instance);
+
+	VULKAN_HPP_DEFAULT_DISPATCHER.init(*m_Instance);
 
 	if (DISPLAY->DisplayDebugModeEnabled()) {
 		m_DebugMessenger = vk::raii::DebugUtilsMessengerEXT(
@@ -718,6 +721,8 @@ RendererVK::InitVulkanState()
 	  m_Instance, physicalDeviceResult->physical_device);
 	m_Device = vk::raii::Device(m_PhysicalDevice, deviceResult->device);
 
+	VULKAN_HPP_DEFAULT_DISPATCHER.init(*m_Device);
+
 	Locator::getLogger()->info("RendererVK: selected GPU: {}",
 							   physicalDeviceResult->name);
 
@@ -731,12 +736,20 @@ RendererVK::InitVulkanState()
 	m_PresentQueueFamily =
 	  deviceResult->get_queue_index(vkb::QueueType::present).value();
 
+	VmaVulkanFunctions vulkanFunctions{};
+	vulkanFunctions.vkGetInstanceProcAddr =
+	  VULKAN_HPP_DEFAULT_DISPATCHER.vkGetInstanceProcAddr;
+	vulkanFunctions.vkGetDeviceProcAddr =
+	  VULKAN_HPP_DEFAULT_DISPATCHER.vkGetDeviceProcAddr;
+
 	VmaAllocatorCreateInfo allocatorInfo = {};
 	allocatorInfo.physicalDevice =
 	  static_cast<vk::PhysicalDevice>(m_PhysicalDevice);
 	allocatorInfo.device = static_cast<vk::Device>(m_Device);
 	allocatorInfo.instance = static_cast<vk::Instance>(m_Instance);
 	allocatorInfo.flags = VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT;
+	allocatorInfo.pVulkanFunctions = &vulkanFunctions;
+	allocatorInfo.vulkanApiVersion = VK_API_VERSION_1_3;
 
 	ThrowIfFail(vmaCreateAllocator(&allocatorInfo, &m_Allocator));
 
@@ -1915,7 +1928,7 @@ RendererVK::DestroyTexture(Texture& texture)
 		vmaDestroyImage(m_Allocator, texture.image, texture.allocation);
 	}
 	if (texture.view) {
-		vkDestroyImageView(*m_Device, texture.view, nullptr);
+		(*m_Device).destroyImageView(texture.view);
 	}
 
 	texture = {};

--- a/src/RageUtil/Graphics/RendererVK/RendererVK.h
+++ b/src/RageUtil/Graphics/RendererVK/RendererVK.h
@@ -1,6 +1,11 @@
 #ifndef RENDERER_VULKAN_H
 #define RENDERER_VULKAN_H
 
+#define VK_NO_PROTOTYPES
+#define VULKAN_HPP_DISPATCH_LOADER_DYNAMIC 1
+#define VMA_STATIC_VULKAN_FUNCTIONS 0
+#define VMA_DYNAMIC_VULKAN_FUNCTIONS 1
+
 #include "RageUtil/Graphics/Display/Renderer.h"
 #include "RageUtil/Graphics/RageDisplay.h"
 #include "Core/Services/Locator.hpp"


### PR DESCRIPTION
Older drivers might not have needed DLLs; this should make the game ... runnable if the user doesn't choose vk explicitly